### PR TITLE
Feature/チェックリストアイテムの表示機能実装

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -22,6 +22,7 @@ class CheckListsController < ApplicationController
 
   def show
     @travel_book = @check_list.travel_book
+    @list_items = @check_list.list_items
   end
 
   def edit

--- a/app/decorators/list_item_decorator.rb
+++ b/app/decorators/list_item_decorator.rb
@@ -1,0 +1,12 @@
+class ListItemDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -1,5 +1,6 @@
 class CheckList < ApplicationRecord
   belongs_to :travel_book
+  has_many :list_items, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,0 +1,3 @@
+class ListItem < ApplicationRecord
+  belongs_to :check_list
+end

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -1,5 +1,4 @@
 <div class="bg-white rounded-lg shadow-md p-6 m-6">
-
   <div class="flex items-center justify-between">
     <%= link_to travel_book_check_lists_path(@travel_book) do %>
       <i class="fa-solid fa-chevron-left"></i>
@@ -19,4 +18,10 @@
       <h2 class="flex-1 text-lg font-bold"><%= @check_list.title %></h2>
     </div>
   </div>
+
+  <% if @list_items.present? %>
+    <%= render @list_items %>
+  <% else %>
+    チェックリストは登録されていません
+  <% end %>
 </div>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -1,0 +1,4 @@
+<div class="flex" >
+  <div><%= list_item.title %></div>
+  <div><%= list_item.compleated %></div>
+</div>

--- a/db/migrate/20250127092638_create_list_items.rb
+++ b/db/migrate/20250127092638_create_list_items.rb
@@ -1,0 +1,10 @@
+class CreateListItems < ActiveRecord::Migration[7.2]
+  def change
+    create_table :list_items do |t|
+      t.references :check_list, null: false, foreign_key: true
+      t.string :title, null: false
+      t.boolean :completed, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_27_041147) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_27_092638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_27_041147) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["travel_book_id"], name: "index_check_lists_on_travel_book_id"
+  end
+
+  create_table "list_items", force: :cascade do |t|
+    t.bigint "check_list_id", null: false
+    t.string "title", null: false
+    t.boolean "completed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["check_list_id"], name: "index_list_items_on_check_list_id"
   end
 
   create_table "schedules", force: :cascade do |t|
@@ -99,6 +108,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_27_041147) do
   end
 
   add_foreign_key "check_lists", "travel_books"
+  add_foreign_key "list_items", "check_lists"
   add_foreign_key "schedules", "travel_books"
   add_foreign_key "spots", "schedules"
   add_foreign_key "travel_books", "areas"


### PR DESCRIPTION
# 概要
しおりに紐づくチェックリストのリストを表示する機能を実装します。

## 実施内容
- [x] ListItemモデルとテーブルを生成
- [x] ListItemとCheckListのリレーションを設定
- [x] チェックリストの詳細画面(check_lists/show)にリストのパーシャルを埋め込み
- [x] リストのパーシャル作成

## 未実施内容
- デザイン調整

## 補足
ListItemDecoratorは現在使用していませんが、先に保存しておきます。

## 関連issue
#42 