### PR TITLE
Feature/しおりとスケジュールのバリデーション機能とその他修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -9,6 +9,10 @@ class SchedulesController < ApplicationController
   def new
     @travel_book = current_user.travel_books.find(params[:travel_book_id])
     @schedule = @travel_book.schedules.new
+    # Scheduleのstart_dateの初期値を設定
+    if @travel_book.start_date.present?
+      @schedule.start_date = @travel_book.start_date.to_datetime
+    end
   end
 
   def create

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -3,7 +3,7 @@ class SchedulesController < ApplicationController
   before_action :set_schedule, only: %i[ show edit update destroy ]
 
   def index
-    @schedules = @travel_book.schedules.sort_by(&:start_date)
+    @schedules = @travel_book.sorted_schedules
   end
 
   def new

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -3,7 +3,37 @@ module SchedulesHelper
     schedules.sum { | schedule | schedule.budged.to_i }
   end
 
+  def fmt_schedule_date(date)
+    return "" if date.nil?
+    date.strftime("%Y年%-m月%-d日(%a) %-H:%M")
+  end
+
   def fmt_datetime(date)
-    date.strftime("%H:%M") || "未定"
+    return "" if date.nil?
+    date.strftime("%-H:%M")
+  end
+
+  def fmt_schedule_duration(schedule)
+    if schedule.start_date && schedule.end_date
+      "#{fmt_schedule_date(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
+    elsif schedule.start_date || schedule.end_date
+      "#{fmt_schedule_date(schedule.start_date)} - #{fmt_schedule_date(schedule.end_date)}".strip
+    else
+      "未定"
+    end
+  end
+
+  def fmt_schedule_datetime_duration(schedule)
+    if schedule.start_date && schedule.end_date
+      "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
+    elsif schedule.start_date || schedule.end_date
+      "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}".strip
+    else
+      "未定"
+    end
+  end
+
+  def display_memo(date)
+    date == "" ? "メモはありません" : date
   end
 end

--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -5,7 +5,7 @@ module TravelBooksHelper
 
   def travel_book_duration(travel_book)
     if travel_book.start_date && travel_book.end_date
-      "#{fmt_date(travel_book.start_date)} ~ #{fmt_date(travel_book.end_date)}"
+      "#{fmt_date(travel_book.start_date)} - #{fmt_date(travel_book.end_date)}"
     elsif travel_book.start_date || travel_book.end_date
       "#{fmt_date(travel_book.start_date) || ''} #{fmt_date(travel_book.end_date) || ''}".strip
     else

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,5 +4,13 @@ class Schedule < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :memo, length: { maximum: 65_535 }
   validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :end_date, comparison: { greater_than: :start_date }
+  validate :end_date_after_start_date
+
+  private
+
+  def end_date_after_start_date
+    if start_date.present? && end_date.present? && end_date < start_date
+      errors.add(:end_date, "must be after start date")
+    end
+  end
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -10,11 +10,20 @@ class TravelBook < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }
+  validate :end_date_after_start_date
 
   scope :public_travel_books, -> { where(is_public: true) }
 
   def owned_by_user?(user)
     return false if user.nil?
     users.exists?(id: user.id)
+  end
+
+  private
+
+  def end_date_after_start_date
+    if start_date.present? && end_date.present? && end_date < start_date
+      errors.add(:end_date, "must be after start date")
+    end
   end
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -19,6 +19,10 @@ class TravelBook < ApplicationRecord
     users.exists?(id: user.id)
   end
 
+  def sorted_schedules
+    schedules.sort_by { |schedule| schedule.start_date || DateTime.new(0) }
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -6,7 +6,7 @@ class TravelBook < ApplicationRecord
   belongs_to :creator, class_name: "User"
   has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
