### PR TITLE
Feature/スケジュール登録機能実装

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,6 +1,27 @@
 class SchedulesController < ApplicationController
   def index
     @travel_book = current_user.travel_books.find(params[:travel_book_id])
-    @schedules = @travel_book.schedules
+    @schedules = @travel_book.schedules.sort_by(&:start_date)
+  end
+
+  def new
+    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @schedule = @travel_book.schedules.new
+  end
+
+  def create
+    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @schedule = @travel_book.schedules.build(schedule_param)
+    if @schedule.save
+      redirect_to travel_book_schedules_path(@travel_book)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def schedule_param
+    params.require(:schedule).permit(:title, :budged, :memo, :start_date, :end_date)
   end
 end

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -1,0 +1,13 @@
+module SchedulesHelper
+  def sum_budgets(schedules)
+    schedules.sum { | schedule | schedule.budged.to_i }
+  end
+
+  def fmt_date(date)
+    date.strftime("%Y年%-m月%-d日(%a)") || ""
+  end
+
+  def fmt_datetime(date)
+    date.strftime("%H:%M") || "未定"
+  end
+end

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,0 +1,63 @@
+  <%= form_with model: [@travel_book, @schedule] do |f| %>
+    <div class="space-y-12">
+      <div class="border-b border-gray-900/10 pb-12">
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-4">
+            <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+              <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
+                <%= f.text_field :title, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+              <%= f.datetime_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+
+          <div class="sm:col-span-3">
+            <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+                <%= f.datetime_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          場所
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= f.label :budged, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+              <%= f.number_field :budged, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="col-span-full">
+            <%= f.label :memo, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2">
+                <%= f.text_area :memo, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          アイコン
+        </div>
+
+      </div>
+    </div>
+    <div class="mt-6 flex items-center justify-end gap-x-6">
+      <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    </div>
+  <% end %>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,9 +1,12 @@
-<div class="flex gap-3">
-  <div class="flex">
-    <%= @schedules.start_date %>
-    ~<%= @schedules.end_date %>
-  </div>
+<div class="flex gap-4">
   <div>
-    <%= @schedules.title %>
+    <p><%= fmt_datetime(schedule.start_date) %></p>
+    <p>~ <%= fmt_datetime(schedule.end_date) %></p>
+  </div>
+  <div class="flex items-center">
+    <i class="fa-solid fa-train-subway"></i>
+  </div>
+  <div class="flex items-center">
+      <%= schedule.title %>
   </div>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,17 +1,32 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6 flex flex-col items-center">
+<div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <div class="flex flex-col items-center">
 
-  <h1 class="mt-2 text-center text-lg font-bold"><%= @travel_book.title %></h2>
+    <h1 class="mt-2 text-center text-lg font-bold"><%= @travel_book.title %></h1>
 
-  <div class="mt-5 flex gap-2">
-    <p><%= travel_book_duration(@travel_book)%></p>
+    <div class="mt-5 flex gap-2">
+      <p><%= travel_book_duration(@travel_book)%></p>
+    </div>
+
   </div>
 
-    <%= render @schedules %>
-  <% if @schedules.present? %>
-    <%= render @schedules %>
+ <% if @schedules.present? %>
+    <% @schedules.group_by { |schedule| schedule.start_date.to_date }.each do |date, schedules| %>
+      <p class="mt-5 mb-2"><%= fmt_date(date) %></p>
+      <div class="divide-y divide-blue-400">
+      <% schedules.each do |schedule| %>
+        <%= render partial: "schedule", locals: { schedule: schedule } %>
+      <% end %>
+      </div>
+    <% end %>
   <% else %>
-    <%= link_to "#" do %>
+    <%= link_to new_travel_book_schedule_path	do %>
       スケジュールを登録のリンク
     <% end %>
+  <% end %>
+
+  <p class="text-right">合計金額：<%= sum_budgets(@schedules) %>円</p>
+
+  <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
+    追加
   <% end %>
 </div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,0 +1,3 @@
+<div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <%= render "form", schedule: @schedule, travel_book: @travel_book %>
+</div>


### PR DESCRIPTION
# 概要
しおりに紐づくスケジュールの登録機能を実装します。

## 実施内容
- [x] Scheduleコントローラーにnew,createアクションを定義
- [x] スケジュール登録のビューとフォームのパーシャルを生成
- [x] スケジュール一覧で表示するスケジュール部分のパーシャル生成
- [x] スケジュールの日付、時間、合計金額表示用のヘルパーメソッド定義
- [x] スケジュール登録画面のリンク設置

## 未実施内容
- 場所の登録
- アイコンの登録
- デザイン調整

## 補足
現在スケジュールで登録できるのはタイトル、日時、メモ、合計金額のみです。

## 関連issue
#26 