### PR TITLE
Feature/マイしおり一覧の実装

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,6 +1,11 @@
 class TravelBooksController < ApplicationController
   def index
-    @travel_books = TravelBook.includes(:users)
+    @travel_books =
+    if params[:scope] == "own"
+      current_user.travel_books
+    else
+      TravelBook.public_travel_books.includes(:users)
+    end
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,12 @@
 module ApplicationHelper
   # 指定したパスが現在のページであれば"active"を返す
   def add_active_class(path)
-    "active" if current_page?(path)
+    if path == travel_books_path && (request.fullpath == root_path || request.fullpath == travel_books_path)
+      "active"
+    elsif request.fullpath == path
+      "active"
+    else
+      ""
+    end
   end
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -9,6 +9,8 @@ class TravelBook < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }
 
+  scope :public_travel_books, -> { where(is_public: true) }
+
   def owned_by_user?(user)
     users.exists?(id: user.id)
   end

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,9 +1,9 @@
 <div class="btm-nav">
-  <%= link_to root_path, class: "#{add_active_class(root_path)}" do %>
+  <%= link_to travel_books_path, class: "#{add_active_class(travel_books_path)}" do %>
     <i class="fa-solid fa-magnifying-glass"></i>
     <span class="btm-nav-label">しおり検索</span>
   <% end %>
-  <%= link_to "#" do %>
+  <%= link_to travel_books_path(scope: 'own'), class: "#{add_active_class(travel_books_path(scope: 'own'))}" do %>
     <i class="fa-solid fa-map-location-dot"></i>
     <span class="btm-nav-label">マイしおり</span>
   <% end %>

--- a/app/views/travel_books/_my_travel_book.html.erb
+++ b/app/views/travel_books/_my_travel_book.html.erb
@@ -1,0 +1,20 @@
+<% travel_books.each do |travel_book| %>
+  <%= link_to travel_book_path(travel_book), class: "block" do %>
+    <div class="card bg-base-100 w-full">
+      <figure>
+        <%= image_tag travel_book.travel_book_image_url %>
+      </figure>
+      <div class="card-body flex flex-col items-center justify-center text-center">
+        <h2 class="card-title"><%= travel_book.title %></h2>
+        <div class="flex items-center justify-center gap-2">
+          <div class="badge">出発</div>
+          <p><%= travel_book.start_date %></p>
+        </div>
+        <div class="flex items-center justify-center gap-2">
+          <div class="badge">到着</div>
+          <p><%= travel_book.end_date %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,6 +1,10 @@
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 p-4">
   <%if @travel_books.present? %>
-    <%= render @travel_books %>
+    <%if params[:scope] == "own" %>
+      <%= render "my_travel_book", travel_books: @travel_books %>
+    <% else %>
+      <%= render @travel_books %>
+    <% end %>
   <% else %>
     しおりがありません
   <% end %>


### PR DESCRIPTION
# 概要
既存のしおり一覧を、公開設定されたしおりを表示するしおり一覧と、自分が所有するマイしおり一覧で
画面を出し分けるように実装しました。

## 実施内容
- [x] TravelBooksController#indexでparamsに応じてマイしおりか公開設定されたしおりを取得する処理
- [x] マイしおりのビューを作成
- [x] ボトムナビゲーションにリンク設置

## 未実施内容
- デザイン調整

## 補足
ボトムナビゲーションの「しおり検索」：公開設定されたしおり一覧を表示します。
ボトムナビゲーションの「マイしおり」：current_userに紐づいたしおり(マイしおり)一覧を表示します。

## 関連issue
#74 