### PR TITLE
Feature/スポット情報の追加,編集,削除

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -9,6 +9,7 @@ class SchedulesController < ApplicationController
   def new
     @travel_book = current_user.travel_books.find(params[:travel_book_id])
     @schedule = @travel_book.schedules.new
+    @spot = @schedule.build_spot
     # Scheduleのstart_dateの初期値を設定
     if @travel_book.start_date.present?
       @schedule.start_date = @travel_book.start_date.to_datetime
@@ -45,6 +46,7 @@ class SchedulesController < ApplicationController
   def destroy
     @schedule.destroy!
     @travel_book = @schedule.travel_book
+    @schedule.spot.destroy
     redirect_to travel_book_schedules_path(@travel_book), notice: "削除成功"
   end
 
@@ -59,6 +61,7 @@ class SchedulesController < ApplicationController
   end
 
   def schedule_param
-    params.require(:schedule).permit(:title, :budged, :memo, :start_date, :end_date)
+    params.require(:schedule).permit(:title, :budged, :memo, :start_date, :end_date,
+    spot_attributes: [:name, :telephone, :post_code, :address, :_destroy])
   end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,6 +1,6 @@
 class SchedulesController < ApplicationController
   before_action :set_travel_book, only: %i[ index new create ]
-  before_action :set_schedule, only: %i[ show edit update destroy delete_spot ]
+  before_action :set_schedule, only: %i[ show edit update destroy ]
 
   def index
     @schedules = @travel_book.sorted_schedules
@@ -9,11 +9,9 @@ class SchedulesController < ApplicationController
   def new
     @travel_book = current_user.travel_books.find(params[:travel_book_id])
     @schedule = @travel_book.schedules.new
-    @spot = @schedule.build_spot
+    @spot = @schedule.build_spot unless @schedule.spot
     # Scheduleのstart_dateの初期値を設定
-    if @travel_book.start_date.present?
-      @schedule.start_date = @travel_book.start_date.to_datetime
-    end
+    @schedule.start_date = @travel_book.start_date.to_datetime if @travel_book.start_date.present?
   end
 
   def create
@@ -45,23 +43,9 @@ class SchedulesController < ApplicationController
   end
 
   def destroy
-    @schedule.destroy!
     @travel_book = @schedule.travel_book
-    @schedule.spot.destroy
+    @schedule.destroy!
     redirect_to travel_book_schedules_path(@travel_book), notice: "削除成功"
-  end
-
-  def delete_spot
-    if @schedule.spot
-      if @schedule.spot.destroy
-        flash[:notice] = "spotを削除しました"
-      else
-        flash[:alert] = "spotを削除できませんでした"
-      end
-    else
-      flash[:alert] = "spotが見つかりません"
-    end
-    redirect_to edit_schedule_path(@schedule)
   end
 
   private
@@ -76,6 +60,6 @@ class SchedulesController < ApplicationController
 
   def schedule_param
     params.require(:schedule).permit(:title, :budged, :memo, :start_date, :end_date,
-    spot_attributes: [ :name, :telephone, :post_code, :address, :_destroy ])
+    spot_attributes: [ :id, :name, :telephone, :post_code, :address, :_destroy ])
   end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -76,6 +76,6 @@ class SchedulesController < ApplicationController
 
   def schedule_param
     params.require(:schedule).permit(:title, :budged, :memo, :start_date, :end_date,
-    spot_attributes: [:name, :telephone, :post_code, :address, :_destroy])
+    spot_attributes: [ :name, :telephone, :post_code, :address, :_destroy ])
   end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,6 +1,6 @@
 class SchedulesController < ApplicationController
   before_action :set_travel_book, only: %i[ index new create ]
-  before_action :set_schedule, only: %i[ show edit update destroy ]
+  before_action :set_schedule, only: %i[ show edit update destroy delete_spot ]
 
   def index
     @schedules = @travel_book.sorted_schedules