-  has_many :schedules
+  has_many :schedules, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: schedule, url: schedule.new_record? ? travel_book_schedules_path(travel_book) : schedule_path(schedule) do |f| %>
-
+  <%= render "shared/error_messages", object: f.object %>
   <div class="space-y-12">
     <div class="border-b border-gray-900/10 pb-12">
 

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,9 +1,7 @@
 <%= form_with model: schedule, url: schedule.new_record? ? travel_book_schedules_path(travel_book) : schedule_path(schedule) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
-  <div class="space-y-12">
-    <div class="border-b border-gray-900/10 pb-12">
-
-      <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+  <div class="space-y-5">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         <div class="sm:col-span-4">
           <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
           <div class="mt-2">
@@ -14,7 +12,7 @@
         </div>
       </div>
 
-      <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         <div class="sm:col-span-3">
           <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
           <div class="mt-2">
@@ -30,11 +28,11 @@
         </div>
       </div>
 
-      <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         場所
       </div>
 
-      <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         <div class="sm:col-span-3">
           <%= f.label :budged, class: "block text-sm/6 font-medium text-gray-900" %>
           <div class="mt-2 grid grid-cols-1">
@@ -43,7 +41,7 @@
         </div>
       </div>
 
-      <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         <div class="col-span-full">
           <%= f.label :memo, class: "block text-sm/6 font-medium text-gray-900" %>
           <div class="mt-2">
@@ -52,11 +50,9 @@
         </div>
       </div>
 
-      <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         アイコン
       </div>
-
-    </div>
   </div>
   <div class="mt-6 flex items-center justify-end gap-x-6">
     <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,14 +1,11 @@
-<%= link_to schedule_path(schedule) do %>
-  <div class="flex gap-4">
-    <div>
-      <p><%= fmt_datetime(schedule.start_date) %></p>
-      <p>~ <%= fmt_datetime(schedule.end_date) %></p>
-    </div>
-    <div class="flex items-center">
-      <i class="fa-solid fa-train-subway"></i>
-    </div>
-    <div class="flex items-center">
-        <%= schedule.title %>
-    </div>
-  </div>
-<% end %>
+<table class="min-w-full">
+  <tbody>
+    <tr>
+      <td class="w-1/3 p-4"><%= fmt_schedule_datetime_duration(schedule) %></td>
+      <td class="w-2/3 p-4">
+        <i class="fa-solid fa-train-subway"></i>
+        <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,7 +1,10 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <%= link_to travel_book_schedules_path(@travel_book) do %>
-    <i class="fa-solid fa-chevron-left"></i>
-  <% end %>
+  <div class="flex items-center justify-between">
+    <%= link_to schedule_path(@schedule) do %>
+      <i class="fa-solid fa-chevron-left"></i>
+    <% end %>
+    <h1 class="text-center flex-1 text-lg font-bold">スケジュールを編集</h1>
+  </div>
 
   <%= render "form", schedule: @schedule %>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,30 +1,23 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
+
   <div class="flex flex-col items-center">
-
-    <h1 class="mt-2 text-center text-lg font-bold"><%= @travel_book.title %></h1>
-
-    <div class="mt-5 flex gap-2">
-      <p><%= travel_book_duration(@travel_book)%></p>
-    </div>
-
+    <h1 class="text-center text-lg font-bold"><%= @travel_book.title %></h1>
+    <p><%= travel_book_duration(@travel_book)%></p>
   </div>
 
- <% if @schedules.present? %>
-    <% @schedules.group_by { |schedule| schedule.start_date.to_date }.each do |date, schedules| %>
-      <p class="mt-5 mb-2"><%= fmt_date(date) %></p>
-      <div class="divide-y divide-blue-400">
-      <% schedules.each do |schedule| %>
-        <%= render partial: "schedule", locals: { schedule: schedule } %>
+  <% if @schedules.present? %>
+      <% @schedules.group_by { |schedule| schedule.start_date.nil? ? "日付未設定" : schedule.start_date.to_date }.each do |date, schedules| %>
+        <p class="mt-5 mb-2"><%= date == "日付未設定" ? "日付未設定" : fmt_date(date) %></p>
+        <div class="divide-y divide-blue-400">
+        <% schedules.each do |schedule| %>
+          <%= render partial: "schedule", locals: { schedule: schedule } %>
+        <% end %>
+        </div>
       <% end %>
