### PR TITLE
Feature/プロフィール編集画面の作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,8 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-  # deviseコントローラーにストロングパラメータを追加
-  before_action :configure_permitted_parameters, if: :devise_controller?
 
   def set_travel_book
     @travel_book = TravelBook.find(params[:id])
-  end
-
-  protected
-  def configure_permitted_parameters
-    # ユーザー登録時にnameのストロングパラメータを追加
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
-    # ユーザー編集時にnameのストロングパラメータを追加
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_sign_up_params, only: [ :create ]
+  before_action :configure_account_update_params, only: [ :update ]
 
   # GET /resource/sign_up
   # def new
@@ -45,14 +45,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -67,7 +67,6 @@
         </div>
 
         <div class="mt-2">
-          <%= image_tag @travel_book.travel_book_image_url, width:"80" %>
           <% if @travel_book.persisted? %>
             <% if @travel_book.travel_book_image_url %>
               <%= link_to "destroy", delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-ghost rounded-btn" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,6 +1,7 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -13,22 +14,11 @@
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
   <div class="actions">
     <%= f.submit "Update" %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<%= link_to "Back", :back, class: "btn" %>
 
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -4,21 +4,23 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true %>
-  </div>
+    <div class="mt-10 grid grid-cols-1">
+      <%= f.label :name, class: "block text-sm/6 font-medium text-gray-900" %>
+      <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
+        <%= f.text_field :name, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
+      </div>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div class="mt-10 grid grid-cols-1">
+      <%= f.label :email, class: "block text-sm/6 font-medium text-gray-900" %>
+      <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
+        <%= f.email_field :email, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
+      </div>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Update" %>
+  <div class="mt-10 flex gap-2 justify-center">
+    <%= link_to "Back", :back, class: "btn" %>
+    <%= f.submit "Update", class: "btn" %><% end %>
   </div>
-<% end %>
-
-<%= link_to "Back", :back, class: "btn" %>
 
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,5 +10,7 @@
       <p><%= @user.email %></p>
     </div>
 
-    <%= link_to "edit", edit_user_registration_path, class: "btn btn-ghost rounded-btn" %>
+    <div class="mt-10 text-center">
+      <%= link_to "edit", edit_user_registration_path, class: "btn rounded-btn" %>
+    </div>
 </div>


### PR DESCRIPTION
# 概要
ログインユーザーのプロフィール編集画面を実装しました。

## 実施内容
- [x] パスワードなしでユーザー情報が編集できるように設定
- [x] ストロングパラメータの設定をRegistrationsControllerに移行
- [x] プロフィール編集のビューを修正
- [x] プロフィール表示のビューを微修正
- [x] (テストのため)しおり新規画面のimageタグをコメントアウト

## 未実施内容
- デザイン調整

## 補足
本番環境のしおり新規作成画面でエラーが出る原因特定のため、imageタグをコメントアウトしています。

## 関連issue
#40 