### PR TITLE
Fix/中間テーブルの関連付けする処理追加

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -9,7 +9,10 @@ class TravelBooksController < ApplicationController
 
   def create
     @travel_book = current_user.travel_books.build(travel_book_param)
+
     if @travel_book.save
+      # 中間テーブルに関連付けを追加
+      current_user.user_travel_books.create(travel_book: @travel_book)
       redirect_to travel_books_path, notice: "作成成功"
     else
       flash.now[:alert] = "作成失敗"


### PR DESCRIPTION
# 概要
しおり作成時に中間テーブルに関連付けする処理が抜けていたため修正しました。

## 実施内容
- [x] コントローラーのcreateアクション(TravelBookController#create)に中間テーブルに関連付けする処理を追加

## 未実施内容
なし

## 補足
しおりとユーザーは多対多の関係です。

## 関連issue
#14,#20 