### PR TITLE
Feature/しおりの作者登録

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -14,6 +14,7 @@ class TravelBooksController < ApplicationController
 
   def create
     @travel_book = current_user.travel_books.build(travel_book_param)
+    @travel_book.creator_id = current_user.id
 
     if @travel_book.save
       # 中間テーブルに関連付けを追加

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -3,6 +3,7 @@ class TravelBook < ApplicationRecord
 
   belongs_to :area, optional: true
   belongs_to :traveler_type, optional: true
+  belongs_to :creator, class_name: "User"
   has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   mount_uploader :icon_image, UserUploader
   has_many :user_travel_books, dependent: :destroy
   has_many :travel_books, through: :user_travel_books
+  has_many :created_travel_books, class_name: "TravelBook", foreign_key: "creator_id", dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -13,7 +13,7 @@
             <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
           </div>
         </div>
-        <p>ニックネーム</p>
+        <p><%= travel_book.creator.name %></p>
       </div>
     </div>
   </div>

--- a/db/migrate/20250120122157_add_creator_id_to_travel_books.rb
+++ b/db/migrate/20250120122157_add_creator_id_to_travel_books.rb
@@ -1,0 +1,5 @@
+class AddCreatorIdToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :travel_books, :creator, null: false, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_19_115048) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_20_122157) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,7 +31,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_19_115048) do
     t.bigint "area_id"
     t.bigint "traveler_type_id"
     t.string "travel_book_image"
+    t.bigint "creator_id", null: false
     t.index ["area_id"], name: "index_travel_books_on_area_id"
+    t.index ["creator_id"], name: "index_travel_books_on_creator_id"
     t.index ["traveler_type_id"], name: "index_travel_books_on_traveler_type_id"
   end
 
@@ -67,6 +69,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_19_115048) do
 
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
+  add_foreign_key "travel_books", "users", column: "creator_id"
   add_foreign_key "user_travel_books", "travel_books"
   add_foreign_key "user_travel_books", "users"
 end


### PR DESCRIPTION
# 概要
しおりの作者がわかるようにしおりにしおり作者(creator_id)を紐づけます。

## 実施内容
- [x] しおりテーブルにcreator_idカラム追加
- [x] TravelBookモデルとUserモデルにリレーション設定
- [x] しおり作成時にコントローラーでcreator_idカラムにcurrentuserのidを格納
- [x] ビューでしおりにしおり作者を表示

## 未実施内容
なし

## 補足
しおりとユーザーは多対多の関係です。
しおりは複数ユーザーから所有される

## 関連issue
#82 