-      </div>
-    <% end %>
-
     <p class="text-right">合計金額：<%= sum_budgets(@schedules) %>円</p>
 
   <% else %>
-    <%= link_to new_travel_book_schedule_path(@travel_book) do %>
-      スケジュールを登録のリンク
-    <% end %>
+    <p>スケジュールを登録しましょう</p>
   <% end %>
 
   <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,3 +1,10 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <div class="flex items-center justify-between">
+    <%= link_to travel_book_schedules_path(@travel_book) do %>
+      <i class="fa-solid fa-chevron-left"></i>
+    <% end %>
+    <h1 class="text-center flex-1 text-lg font-bold">スケジュールを追加</h1>
+  </div>
+
   <%= render "form", schedule: @schedule, travel_book: @travel_book %>
 </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,38 +1,42 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <%= link_to travel_book_schedules_path(@travel_book) do %>
-    <i class="fa-solid fa-chevron-left"></i>
-  <% end %>
 
-  <div class="flex flex-col items-center">
-    <h1 class="mt-2 text-center text-lg font-bold"><%= @schedule.title %></h2>
-  </div>
-
-  <div class="mt-5">
-    <p>日時</p>
-    <p><%= @schedule.start_date.strftime("%Y年%-m月%-d日(%a) %H:%M") %> ~ <%= @schedule.end_date.strftime("%Y年%-m月%-d日(%a) %H:%M") %></p>
-  </div>
-
-  <div class="mt-5">
-    <p>場所</p>
-    <p>これから設定</p>
-  </div>
-
-  <div class="mt-5">
-    <p>予算</p>
-    <p><%= @schedule.budged %>円</p>
-  </div>
-
-  <div class="mt-5">
-    <p>メモ</p>
-    <p><%= @schedule.memo.blank?  ? "未設定" : @schedule.memo %></p>
-  </div>
-
-  <div class="mt-10 text-right">
-    <%= link_to edit_schedule_path(@schedule), class: "btn rounded-btn" do %>
-      <i class="fa-solid fa-pen"></i>
+  <div class="flex items-center justify-between">
+    <%= link_to travel_book_schedules_path(@travel_book) do %>
+      <i class="fa-solid fa-chevron-left"></i>
     <% end %>
-    <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn rounded-btn" do %>
-      <i class="fa-solid fa-trash-can"></i>
-    <% end %>
+    <div>
+      <%= link_to edit_schedule_path(@schedule) do %>
+        <i class="fa-solid fa-pen"></i>
+      <% end %>
+      <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+        <i class="fa-solid fa-trash-can"></i>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mx-10 mb-5">
+    <div class="mt-5">
+      <h2 class="flex-1 text-lg font-bold"><%= @schedule.title %></h2>
+    </div>
+
+    <div class="mt-5 flex items-center">
+      <i class="fa-regular fa-clock"></i>
+      <p class="ml-2"><%= fmt_schedule_duration(@schedule) %></p>
+    </div>
+
+    <div class="mt-5 flex items-center">
+      <i class="fa-solid fa-location-dot"></i>
+      <p class="ml-2">場所</p>
+    </div>
+
+    <div class="mt-5 flex items-center">
+      <i class="fa-solid fa-wallet"></i>
+      <p class="ml-2"><%= @schedule.budged %>円</p>
+    </div>
+
+    <div class="mt-5 flex items-start">
+      <i class="fa-solid fa-file-pen mt-1"></i>
+      <p class="ml-2"><%= display_memo(@schedule.memo) %></p>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div role="alert" class="alert alert-error">
+    <ul>
+      <% object.errors.each do | error | %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -1,4 +1,5 @@
   <%= form_with model: @travel_book do |f| %>