@@ -32,6 +32,7 @@ class SchedulesController < ApplicationController
 
   def edit
     @travel_book = @schedule.travel_book
+    @spot = @schedule.build_spot unless @schedule.spot
   end
 
   def update
@@ -48,6 +49,19 @@ class SchedulesController < ApplicationController
     @travel_book = @schedule.travel_book
     @schedule.spot.destroy
     redirect_to travel_book_schedules_path(@travel_book), notice: "削除成功"
+  end
+
+  def delete_spot
+    if @schedule.spot
+      if @schedule.spot.destroy
+        flash[:notice] = "spotを削除しました"
+      else
+        flash[:alert] = "spotを削除できませんでした"
+      end
+    else
+      flash[:alert] = "spotが見つかりません"
+    end
+    redirect_to edit_schedule_path(@schedule)
   end
 
   private

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -33,7 +33,11 @@ module SchedulesHelper
     end
   end
 
-  def display_memo(date)
-    date == "" ? "メモはありません" : date
+  def desplay_value(data)
+    data.presence || ""
+  end
+
+  def display_memo(data)
+    data == "" ? "メモはありません" : date
   end
 end

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -38,6 +38,6 @@ module SchedulesHelper
   end
 
   def display_memo(data)
-    data == "" ? "メモはありません" : date
+    data == "" ? "メモはありません" : data
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,6 +2,8 @@ class Schedule < ApplicationRecord
   belongs_to :travel_book
   has_one :spot, dependent: :destroy
 
+  accepts_nested_attributes_for :spot, allow_destroy: true, reject_if: :all_blank, limit: 1
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :memo, length: { maximum: 65_535 }
   validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,6 @@
 class Schedule < ApplicationRecord
   belongs_to :travel_book
+  has_one :spot, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :memo, length: { maximum: 65_535 }

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,7 +2,7 @@ class Schedule < ApplicationRecord
   belongs_to :travel_book
   has_one :spot, dependent: :destroy
 
-  accepts_nested_attributes_for :spot, allow_destroy: true, reject_if: :all_blank, limit: 1
+  accepts_nested_attributes_for :spot, allow_destroy: true, reject_if: :all_blank
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :memo, length: { maximum: 65_535 }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,0 +1,3 @@
+class Spot < ApplicationRecord
+  belongs_to :schedule, optional: true
+end

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -30,6 +30,12 @@
 
       <%# 場所情報の登録フォーム %>
       <%= f.fields_for :spot do |spot_form| %>
