### PR TITLE
Feature/スケジュール一覧表示機能の実装

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,6 +1,6 @@
 class SchedulesController < ApplicationController
   def index
-    travel_book = current_user.travel_books.find(params[:travel_book_id])
-    @schedules = travel_book.schedules
+    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @schedules = @travel_book.schedules
   end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,0 +1,6 @@
+class SchedulesController < ApplicationController
+  def index
+    travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @schedules = travel_book.schedules
+  end
+end

--- a/app/decorators/schedule_decorator.rb
+++ b/app/decorators/schedule_decorator.rb
@@ -1,0 +1,11 @@
+class ScheduleDecorator < Draper::Decorator
+  delegate_all
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,7 @@ module ApplicationHelper
   # ボトムナビゲーションのだしわけ
   # TravelController#showでユーザーがしおりとリレーションを組んでいる場合true
   def display_bottom_nav?
+    return false if current_user.nil?
     controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(id: params[:id])
   end
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,0 +1,3 @@
+class Schedule < ApplicationRecord
+  belongs_to :travel_book
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,3 +1,8 @@
 class Schedule < ApplicationRecord
   belongs_to :travel_book
+
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :memo, length: { maximum: 65_535 }
+  validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :end_date, comparison: { greater_than: :start_date }
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -14,6 +14,7 @@ class TravelBook < ApplicationRecord
   scope :public_travel_books, -> { where(is_public: true) }
 
   def owned_by_user?(user)
+    return false if user.nil?
     users.exists?(id: user.id)
   end
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -6,6 +6,7 @@ class TravelBook < ApplicationRecord
   belongs_to :creator, class_name: "User"
   has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
+  has_many :schedules
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,0 +1,9 @@
+<div class="flex gap-3">
+  <div class="flex">
+    <%= @schedules.start_date %>
+    ~<%= @schedules.end_date %>
+  </div>
+  <div>
+    <%= @schedules.title %>
+  </div>
+</div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,0 +1,17 @@
+<div class="bg-white rounded-lg shadow-md p-6 m-6 flex flex-col items-center">
+
+  <h1 class="mt-2 text-center text-lg font-bold"><%= @travel_book.title %></h2>
+
+  <div class="mt-5 flex gap-2">
+    <p><%= travel_book_duration(@travel_book)%></p>
+  </div>
+
+    <%= render @schedules %>
+  <% if @schedules.present? %>
+    <%= render @schedules %>
+  <% else %>
+    <%= link_to "#" do %>
+      スケジュールを登録のリンク
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -3,7 +3,7 @@
     <i class="fa-regular fa-map"></i>
     <span class="btm-nav-label">しおり情報</span>
   <% end %>
-  <%= link_to "#" do %>
+  <%= link_to travel_book_schedules_path(@travel_book) do %>
     <i class="fa-regular fa-clock"></i>
     <span class="btm-nav-label">スケジュール</span>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "home/index"
   resources :travel_books, only: %i[ index new create show edit update destroy ] do
     delete "delete_image", on: :member
+    resources :schedules, shallow: true
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250122022836_create_schedules.rb
+++ b/db/migrate/20250122022836_create_schedules.rb
@@ -1,0 +1,13 @@
+class CreateSchedules < ActiveRecord::Migration[7.2]
+  def change
+    create_table :schedules do |t|
+      t.references :travel_book, null: false, foreign_key: true
+      t.string :title, null: false
+      t.integer :budged, default: 0
+      t.text :memo
+      t.datetime :start_date
+      t.datetime :end_date
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_20_122157) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_22_022836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_20_122157) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "schedules", force: :cascade do |t|
+    t.bigint "travel_book_id", null: false
+    t.string "title", null: false
+    t.integer "budged", default: 0
+    t.text "memo"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["travel_book_id"], name: "index_schedules_on_travel_book_id"
   end
 
   create_table "travel_books", force: :cascade do |t|
@@ -67,6 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_20_122157) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "schedules", "travel_books"
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "travel_books", "users", column: "creator_id"


### PR DESCRIPTION
# 概要
しおりに紐づいたスケジュール一覧を表示する機能を実装しました。

## 実施内容
- [x] schedulesテーブルの生成とリレーション設定
- [x] scheduleモデルにバリデーション設定
- [x] ボトムナビゲーションにスケジュール一覧画面へのリンク設置
- [x] スケジュール一覧のビューファイル生成
- [x] ログインしていない状態でしおり一覧、確認画面を操作した際のエラー解消

## 未実施内容
- スケジュール一覧画面の作り込み

## 補足
ログインしていない状態でしおり一覧やしおり確認画面を操作していると
current_userがnilのためにエラーが表示される箇所があったため、エラー解消を行いました。

コントローラー作成時に自動生成されたデコレーターは現在使用していませんが、
今後使用を検討しているため、メソッド未定義の状態でコミットしています。

## 関連issue
#27 