+    <%= render "shared/error_messages", object: f.object %>
     <div class="space-y-12">
       <div class="border-b border-gray-900/10 pb-12">
 

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -1,97 +1,93 @@
-  <%= form_with model: @travel_book do |f| %>
-    <%= render "shared/error_messages", object: f.object %>
-    <div class="space-y-12">
-      <div class="border-b border-gray-900/10 pb-12">
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-4">
-            <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2">
-              <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
-                <%= f.text_field :title, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
-              </div>
+<%= form_with model: @travel_book do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
+  <div class="space-y-5">
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="sm:col-span-4">
+          <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2">
+            <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
+              <%= f.text_field :title, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
             </div>
           </div>
         </div>
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="col-span-full">
-            <%= f.label :description, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2">
-                <%= f.text_area :description, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2">
-              <%= f.date_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-
-          <div class="sm:col-span-3">
-            <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2">
-                <%= f.date_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= f.label :area_id, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= f.label :traveler_type_id, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= f.label :travel_book_image, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= f.file_field :travel_book_image, accept: "image/*", class: "" %>
-              <%= f.hidden_field :travel_book_image_cache %>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-2">
-          <% if @travel_book.persisted? %>
-            <% if @travel_book.travel_book_image %>
-              <%= link_to "destroy", delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-ghost rounded-btn" %>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="mt-6 space-y-1">
-            <p class="block text-sm/6 font-medium text-gray-900">tet</p>
-            <div class="flex items-center gap-x-3">
-              <%= f.radio_button :is_public, true, id: "is_public_true", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-              <%= f.label :is_public, "公開", for: "is_public_true" %>
-            </div>
-            <div class="flex items-center gap-x-3">
-              <%= f.radio_button :is_public, false, id: "is_public_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-              <%= f.label :is_public, "非公開", for: "is_public_false" %>
-            </div>
-          </div>
-        </div>
-
       </div>
-    </div>
-    <div class="mt-6 flex items-center justify-end gap-x-6">
-      <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
-    </div>
-  <% end %>
+
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="col-span-full">
+          <%= f.label :description, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2">
+              <%= f.text_area :description, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="sm:col-span-3">
+          <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2">
+            <%= f.date_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+          </div>
+        </div>
+
+        <div class="sm:col-span-3">
+          <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2">
+              <%= f.date_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="sm:col-span-3">
+          <%= f.label :area_id, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2 grid grid-cols-1">
+            <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="sm:col-span-3">
+          <%= f.label :traveler_type_id, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2 grid grid-cols-1">
+            <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="sm:col-span-3">
+          <%= f.label :travel_book_image, class: "block text-sm/6 font-medium text-gray-900" %>
+          <div class="mt-2 grid grid-cols-1">
+            <%= f.file_field :travel_book_image, accept: "image/*", class: "" %>
+            <%= f.hidden_field :travel_book_image_cache %>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-2">
+        <% if @travel_book.persisted? %>
+          <% if @travel_book.travel_book_image %>
+            <%= link_to "destroy", delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-ghost rounded-btn" %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div class="space-y-1">
+          <p class="block text-sm/6 font-medium text-gray-900">公開設定</p>
+          <div class="flex items-center gap-x-3">
+            <%= f.radio_button :is_public, true, id: "is_public_true", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.label :is_public, "公開", for: "is_public_true" %>
+          </div>
+          <div class="flex items-center gap-x-3">
+            <%= f.radio_button :is_public, false, id: "is_public_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
+            <%= f.label :is_public, "非公開", for: "is_public_false" %>
+          </div>
+        </div>
+      </div>
+  </div>
+  <div class="mt-6 flex items-center justify-end gap-x-6">
+    <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+  </div>
+<% end %>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,3 +1,10 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <div class="flex items-center justify-between">
+    <%= link_to travel_book_path(@travel_book) do %>
+      <i class="fa-solid fa-chevron-left"></i>
+    <% end %>
+    <h1 class="text-center flex-1 text-lg font-bold">しおりを編集</h1>
+  </div>
+
   <%= render "form", travel_book: @travel_book %>
 </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,3 +1,10 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
