### PR TITLE
Feature/しおり作成機能の作成

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -2,4 +2,8 @@ class TravelBooksController < ApplicationController
   def index
     @travel_books = TravelBook.all
   end
+
+  def new
+    @travel_book = TravelBook.new
+  end
 end

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,9 +1,25 @@
 class TravelBooksController < ApplicationController
   def index
-    @travel_books = TravelBook.all
+    @travel_books = TravelBook.includes(:users)
   end
 
   def new
     @travel_book = TravelBook.new
+  end
+
+  def create
+    @travel_book = current_user.travel_books.build(travel_book_param)
+    if @travel_book.save
+      redirect_to travel_books_path, success: "作成成功"
+    else
+      flash.now[:danger] = "作成失敗"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def travel_book_param
+    params.require(:travel_book).permit(:title, :description, :is_public, :start_date, :end_date)
   end
 end

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -10,9 +10,9 @@ class TravelBooksController < ApplicationController
   def create
     @travel_book = current_user.travel_books.build(travel_book_param)
     if @travel_book.save
-      redirect_to travel_books_path, success: "作成成功"
+      redirect_to travel_books_path, notice: "作成成功"
     else
-      flash.now[:danger] = "作成失敗"
+      flash.now[:alert] = "作成失敗"
       render :new, status: :unprocessable_entity
     end
   end
@@ -20,6 +20,6 @@ class TravelBooksController < ApplicationController
   private
 
   def travel_book_param
-    params.require(:travel_book).permit(:title, :description, :is_public, :start_date, :end_date)
+    params.require(:travel_book).permit(:title, :description, :is_public, :area_id, :start_date, :end_date)
   end
 end

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -20,6 +20,6 @@ class TravelBooksController < ApplicationController
   private
 
   def travel_book_param
-    params.require(:travel_book).permit(:title, :description, :is_public, :area_id, :start_date, :end_date)
+    params.require(:travel_book).permit(:title, :description, :is_public, :area_id, :traveler_type_id, :start_date, :end_date)
   end
 end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,0 +1,3 @@
+class Area < ApplicationRecord
+  has_many :travel_books
+end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -1,5 +1,6 @@
 class TravelBook < ApplicationRecord
   belongs_to :area
+  belongs_to :traveler_type
   has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
 

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -1,4 +1,7 @@
 class TravelBook < ApplicationRecord
+  has_many :user_travel_books, dependent: :destroy
+  has_many :users, through: :user_travel_books
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -1,4 +1,5 @@
 class TravelBook < ApplicationRecord
+  belongs_to :area
   has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
 

--- a/app/models/traveler_type.rb
+++ b/app/models/traveler_type.rb
@@ -1,0 +1,3 @@
+class TravelerType < ApplicationRecord
+  has_many :travel_books
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :user_travel_books, dependent: :destroy
+  has_many :travel_books, through: :user_travel_books
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user_travel_book.rb
+++ b/app/models/user_travel_book.rb
@@ -1,0 +1,6 @@
+class UserTravelBook < ApplicationRecord
+  belongs_to :user
+  belongs_to :travel_book
+
+  validates :user_id, uniqueness: { scope: :travel_book_id }
+end

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -25,6 +25,22 @@
 
         <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
           <div class="sm:col-span-3">
+            <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+              <%= f.date_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+
+          <div class="sm:col-span-3">
+            <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+                <%= f.date_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
             <%= f.label :area_id, class: "block text-sm/6 font-medium text-gray-900" %>
             <div class="mt-2 grid grid-cols-1">
               <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
@@ -41,29 +57,16 @@
           </div>
         </div>
 
-        <div class="mt-6 space-y-1">
-          <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_public, true, id: "is_public_true", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-            <%= f.label :is_public, "公開", for: "is_public_true" %>
-          </div>
-          <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_public, false, id: "is_public_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-            <%= f.label :is_public, "非公開", for: "is_public_false" %>
-          </div>
-        </div>
-
         <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2">
-              <%= f.date_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+          <div class="mt-6 space-y-1">
+            <p class="block text-sm/6 font-medium text-gray-900">tet</p>
+            <div class="flex items-center gap-x-3">
+              <%= f.radio_button :is_public, true, id: "is_public_true", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+              <%= f.label :is_public, "公開", for: "is_public_true" %>
             </div>
-          </div>
-
-          <div class="sm:col-span-3">
-            <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2">
-                <%= f.date_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            <div class="flex items-center gap-x-3">
+              <%= f.radio_button :is_public, false, id: "is_public_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+              <%= f.label :is_public, "非公開", for: "is_public_false" %>
             </div>
           </div>
         </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -25,12 +25,12 @@
 
         <div class="mt-6 space-y-1">
           <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_publish, true, id: "is_publish_true",class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-            <%= f.label :is_publish, "公開", for: "is_publish_true" %>