+      <div class="text-right">
+        <% if @schedule.persisted? && @schedule.spot.present? %>
+          <%= link_to "削除", delete_spot_schedule_path(@schedule),
+                      data:{ turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+        <% end %>
+      </div>
         <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
           <div class="sm:col-span-3">
             <%= spot_form.label :name, class: "block text-sm/6 font-medium text-gray-900" %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -28,9 +28,44 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        場所
-      </div>
+      <%# 場所情報の登録フォーム %>
+      <%= f.fields_for :spot do |spot_form| %>
+        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= spot_form.label :name, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+              <%= spot_form.text_field :name, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= spot_form.label :telephone, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+              <%= spot_form.text_field :telephone, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= spot_form.label :post_code, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+              <%= spot_form.text_field :post_code, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+          <div class="sm:col-span-3">
+            <%= spot_form.label :address, class: "block text-sm/6 font-medium text-gray-900" %>
+            <div class="mt-2 grid grid-cols-1">
+              <%= spot_form.text_field :address, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
 
       <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
         <div class="sm:col-span-3">

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -10,20 +10,14 @@
     <%= f.datetime_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
     <%# 場所情報の登録フォーム %>
-    <div class="flex justify-between">
-      <div>
-        <%= f.label :spot_id, class: "" %>
-      </div>
-      <div>
-          <% if @schedule.persisted? && @schedule.spot.present? %>
-            <%= link_to "削除", delete_spot_schedule_path(@schedule),
-                        data:{ turbo_method: :delete, turbo_confirm: "場所情報を削除しますか?" } %>
-          <% end %>
-      </div>
-    </div>
+    <%= f.label :spot_id, class: "" %>
     <%= f.fields_for :spot do |spot_form| %>
     <div class="ml-2">
-      <%= spot_form.label :name, class: "" %>
+    <% if @schedule.spot&.persisted? %>
+      <%= spot_form.label :_destroy, "削除" %>
+      <%= spot_form.check_box :_destroy %>
+    <% end %>
+      <%= spot_form.label :name, class: "block" %>
       <%= spot_form.text_field :name, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
       <%= spot_form.label :telephone, class: "" %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,101 +1,49 @@
 <%= form_with model: schedule, url: schedule.new_record? ? travel_book_schedules_path(travel_book) : schedule_path(schedule) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
-  <div class="space-y-5">
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-4">
-          <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-            <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
-              <%= f.text_field :title, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
+    <%= f.label :title, class: "" %>
+    <%= f.text_field :title, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+
+    <%= f.label :start_date, class: "" %>
+    <%= f.datetime_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+
+    <%= f.label :end_date, class: "" %>
+    <%= f.datetime_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+
+    <%# 場所情報の登録フォーム %>
+    <div class="flex justify-between">
+      <div>
+        <%= f.label :spot_id, class: "" %>
       </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-3">
-          <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.datetime_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
-
-        <div class="sm:col-span-3">
-          <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-              <%= f.datetime_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
+      <div>
+          <% if @schedule.persisted? && @schedule.spot.present? %>
+            <%= link_to "削除", delete_spot_schedule_path(@schedule),
+                        data:{ turbo_method: :delete, turbo_confirm: "場所情報を削除しますか?" } %>
+          <% end %>
       </div>
+    </div>
+    <%= f.fields_for :spot do |spot_form| %>
+    <div class="ml-2">
+      <%= spot_form.label :name, class: "" %>
+      <%= spot_form.text_field :name, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-      <%# 場所情報の登録フォーム %>
-      <%= f.fields_for :spot do |spot_form| %>
-      <div class="text-right">
-        <% if @schedule.persisted? && @schedule.spot.present? %>
-          <%= link_to "削除", delete_spot_schedule_path(@schedule),
-                      data:{ turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
-        <% end %>
-      </div>
-        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= spot_form.label :name, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= spot_form.text_field :name, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
+      <%= spot_form.label :telephone, class: "" %>
+      <%= spot_form.text_field :telephone, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= spot_form.label :telephone, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= spot_form.text_field :telephone, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
+      <%= spot_form.label :post_code, class: "" %>
+      <%= spot_form.text_field :post_code, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= spot_form.label :post_code, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= spot_form.text_field :post_code, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
+      <%= spot_form.label :address, class: "" %>
+      <%= spot_form.text_field :address, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+    </div>
+    <% end %>
 
-        <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-          <div class="sm:col-span-3">
-            <%= spot_form.label :address, class: "block text-sm/6 font-medium text-gray-900" %>
-            <div class="mt-2 grid grid-cols-1">
-              <%= spot_form.text_field :address, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
-      <% end %>
+    <%= f.label :budged, class: "" %>
+    <%= f.number_field :budged, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-3">
-          <%= f.label :budged, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2 grid grid-cols-1">
-            <%= f.number_field :budged, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
-      </div>
+    <%= f.label :memo, class: "" %>
+    <%= f.text_area :memo, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="col-span-full">
-          <%= f.label :memo, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-              <%= f.text_area :memo, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        アイコン
-      </div>
-  </div>
-  <div class="mt-6 flex items-center justify-end gap-x-6">
+  <div class="flex justify-end mt-5">
     <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
   </div>
 <% end %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -26,11 +26,15 @@
 
     <div class="mt-5 flex items-center">
       <i class="fa-solid fa-location-dot"></i>
-      <div>
-        <p class="ml-2"><%= @schedule.spot.name %></p>
-        <p class="ml-2"><%= desplay_value(@schedule.spot.telephone) %></p>
-        <p class="ml-2"><%= desplay_value(@schedule.spot.post_code) %></p>
-        <p class="ml-2"><%= desplay_value(@schedule.spot.address) %></p>
+      <div class="ml-2">
+        <% if @schedule.spot.present? %>
+          <p><%= desplay_value(@schedule.spot.name) %></p>
+          <p><%= desplay_value(@schedule.spot.telephone) %></p>
+          <p><%= desplay_value(@schedule.spot.post_code) %></p>
+          <p><%= desplay_value(@schedule.spot.address) %></p>
+        <% else %>
+          <p>場所は登録されていません</p>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -26,7 +26,12 @@
 
     <div class="mt-5 flex items-center">
       <i class="fa-solid fa-location-dot"></i>
-      <p class="ml-2">場所</p>
+      <div>
+        <p class="ml-2"><%= @schedule.spot.name %></p>
+        <p class="ml-2"><%= desplay_value(@schedule.spot.telephone) %></p>
+        <p class="ml-2"><%= desplay_value(@schedule.spot.post_code) %></p>
+        <p class="ml-2"><%= desplay_value(@schedule.spot.address) %></p>
+      </div>
     </div>
 
     <div class="mt-5 flex items-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,7 @@ Rails.application.routes.draw do
   get "home/index"
   resources :travel_books, only: %i[ index new create show edit update destroy ] do
     delete "delete_image", on: :member
-    resources :schedules, shallow: true do
-      delete "delete_spot", on: :member
-    end
+    resources :schedules, shallow: true
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
   get "home/index"
   resources :travel_books, only: %i[ index new create show edit update destroy ] do
     delete "delete_image", on: :member
-    resources :schedules, shallow: true
+    resources :schedules, shallow: true do
+      delete "delete_spot", on: :member
+    end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250126014044_create_spots.rb
+++ b/db/migrate/20250126014044_create_spots.rb
@@ -1,0 +1,12 @@
+class CreateSpots < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spots do |t|
+      t.references :schedule, null: true, foreign_key: true
+      t.string :name, null: false
+      t.string :telephone
+      t.string :post_code
+      t.string :address
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_22_022836) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_26_014044) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_022836) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["travel_book_id"], name: "index_schedules_on_travel_book_id"
+  end
+
+  create_table "spots", force: :cascade do |t|
+    t.bigint "schedule_id"
+    t.string "name", null: false
+    t.string "telephone"
+    t.string "post_code"
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["schedule_id"], name: "index_spots_on_schedule_id"
   end
 
   create_table "travel_books", force: :cascade do |t|
