### PR TITLE
Chore/seedsデータの適用設定

### DIFF
--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -1,8 +1,8 @@
 class TravelBook < ApplicationRecord
   mount_uploader :travel_book_image, TravelBookUploader
 
-  belongs_to :area
-  belongs_to :traveler_type
+  belongs_to :area, optional: true
+  belongs_to :traveler_type, optional: true
   has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
 

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# データベースのマイグレーション
+bin/rails db:migrate
+
+# seedsデータの適用
+bin/rails db:seed


### PR DESCRIPTION
# 概要
seedsデータをRenderで適用するための設定をしました。
しおりのエリアと旅行者タイプの入力必須をなくしました。

## 実施内容
- [x] bin/render-build.sh作成
- [x] エリアと旅行者タイプにoptional: trueを設定

## 未実施内容
なし

## 補足
seedsが適用できたら、bin/render-build.shのseeds適用をコメントアウトします。

## 関連issue