### PR TITLE
Feature/リストアイテム登録機能の実装

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -23,6 +23,7 @@ class CheckListsController < ApplicationController
   def show
     @travel_book = @check_list.travel_book
     @list_items = @check_list.list_items
+    @list_item = @check_list.list_items.build
   end
 
   def edit

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,0 +1,19 @@
+class ListItemsController < ApplicationController
+
+  def create
+    @check_list = CheckList.find(params[:check_list_id])
+    @list_item = @check_list.list_items.build(list_item_param)
+
+    if @list_item.save
+      redirect_to check_list_path(@check_list)
+    else
+      render "check_lists/show"
+    end
+  end
+
+  private
+
+  def list_item_param
+    params.require(:list_item).permit(:title, :completed)
+  end
+end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,5 +1,4 @@
 class ListItemsController < ApplicationController
-
   def create
     @check_list = CheckList.find(params[:check_list_id])
     @list_item = @check_list.list_items.build(list_item_param)

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -24,4 +24,7 @@
   <% else %>
     チェックリストは登録されていません
   <% end %>
+
+  <button><i class="fa-solid fa-circle-plus"></i></button>
+  <%= render "list_items/form", check_list: @check_list, list_item: @list_item %>
 </div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -1,0 +1,9 @@
+  <%= form_with model: list_item, url: check_list_list_items_path(@check_list) do |f| %>
+    <div>
+      <%= f.label :title %>
+      <%= f.text_field :title %>
+    </div>
+    <div>
+      <%= f.submit 'Add Item' %>
+    </div>
+  <% end %>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -1,4 +1,4 @@
-<div class="flex" >
+<div class="flex gap-2" >
+  <div><%= check_box_tag "list_item[completed]", "true", list_item.completed %></div>
   <div><%= list_item.title %></div>
-  <div><%= list_item.compleated %></div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,11 @@ Rails.application.routes.draw do
   resources :travel_books do
     delete "delete_image", on: :member
     resources :schedules, shallow: true
-    resources :check_lists, shallow: true
+    resources :check_lists, shallow: true do
+      resources :list_items, only: %i[ create ]
+    end
   end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# 概要
チェックリストに紐づくリストアイテム登録機能を実装しました。

## 実施内容
- [x] list_items用のルーティングを追加
- [x] リストアイテム登録用のビュー(パーシャル)をチェックリスト詳細確認画面内に組み込み
- [x] ListItemsコントローラーのcreateアクションを追加

## 未実施内容
- フォームの動的表示(※1)
- デザイン調整

## 補足
※1:リストアイテムのフォームはチェックリスト詳細画面に表示されている追加ボタン押下時に表示するようにします

## 関連issue
#43 