### PR TITLE
Feature/ボトムナビゲーション表示切り替え機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def set_travel_book
+    @travel_book = TravelBook.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  # ボトムナビゲーションのだしわけ
+  # TravelController#showでユーザーがしおりとリレーションを組んでいる場合true
+  def display_bottom_nav?
+    controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(id: params[:id])
+  end
+
   # 指定したパスが現在のページであれば"active"を返す
   def add_active_class(path)
     if path == travel_books_path && (request.fullpath == root_path || request.fullpath == travel_books_path)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,10 @@
   <body class="bg-base-200 min-h-screen">
     <%= render "shared/header" %>
     <%= yield %>
-    <%= render "shared/bottom_navigation" %>
+    <% if display_bottom_nav? %>
+      <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>
+    <% else %>
+      <%= render "shared/bottom_navigation" %>
+    <% end %>
   </body>
 </html>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -1,0 +1,22 @@
+<div class="btm-nav">
+  <%= link_to travel_book_path(travel_book.id), class: "#{add_active_class(travel_book_path)}" do %>
+    <i class="fa-regular fa-map"></i>
+    <span class="btm-nav-label">しおり情報</span>
+  <% end %>
+  <%= link_to "#" do %>
+    <i class="fa-regular fa-clock"></i>
+    <span class="btm-nav-label">スケジュール</span>
+  <% end %>
+  <%= link_to "#" do %>
+  <i class="fa-solid fa-location-dot"></i>
+    <span class="btm-nav-label">マップ</span>
+  <% end %>
+  <%= link_to "#" do %>
+    <i class="fa-solid fa-file-pen"></i>
+    <span class="btm-nav-label">ノート</span>
+  <% end %>
+  <%= link_to "#" do %>
+    <i class="fa-solid fa-image"></i>
+    <span class="btm-nav-label">アルバム</span>
+  <% end %>
+</div>


### PR DESCRIPTION
# 概要
画面によって表示するボトムナビゲーションの表示を切り替える機能を実装します。
マイしおりの詳細表示画面とそれ以外の画面で表示を切り替えます。

## 実施内容
- [x] ボトムナビゲーションのビュー作成
- [x] 表示するボトムナビゲーションの条件分岐
- [x] ヘルパーにボトムナビゲーションの表示条件判断メソッドを定義

## 未実施内容
- ボトムナビゲーションへのリンク設置(スケジュール,マップ,ノート,アルバム)
- デザイン調整

## 補足
表示するボトムナビゲーションの条件分岐はヘルパー(app/helpers/application_helper.rb)に記述しています。

## 関連issue
#13 