+  <div class="flex items-center justify-between">
+    <%= link_to travel_books_path do %>
+      <i class="fa-solid fa-chevron-left"></i>
+    <% end %>
+    <h1 class="text-center flex-1 text-lg font-bold">しおりを追加</h1>
+  </div>
+
   <%= render "form", travel_book: @travel_book %>
 </div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -4,44 +4,42 @@
   </figure>
 
   <div class="card-body">
-    <!-- タイトル -->
-    <h2 class="card-title"><%= @travel_book.title %></h2>
+    <div class="card-actions items-center justify-between">
+      <h2 class="card-title"><%= @travel_book.title %></h2>
+      <div>
+        <% if @travel_book.owned_by_user?(current_user) %>
+          <div class="justify-end">
+            <%= link_to edit_travel_book_path(@travel_book) do %>
+              <i class="fa-solid fa-pen"></i>
+            <% end %>
+            <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+              <i class="fa-solid fa-trash-can"></i>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
 
-    <!-- 説明 -->
     <p><%= travel_book_desctiption(@travel_book) %></p>
 
-    <!-- 期間 -->
     <div class="mb-6">
       <p>期間</p>
       <p class="text-gray-700"><%= travel_book_duration(@travel_book)%></p>
     </div>
 
-    <!-- エリア -->
     <div class="mb-6">
       <p>エリア</p>
       <p class="text-gray-700"><%= area_name(@travel_book) %></p>
     </div>
 
-    <!-- 旅行タイプ -->
     <div class="mb-6">
       <p>旅行タイプ</p>
       <p class="text-gray-700"><%= traveler_type_name(@travel_book) %></p>
     </div>
 
-    <!-- 公開設定 -->
     <div class="mb-6">
       <p>公開設定</p>
       <p class="text-gray-700"><%= travel_book_is_public(@travel_book) %></p>
     </div>
-
-    <% if @travel_book.owned_by_user?(current_user) %>
-      <div class="card-actions justify-end">
-        <!-- 編集ボタン -->
-        <%= link_to "edit", edit_travel_book_path(@travel_book), class: "btn btn-ghost rounded-btn" %>
-        <!-- 削除ボタン -->
-        <%= link_to "destroy", travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-ghost rounded-btn" %>
-      </div>
-    <% end %>
-
   </div>
 </div>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,11 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
+  <div role="alert" class="alert alert-error" data-turbo-cache="false">
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>


### PR DESCRIPTION
# 概要
しおりとスケジュールのバリデーションエラーメッセージの表示機能を実装しました。
また、その他レイアウト等軽微な修正を行いました。

## 実施内容
- [x]  エラーメッセージ用のパーシャルを作成
- [x] しおりとスケジュールの登録,編集画面にエラーメッセージのパーシャルを組み込み
- [x] devise用のエラーメッセージ用パーシャルの編集
- [x] しおりとスケジュールのバリデーション追加
  - end_dateにstart_dateより前の日付を入力した際にエラーを出力
- [x] スケジュール新規登録時の初期値を追加
  - スケジュールの開始日にしおりの開始日を入力
- [x] スケジュール一覧のスケジュールソート処理でスケジュールの開始時刻がnilの場合の処理追加
- [x] しおり・スケジュールの追加・編集画面でページタイトルと前の画面に戻るリンクを設置
- [x] しおり詳細画面で編集・削除リンクを編集
  - リンクをアイコンにし、配置変更
- [x] しおり詳細画面、スケジュール一覧画面のレイアウト変更,ヘルパーメソッドの修正
- [x] しおりとスケジュールのリレーション修正
  - しおりを削除した際に紐づくスケジュールを削除するように修正

## 未実施内容
- デザインの微調整

## 補足
バリデーションエラーに直接関係のない箇所の修正が多くなってしまいました。

deviseのバリデーションエラーのパーシャルはdeviseの機能実装時に自動生成したファイル(#39 )を流用します。（※要検討）

## 関連issue
#31 
#34 