### PR TITLE
Feature/ボトムナビゲーションの実装

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  # 指定したパスが現在のページであれば"active"を返す
+  def add_active_class(path)
+    "active" if current_page?(path)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,8 @@
   </head>
 
   <body class="bg-base-200 min-h-screen">
-    <%= render 'shared/header' %>
+    <%= render "shared/header" %>
     <%= yield %>
+    <%= render "shared/bottom_navigation" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <script src="https://kit.fontawesome.com/db3944d085.js" crossorigin="anonymous"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,14 +1,14 @@
 <div class="btm-nav">
-  <button>
+  <%= link_to root_path, class: "#{add_active_class(root_path)}" do %>
     <i class="fa-solid fa-magnifying-glass"></i>
     <span class="btm-nav-label">しおり検索</span>
-  </button>
-  <button class="active">
+  <% end %>
+  <%= link_to "#" do %>
     <i class="fa-solid fa-map-location-dot"></i>
     <span class="btm-nav-label">マイしおり</span>
-  </button>
-  <button>
+  <% end %>
+  <%= link_to "#" do %>
     <i class="fa-solid fa-circle-user"></i>
     <span class="btm-nav-label">マイページ</span>
-  </button>
+  <% end %>
 </div>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,0 +1,47 @@
+<div class="btm-nav">
+  <button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+    </svg>
+    <span class="btm-nav-label">Home</span>
+  </button>
+  <button class="active">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span class="btm-nav-label">Warnings</span>
+  </button>
+  <button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+    </svg>
+    <span class="btm-nav-label">Statics</span>
+  </button>
+</div>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,47 +1,14 @@
 <div class="btm-nav">
   <button>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class="h-5 w-5"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-    </svg>
-    <span class="btm-nav-label">Home</span>
+    <i class="fa-solid fa-magnifying-glass"></i>
+    <span class="btm-nav-label">しおり検索</span>
   </button>
   <button class="active">
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class="h-5 w-5"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-    <span class="btm-nav-label">Warnings</span>
+    <i class="fa-solid fa-map-location-dot"></i>
+    <span class="btm-nav-label">マイしおり</span>
   </button>
   <button>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class="h-5 w-5"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-    </svg>
-    <span class="btm-nav-label">Statics</span>
+    <i class="fa-solid fa-circle-user"></i>
+    <span class="btm-nav-label">マイページ</span>
   </button>
 </div>


### PR DESCRIPTION
# 概要
アプリ下部に固定表示させるナビゲーションメニューを作成します。
トップページ、マイしおり、マイページへの仮リンクを設置します。

## 実施内容
- [x] ビューファイルを作成(app/views/shared/_bottom_menu.html.erb)
- [x] 全ページ共通ファイルとして設定(app/views/layouts/application.html.erb)
- [x] ヘルパーメソッドを定義(指定されたパスが現在のページと同じであればactiveを返す)
- [x] fontawesomeの導入

## 未実施内容
- マイしおり、マイページへのリンク,classの設定(マイしおり、マイページ未実装)
- デザイン調整

## 補足
なし

## 関連issue
#12 