### PR TITLE
Feature/しおりの画像削除機能実装

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -45,6 +45,13 @@ class TravelBooksController < ApplicationController
     redirect_to travel_books_path, notice: "削除成功"
   end
 
+  def delete_image
+    @travel_book = TravelBook.find(params[:id])
+    @travel_book.remove_travel_book_image! # CarrierWaveのメソッドを使って画像を削除
+    @travel_book.save
+    redirect_to edit_travel_book_path(@travel_book), notice: "削除しました"
+  end
+
   private
 
   def travel_book_param

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -66,6 +66,13 @@
           </div>
         </div>
 
+        <div class="mt-2">
+          <%= image_tag @travel_book.travel_book_image_url, width:"80" %>
+          <% if @travel_book.travel_book_image_url %>
+            <%= link_to "destroy", delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-ghost rounded-btn" %>
+          <% end %>
+        </div>
+
         <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
           <div class="mt-6 space-y-1">
             <p class="block text-sm/6 font-medium text-gray-900">tet</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get "home/index"
   resources :travel_books, only: %i[ index new create show edit update destroy ] do
-    delete 'delete_image', on: :member
+    delete "delete_image", on: :member
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   get "home/index"
-  resources :travel_books, only: %i[ index new create show edit update destroy ]
+  resources :travel_books, only: %i[ index new create show edit update destroy ] do
+    delete 'delete_image', on: :member
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# 概要
自分が所有するしおりにアップロードした画像を削除する機能を実装します。
（S3のストレージを圧迫しないようにするため）

## 実施内容
- [x] ルーティング定義(delete "delete_image")
- [x] ビューファイルを編集（_form.html.erb）
- [x] コントローラーにカスタムアクションを定義(TravelBookController#delete_image)

## 未実施内容
- デザイン調整

## 補足
- 画像削除機能の要否を検討

## 関連issue
#71 