### PR TITLE
Feature/しおり一覧機能の作成

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,0 +1,5 @@
+class TravelBooksController < ApplicationController
+  def index
+    @travel_books = TravelBook.all
+  end
+end

--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -1,0 +1,2 @@
+module TravelBooksHelper
+end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -1,0 +1,4 @@
+class TravelBook < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :description, length: { maximum: 65_535 }
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
+  <body class="bg-base-200 min-h-screen">
     <%= render 'shared/header' %>
     <%= yield %>
   </body>

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,0 +1,3 @@
+<%= @travel_books.each do | travel_book | %>
+  <%= travel_book %>
+<% end %>

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,3 +1,22 @@
-<%= @travel_books.each do | travel_book | %>
-  <%= travel_book %>
+<%= link_to new_user_session_path, class: "block" do %>
+  <div class="card bg-base-100 w-full">
+    <figure>
+      <img
+        src="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.webp"
+        alt="Shoes" />
+    </figure>
+    <div class="card-body flex flex-col items-center justify-center text-center">
+      <h2 class="card-title"><%= travel_book.title %></h2>
+      <p>エリア</p>
+      <p>カテゴリー</p>
+      <div class="flex items-center justify-center gap-2">
+        <div class="avatar">
+          <div class="w-6 md:w-7 rounded-full">
+            <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
+          </div>
+        </div>
+        <p>ニックネーム</p>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,5 +1,7 @@
-<%if @travel_books.present? %>
-  <%= render @travel_books %>
-<% else %>
-  しおりがありません
-<% end %>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 p-4">
+  <%if @travel_books.present? %>
+    <%= render @travel_books %>
+  <% else %>
+    しおりがありません
+  <% end %>
+</div>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,0 +1,5 @@
+<%if @travel_books.present? %>
+  <%= render @travel_books %>
+<% else %>
+  しおりがありません
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "home#index"
+  root "travel_books#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   get "home/index"
+  resources :travel_books, only: %i[ index ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250108233522_create_travel_books.rb
+++ b/db/migrate/20250108233522_create_travel_books.rb
@@ -6,6 +6,8 @@ class CreateTravelBooks < ActiveRecord::Migration[7.2]
       t.boolean :is_public, null: false
       t.date :start_date
       t.date :end_date
+
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20250108233522_create_travel_books.rb
+++ b/db/migrate/20250108233522_create_travel_books.rb
@@ -1,0 +1,11 @@
+class CreateTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :travel_books do |t|
+      t.string :title, null: false
+      t.text :description
+      t.boolean :is_public, null: false
+      t.date :start_date
+      t.date :end_date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_06_123813) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_08_233522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "travel_books", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.boolean "is_public", null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION
# 概要
しおり一覧(ログインなしで閲覧可)を表示する機能を実装しました。

## 実施内容
- [x] TravelBookモデルとマイグレーションファイルの作成・適用
- [x] TravelBooksControllerの作成とindexアクションの定義
- [x] しおり一覧画面へのルーティング設定
- [x] ビューファイルのデザイン適用（仮）
- [x] しおり部分のパーシャル作成

## 未実施内容
- Usersテーブルとのアソシエーション設定（TravelBooksテーブルとUsersテーブルの中間テーブル未作成）
- ビューファイルのデザイン調整

## 補足
TravelBooksController#indexでしおり一覧のレコードを取得する際にallで取得していますが、しおりとユーザーの中間テーブルにアソシエーションの設定ができたらincludesで取得するように修正してください。

## 関連issue
#15 