+            <%= f.radio_button :is_public, true, id: "is_public_true",class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.label :is_public, "公開", for: "is_public_true" %>
           </div>
           <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_publish, false, id: "is_publish_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-            <%= f.label :is_publish, "非公開", for: "is_publish_false" %>
+            <%= f.radio_button :is_public, false, id: "is_public_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.label :is_public, "非公開", for: "is_public_false" %>
           </div>
         </div>
 

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -23,9 +23,18 @@
           </div>
         </div>
 
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= f.label :area_id, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+            <%= f.select :area_id, Area.all.collect { |a| a.name }, class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
         <div class="mt-6 space-y-1">
           <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_public, true, id: "is_public_true",class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.radio_button :is_public, true, id: "is_public_true", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
             <%= f.label :is_public, "公開", for: "is_public_true" %>
           </div>
           <div class="flex items-center gap-x-3">

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,0 +1,59 @@
+<div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <%= form_with model: @travel_book do |f| %>
+    <div class="space-y-12">
+      <div class="border-b border-gray-900/10 pb-12">
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-4">
+            <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+              <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
+                <%= f.text_field :title, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="col-span-full">
+            <%= f.label :description, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+                <%= f.text_area :description, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-6 space-y-1">
+          <div class="flex items-center gap-x-3">
+            <%= f.radio_button :is_publish, true, id: "is_publish_true",class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.label :is_publish, "公開", for: "is_publish_true" %>
+          </div>
+          <div class="flex items-center gap-x-3">
+            <%= f.radio_button :is_publish, false, id: "is_publish_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.label :is_publish, "非公開", for: "is_publish_false" %>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+              <%= f.date_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+
+          <div class="sm:col-span-3">
+            <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+                <%= f.date_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+    <div class="mt-6 flex items-center justify-end gap-x-6">
+      <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -27,7 +27,16 @@
           <div class="sm:col-span-3">
             <%= f.label :area_id, class: "block text-sm/6 font-medium text-gray-900" %>
             <div class="mt-2 grid grid-cols-1">
-            <%= f.select :area_id, Area.all.collect { |a| a.name }, class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+              <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= f.label :traveler_type_id, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+              <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   get "home/index"
-  resources :travel_books, only: %i[ index new ]
+  resources :travel_books, only: %i[ index new create ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   get "home/index"
-  resources :travel_books, only: %i[ index ]
+  resources :travel_books, only: %i[ index new ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250111000040_create_user_travel_books.rb
+++ b/db/migrate/20250111000040_create_user_travel_books.rb
@@ -1,0 +1,11 @@
+class CreateUserTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_travel_books do |t|
+      t.references :user, foreign_key: true
+      t.references :travel_book, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :user_travel_books, [ :user_id, :travel_book_id ], unique: true
+  end
+end

--- a/db/migrate/20250111012216_change_is_public_to_travel_books.rb
+++ b/db/migrate/20250111012216_change_is_public_to_travel_books.rb
@@ -1,0 +1,5 @@
+class ChangeIsPublicToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default(:travel_books, :is_public, from: nil, to: false)
+  end
+end

--- a/db/migrate/20250111023510_create_areas.rb
+++ b/db/migrate/20250111023510_create_areas.rb
@@ -1,0 +1,8 @@
+class CreateAreas < ActiveRecord::Migration[7.2]
+  def change
+    create_table :areas do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250111025022_add_area_id_to_travel_books.rb
+++ b/db/migrate/20250111025022_add_area_id_to_travel_books.rb
@@ -1,0 +1,5 @@
+class AddAreaIdToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :travel_books, :area, foreign_key: true
+  end
+end

--- a/db/migrate/20250111115250_create_traveler_types.rb
+++ b/db/migrate/20250111115250_create_traveler_types.rb
@@ -1,0 +1,8 @@
+class CreateTravelerTypes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :traveler_types do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250111131352_add_traveler_type_id_to_travel_books.rb
+++ b/db/migrate/20250111131352_add_traveler_type_id_to_travel_books.rb
@@ -1,0 +1,5 @@
+class AddTravelerTypeIdToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :travel_books, :traveler_type, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_025022) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_131352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +29,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_025022) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "area_id"
+    t.bigint "traveler_type_id"
     t.index ["area_id"], name: "index_travel_books_on_area_id"
+    t.index ["traveler_type_id"], name: "index_travel_books_on_traveler_type_id"
+  end
+
+  create_table "traveler_types", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "user_travel_books", force: :cascade do |t|
@@ -55,6 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_025022) do
   end
 
   add_foreign_key "travel_books", "areas"
