### PR TITLE
Feature/画像を外部ストレージへ保存する設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem "devise"
 # 画像
 gem "carrierwave", "~> 3.0"
 
+# Amazon S3
+gem "fog-aws"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,8 +120,26 @@ GEM
       warden (~> 1.2.3)
     drb (2.2.1)
     erubi (1.13.1)
+    excon (1.2.3)
     ffi (1.17.1-aarch64-linux-gnu)
     ffi (1.17.1-x86_64-linux-gnu)
+    fog-aws (3.30.0)
+      base64 (~> 0.2.0)
+      fog-core (~> 2.6)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.6.0)
+      builder
+      excon (~> 1.0)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.5)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -152,10 +170,15 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0107)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    multi_json (1.15.0)
     net-imap (0.5.5)
       date
       net-protocol
@@ -327,6 +350,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  fog-aws
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/uploaders/travel_book_uploader.rb
+++ b/app/uploaders/travel_book_uploader.rb
@@ -47,4 +47,11 @@ class TravelBookUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg"
   # end
+
+  # 本番環境と開発・テスト環境で保存先を分ける
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+require "carrierwave/storage/abstract"
+require "carrierwave/storage/file"
+require "carrierwave/storage/fog"
+
+CarrierWave.configure do |config|
+  if Rails.env.production?
+    config.storage :fog
+    config.fog_provider = "fog/aws"
+    config.fog_directory  = ENV["S3_BUCKET_NAME"]
+    config.fog_public = false
+    config.fog_credentials = {
+      provider: "AWS",
+      aws_access_key_id: ENV["S3_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["S3_SECRET_ACCESS_KEY"],
+      region: ENV["S3_REGION"],
+      path_style: true
+    }
+  else
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
+end


### PR DESCRIPTION
# 概要
carrierwaveでアップロードした画像を外部ストレージのAmazonS3へ保存する設定を行いました。

## 実施内容
- [x] IAMユーザーの作成
- [x] S3バケットの作成
- [x] バケットポリシーの追加
- [x] Gemfileの追加(fog-aws)
- [x] アップローダーのストレージを変更
- [x] IAMユーザーとバケットの情報を設定
- [x] 環境変数の設定
- [x] .envをgitignoreへ追加

## 未実施内容
なし

## 補足
デプロイしたサービスで画像ファイルをアップロードした際に、S3にアップロードされているかを確認します。

本番環境ではS3へ、開発・テスト環境ではローカルストレージへ保存するように設定しています。

## 関連issue
#50 