### PR TITLE
Feature/認証関連のCSS設定

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.container {
+  width: 80%;
+  margin: 20px auto;
+  padding-bottom: 80px;
+}
+
+.form-container {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.travel-book-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+h2 {
+  font-size: 1.5rem;
+  text-align: center;
+  font-weight: bold;
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,8 +6,8 @@
   </div>
   <div class="flex flex-1 justify-end px-2">
     <div class="flex items-stretch">
-      <%= link_to '#', class: "btn btn-ghost rounded-btn" do %>
-        Button
+      <% unless user_signed_in? %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost rounded-btn" %>
       <% end %>
       <div class="dropdown dropdown-end">
         <div class="flex-none">

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -9,8 +9,8 @@
       <p><%= traveler_type_name(travel_book) %></p>
       <div class="flex items-center justify-center gap-2">
         <div class="avatar">
-          <div class="w-6 md:w-7 rounded-full">
-            <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
+          <div class="w-8 rounded-full shadow-lg border border-gray-200">
+            <%= image_tag(travel_book.creator.icon_image? ? travel_book.creator.icon_image_url : "default_icon.png") %>
           </div>
         </div>
         <p><%= travel_book.creator.name %></p>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Forgot your password?</h2>
+<div class="container">
+  <div class="form-container rounded-lg shadow-md bg-white p-8">
+    <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :email, class: "label" %>
+          <i class="fa-solid fa-envelope"></i>
+        </div>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "tabiclip@example.com", class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Send me reset password instructions", class: "btn btn-primary w-full mt-6 mx-auto" %>
+      </div>
+    <% end %>
+
+    <%= render "users/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,34 +1,47 @@
-<h2>Sign up</h2>
+<div class="container">
+  <div class="form-container rounded-lg shadow-md bg-white p-8">
+    <h2>アカウント登録</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true %>
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :name, class: "label" %>
+          <i class="fa-solid fa-user"></i>
+        </div>
+        <%= f.text_field :name, placeholder: "アカウント名", class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :email, class: "label" %>
+          <i class="fa-solid fa-envelope"></i>
+        </div>
+        <%= f.email_field :email, autocomplete: "email", placeholder: "tabiclip@example.com", class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :password, class: "label" %>
+          <i class="fa-solid fa-key"></i>
+        </div>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "半角英数6文字以上", class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :password_confirmation, class: "label" %>
+          <i class="fa-solid fa-key"></i>
+        </div>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "半角英数6文字以上", class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Sign up", class: "btn btn-primary w-full mt-6 mx-auto" %>
+      </div>
+    <% end %>
+
+    <%= render "users/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,37 @@
-<h2>Log in</h2>
+<div class="container">
+  <div class="form-container rounded-lg shadow-md bg-white p-8">
+    <h2>ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :email, class: "label" %>
+          <i class="fa-solid fa-envelope"></i>
+        </div>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "tabiclip@example.com", class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :password, class: "label" %>
+          <i class="fa-solid fa-key"></i>
+        </div>
+        <%= f.password_field :password, autocomplete: "current-password", placeholder: "半角英数6文字以上", class: "input input-bordered w-full" %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="flex items-center mt-3">
+          <%= f.check_box :remember_me, class: "checkbox checkbox-primary mr-2" %>
+          <%= f.label :remember_me, class: "cursor-pointer" %>
+        </div>
+      <% end %>
+
+      <div class="actions">
+        <%= f.submit "Log in", class: "btn btn-primary w-full mt-6 mx-auto" %>
+      </div>
+    <% end %>
+
+    <%= render "users/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,13 +1,17 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <div class="text-center my-3">
+    <%= link_to "ログインページはこちら", new_session_path(resource_name), class: "underline" %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "btn btn-ghost border-primary w-full my-3 mx-auto" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <div class="text-center my-3">
+    <%= link_to "Forgot your password?", new_password_path(resource_name), class: "underline" %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>


### PR DESCRIPTION
# 概要
deviseで導入したアカウント登録、ログイン画面のビューにCSSクラスを設定しUIを整えました。

## 実施内容
- [x] 共通で使用するCSSをapplication.tailwind.cssに定義
- [x] ログイン・アカウント登録画面のCSSクラスを設定
- [x] devise用リンクにCSSクラスを設定
- [x] 未ログイン時のヘッダーにログイン画面へのリンクを設置
- [x] しおり一覧のしおりのアイコンを設置

## 未実施内容
- パスワード再発行画面のCSSが当たらなかったため、優先度を下げて今後対応予定

## 補足
しおり一覧のしおりのアイコンは、簡単に修正できる箇所だったため修正しました。

## 関連issue
#103 