+  add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "user_travel_books", "travel_books"
   add_foreign_key "user_travel_books", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_012216) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_025022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "areas", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "travel_books", force: :cascade do |t|
     t.string "title", null: false
@@ -22,6 +28,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_012216) do
     t.date "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "area_id"
+    t.index ["area_id"], name: "index_travel_books_on_area_id"
   end
 
   create_table "user_travel_books", force: :cascade do |t|
@@ -46,6 +54,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_012216) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "travel_books", "areas"
   add_foreign_key "user_travel_books", "travel_books"
   add_foreign_key "user_travel_books", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_08_233522) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_000040) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_233522) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_travel_books", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "travel_book_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["travel_book_id"], name: "index_user_travel_books_on_travel_book_id"
+    t.index ["user_id", "travel_book_id"], name: "index_user_travel_books_on_user_id_and_travel_book_id", unique: true
+    t.index ["user_id"], name: "index_user_travel_books_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -35,4 +45,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_233522) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "user_travel_books", "travel_books"
+  add_foreign_key "user_travel_books", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_000040) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_012216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "travel_books", force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
-    t.boolean "is_public", null: false
+    t.boolean "is_public", default: false, null: false
     t.date "start_date"
     t.date "end_date"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,25 +7,43 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# Areasテーブルに値を格納
 ApplicationRecord.transaction do
 areas = [
   { id: 1, name: "Hokkaido" },
   { id: 2, name: "Tohoku" },
   { id: 3, name: "KitaKanto" },
-  { id: 3, name: "Syutoken" },
-  { id: 4, name: "Koshinetsu" },
-  { id: 4, name: "Tokai" },
-  { id: 5, name: "Hokuriku" },
-  { id: 5, name: "Kinki" },
-  { id: 6, name: "SaninSanyou" },
-  { id: 7, name: "Shikoku" },
-  { id: 8, name: "Kyushu" },
-  { id: 9, name: "Okinawa" }
+  { id: 4, name: "Syutoken" },
+  { id: 5, name: "Koshinetsu" },
+  { id: 6, name: "Tokai" },
+  { id: 7, name: "Hokuriku" },
+  { id: 8, name: "Kinki" },
+  { id: 9, name: "SaninSanyou" },
+  { id: 10, name: "Shikoku" },
+  { id: 11, name: "Kyushu" },
+  { id: 12, name: "Okinawa" },
+  { id: 13, name: "other" }
 ]
 
   areas.each do |area|
     Area.find_or_create_by(id: area[:id]) do |a|
       a.name = area[:name]
+    end
+  end
+
+  # TravelerTypesテーブルに値を格納
+  traveler_types = [
+    { id: 1, name: "family" },
+    { id: 2, name: "friends" },
+    { id: 3, name: "alone" },
+    { id: 4, name: "couple" },
+    { id: 5, name: "other" }
+  ]
+
+  traveler_types.each do | traveler_type |
+    TravelerType.find_or_create_by(id: traveler_type[:id]) do |t|
+      t.name = traveler_type[:name]
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,25 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+ApplicationRecord.transaction do
+areas = [
+  { id: 1, name: "Hokkaido" },
+  { id: 2, name: "Tohoku" },
+  { id: 3, name: "KitaKanto" },
+  { id: 3, name: "Syutoken" },
+  { id: 4, name: "Koshinetsu" },
+  { id: 4, name: "Tokai" },
+  { id: 5, name: "Hokuriku" },
+  { id: 5, name: "Kinki" },
+  { id: 6, name: "SaninSanyou" },
+  { id: 7, name: "Shikoku" },
+  { id: 8, name: "Kyushu" },
+  { id: 9, name: "Okinawa" }
+]
+
+  areas.each do |area|
+    Area.find_or_create_by(id: area[:id]) do |a|
+      a.name = area[:name]
+    end
+  end
+end


### PR DESCRIPTION
# 概要
しおりの作成機能を実装しました。

## 実施内容
- [x] ルーティング追加
- [x] コントローラーにnewをアクション追加
- [x] TravelBooksとUsersの中間テーブル(UserTravelBooks)を作成
- [x] Areaモデル、Areasテーブルの生成とアソシエーション設定
- [x] TravelTypeモデル、TravelTypesテーブルの生成とアソシエーション設定
- [x] seedsファイル編集(Areas、TravelTypesテーブルのレコード投入用)
- [x] しおり作成のビューファイルを追加

## 未実施内容
- デザインの調整
- フラッシュメッセージ機能
- しおり作成画面へのリンク設置

## 補足
しおり作成画面へのリンクはマイしおり一覧を作成したタイミングで設置します。
現在、しおり作成時、タイトル、公開設定(デフォルト値:false)、エリアと旅行者属性は入力必須(null false)にしています。

## 関連issue
#14 