### PR TITLE
Fix/しおり詳細画面の変数を修正

### DIFF
--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,6 +1,6 @@
 <div class="card bg-base-100 shadow-md m-6">
   <figure>
-    <%= image_tag(travel_book.travel_book_image? ? travel_book.travel_book_image_url : "default_travel_book_image.jpg") %>
+    <%= image_tag(@travel_book.travel_book_image? ? @travel_book.travel_book_image_url : "default_travel_book_image.jpg") %>
   </figure>
 
   <div class="card-body">


### PR DESCRIPTION
# 概要
本番環境でしおり詳細画面でエラーが出ていたため修正しました。
※しおり詳細画面(travel_books/show)で変数の@が抜けていたため追記(#81の修正)

## 実施内容
-[x] しおり詳細画面(travel_books/show)で変数の@が抜けていたため追記

## 未実施内容
なし

## 補足
なし

## 関連issue
#81