@@ -80,6 +91,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_022836) do
   end
 
   add_foreign_key "schedules", "travel_books"
+  add_foreign_key "spots", "schedules"
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "travel_books", "users", column: "creator_id"


### PR DESCRIPTION
# 概要
スケジュールに紐づく場所情報の追加、表示、編集、削除機能を実装しました。

## 実施内容
- [x] spotモデルとspots テーブルの作成
- [x] spotモデルとscheduleモデルのリレーション設定
- [x] コントローラーにnew,destroyアクション,ストロングパラメーターを追加
- [x] スケジュール詳細画面に場所情報を表示(schedules/show)できるように追加
- [x] スケジュールに紐づく場所情報が登録されている場合スケジュール編集画面に削除のチェックボックスを配置
- [x] タイポの修正、不要なCSSの削除

## 未実施内容
- spotモデルのバリデーション設定(api検討した後に実装予定)

## 補足
スケジュールと場所は一対一のリレーションです。
スケジュールの新規登録・編集フォームで場所情報の追加・編集・削除ができるようにしています。

## つまづいた点など
- 場所情報を削除する際に削除フラグの仕組みを知らず、最初は削除のためのリンクを作ってしまった。
  `spot_form.check_box :_destroy`で削除できることを学んだ

## 関連issue
#47 