### PR TITLE
Update/スケジュール一覧画面でスケジュールを日毎に表示する機能を実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -26,3 +26,9 @@ h2 {
   text-align: center;
   font-weight: bold;
 }
+
+h3 {
+  font-size: 1.25rem;
+  text-align: center;
+  font-weight: bold;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,6 @@ module ApplicationHelper
   # 日付をフォーマットする
   def fmt_date(date)
     return "未定" if date.nil?
-    date.strftime("%Y年%-m月%-d日(%a)")
+    date.strftime("%Y/%-m/%-d(%a)")
   end
 end

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -5,12 +5,12 @@ module SchedulesHelper
 
   def fmt_schedule_date(date)
     return "" if date.nil?
-    date.strftime("%Y年%-m月%-d日(%a) %-H:%M")
+    date.strftime("%Y/%-m/%-d/(%a) %-H:%M")
   end
 
   def fmt_simple_date(date)
     return date if date.is_a?(String)  # 文字列ならそのまま返す
-    date.strftime("%-m月%-d日(%a)")
+    date.strftime("%-m/%-d(%a)")
   end
 
   def fmt_datetime(date)

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -18,6 +18,11 @@ module SchedulesHelper
     date.strftime("%-H:%M")
   end
 
+  def fmt_date_with_datetime(date)
+    return "" if date.nil?
+    date.strftime("%-m/%-d %-H:%M")
+  end
+
   def fmt_schedule_duration(schedule)
     if schedule.start_date && schedule.end_date
       "#{fmt_schedule_date(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
@@ -33,6 +38,16 @@ module SchedulesHelper
       "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
     elsif schedule.start_date || schedule.end_date
       "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}".strip
+    else
+      "未定"
+    end
+  end
+
+  def fmt_all_day_schedule_datetime_duration(schedule)
+    if schedule.start_date && schedule.end_date
+      "#{fmt_date_with_datetime(schedule.start_date)} - #{fmt_date_with_datetime(schedule.end_date)}"
+    elsif schedule.start_date || schedule.end_date
+      "#{fmt_date_with_datetime(schedule.start_date)} - #{fmt_date_with_datetime(schedule.end_date)}".strip
     else
       "未定"
     end

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -8,6 +8,11 @@ module SchedulesHelper
     date.strftime("%Y年%-m月%-d日(%a) %-H:%M")
   end
 
+  def fmt_simple_date(date)
+    return date if date.is_a?(String)  # 文字列ならそのまま返す
+    date.strftime("%-m月%-d日(%a)")
+  end
+
   def fmt_datetime(date)
     return "" if date.nil?
     date.strftime("%-H:%M")
@@ -39,5 +44,9 @@ module SchedulesHelper
 
   def display_memo(data)
     data == "" ? "メモはありません" : data
+  end
+
+  def total_budget(schedules)
+    schedules.sum { |schedule| schedule.budged.to_i }
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import LinkController from "./link_controller";
+application.register("link", LinkController);

--- a/app/javascript/controllers/link_controller.js
+++ b/app/javascript/controllers/link_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+
+  go(event) {
+    const url = event.currentTarget.dataset.url;
+    if (url) {
+      window.location.href = url;
+    }
+  }
+}

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -10,7 +10,7 @@ class Schedule < ApplicationRecord
   validate :end_date_after_start_date
 
   def self.group_by_date(schedules)
-    schedules.group_by { |schedule| (schedule.start_date&.to_date || schedule.end_date&.to_date ) || "日付未定" }
+    schedules.group_by { |schedule| (schedule.start_date&.to_date || schedule.end_date&.to_date) || "日付未定" }
   end
 
   private

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -10,7 +10,7 @@ class Schedule < ApplicationRecord
   validate :end_date_after_start_date
 
   def self.group_by_date(schedules)
-    schedules.group_by { |schedule| schedule.start_date&.to_date || "日付未定" }
+    schedules.group_by { |schedule| (schedule.start_date&.to_date || schedule.end_date&.to_date ) || "日付未定" }
   end
 
   private

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -9,6 +9,10 @@ class Schedule < ApplicationRecord
   validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :end_date_after_start_date
 
+  def self.group_by_date(schedules)
+    schedules.group_by { |schedule| schedule.start_date&.to_date || "日付未定" }
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,43 +1,65 @@
 <%= form_with model: schedule, url: schedule.new_record? ? travel_book_schedules_path(travel_book) : schedule_path(schedule) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
-    <%= f.label :title, class: "" %>
-    <%= f.text_field :title, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-    <%= f.label :start_date, class: "" %>
-    <%= f.datetime_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+      <div class="field mt-3">
+        <%= f.label :title, class: "w-full" do %>
+          <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
+        <% end %>
+        <%= f.text_field :title, autofocus: true, placeholder: "待ち合わせ", class: "input input-bordered w-full" %>
+      </div>
 
-    <%= f.label :end_date, class: "" %>
-    <%= f.datetime_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+    <div class="mt-3 flex flex-col sm:flex-row gap-2">
+      <div class="w-full">
+        <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
+        <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
+      </div>
+      <div class="w-full">
+        <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
+        <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
+      </div>
+    </div>
 
     <%# 場所情報の登録フォーム %>
-    <%= f.label :spot_id, class: "" %>
+    <%= f.label :spot_id, class: "label" %>
     <%= f.fields_for :spot do |spot_form| %>
-    <div class="ml-2">
-    <% if @schedule.spot&.persisted? %>
-      <%= spot_form.label :_destroy, "削除" %>
-      <%= spot_form.check_box :_destroy %>
+      <div class="ml-3">
+        <% if @schedule.spot&.persisted? %>
+          <%= spot_form.label :_destroy, "削除" %>
+          <%= spot_form.check_box :_destroy, class: "checkbox checkbox-primary mr-2" %>
+        <% end %>
+        <div class="field">
+          <%= spot_form.label :name, Schedule.human_attribute_name(:name), class: "label" %>
+          <%= spot_form.text_field :name, class: "input input-bordered w-full" %>
+        </div>
+        <div class="field">
+          <%= spot_form.label :telephone, Schedule.human_attribute_name(:telephone), class: "label" %>
+          <%= spot_form.text_field :telephone, class: "input input-bordered w-full" %>
+        </div>
+        <div class="field">
+          <%= spot_form.label :post_code, Schedule.human_attribute_name(:post_code), class: "label" %>
+          <%= spot_form.text_field :post_code, class: "input input-bordered w-full" %>
+        </div>
+        <div class="field">
+          <%= spot_form.label :address, Schedule.human_attribute_name(:address), class: "label" %>
+          <%= spot_form.text_field :address, class: "input input-bordered w-full" %>
+        </div>
+      </div>
     <% end %>
-      <%= spot_form.label :name, class: "block" %>
-      <%= spot_form.text_field :name, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
 
-      <%= spot_form.label :telephone, class: "" %>
-      <%= spot_form.text_field :telephone, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
-
-      <%= spot_form.label :post_code, class: "" %>
-      <%= spot_form.text_field :post_code, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
-
-      <%= spot_form.label :address, class: "" %>
-      <%= spot_form.text_field :address, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+  <div class="field mt-3">
+    <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>
+    <div class="flex items-center">
+      <%= f.number_field :budged, class: "input input-bordered w-full" %>
+      <span class="ml-2">円</span>
     </div>
-    <% end %>
+  </div>
 
-    <%= f.label :budged, class: "" %>
-    <%= f.number_field :budged, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
-
-    <%= f.label :memo, class: "" %>
-    <%= f.text_area :memo, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600" %>
+  <div class="field mt-3">
+    <%= f.label :memo, Schedule.human_attribute_name(:memo), class: "label" %>
+    <%= f.text_area :memo, placeholder: "移動手段や観光地の情報などをメモ", rows: "3", class: "textarea textarea-bordered w-full" %>
+  </div>
 
   <div class="flex justify-end mt-5">
-    <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
   </div>
 <% end %>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -6,7 +6,7 @@
           <%= fmt_schedule_datetime_duration(schedule) %>
         </td>
         <td class="w-2/3 p-4">
-        <i class="fa-solid fa-train-subway"></i>
+        <i class="fa-solid fa-circle"></i>
         <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
         </td>
       </tr>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,11 +1,15 @@
-<table class="min-w-full">
-  <tbody>
-    <tr>
-      <td class="w-1/3 p-4"><%= fmt_schedule_datetime_duration(schedule) %></td>
-      <td class="w-2/3 p-4">
+<div class="overflow-x-auto">
+  <table class="table">
+    <tbody>
+      <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
+        <td class="w-1/3 p-4">
+          <%= fmt_schedule_datetime_duration(schedule) %>
+        </td>
+        <td class="w-2/3 p-4">
         <i class="fa-solid fa-train-subway"></i>
         <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -3,7 +3,11 @@
     <tbody>
       <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
         <td class="w-1/3 p-4">
-          <%= fmt_schedule_datetime_duration(schedule) %>
+          <% if defined?(all_day) && all_day %>
+            <%= fmt_all_day_schedule_datetime_duration(schedule) %>
+          <% else %>
+            <%= fmt_schedule_datetime_duration(schedule) %>
+          <% end %>
         </td>
         <td class="w-2/3 p-4">
         <i class="fa-solid fa-circle"></i>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -12,7 +12,7 @@
         <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="ALL" checked="checked" />
         <div role="tabpanel" class="tab-content p-10">
           <% @schedules.each do |schedule| %>
-            <%= render partial: "schedule", locals: { schedule: schedule } %>
+            <%= render partial: "schedule", locals: { schedule: schedule, all_day: true } %>
           <% end %>
           <p class="text-right my-5">合計金額：<%= total_budget(@schedules) %>円</p>
         </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,26 +1,40 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
 
-  <div class="flex flex-col items-center">
-    <h1 class="text-center text-lg font-bold"><%= @travel_book.title %></h1>
-    <p><%= travel_book_duration(@travel_book)%></p>
-  </div>
+    <div class="flex flex-col items-center mb-5">
+      <h3><%= @travel_book.title %></h3>
+      <p><%= travel_book_duration(@travel_book)%></p>
+    </div>
 
-  <% if @schedules.present? %>
-      <% @schedules.group_by { |schedule| schedule.start_date.nil? ? "日付未設定" : schedule.start_date.to_date }.each do |date, schedules| %>
-        <p class="mt-5 mb-2"><%= date == "日付未設定" ? "日付未設定" : fmt_date(date) %></p>
-        <div class="divide-y divide-blue-400">
-        <% schedules.each do |schedule| %>
-          <%= render partial: "schedule", locals: { schedule: schedule } %>
-        <% end %>
+    <% if @schedules.present? %>
+      <div role="tablist" class="tabs tabs-bordered">
+        <!-- 全日程タブを追加 -->
+        <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="ALL" checked="checked" />
+        <div role="tabpanel" class="tab-content p-10">
+          <% @schedules.each do |schedule| %>
+            <%= render partial: "schedule", locals: { schedule: schedule } %>
+          <% end %>
+          <p class="text-right my-5">合計金額：<%= total_budget(@schedules) %>円</p>
         </div>
-      <% end %>
-    <p class="text-right">合計金額：<%= sum_budgets(@schedules) %>円</p>
 
-  <% else %>
-    <p>スケジュールを登録しましょう</p>
-  <% end %>
+        <!-- 各日付ごとのタブ -->
+        <% Schedule.group_by_date(@schedules).each do |date, schedules| %>
+          <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_simple_date(date) %>" />
+          <div role="tabpanel" class="tab-content p-10">
+            <% schedules.each do |schedule| %>
+              <%= render partial: "schedule", locals: { schedule: schedule } %>
+            <% end %>
+            <p class="text-right my-5">合計金額：<%= total_budget(schedules) %>円</p>
+          </div>
+        <% end %>
+      </div>
 
-  <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-    追加
-  <% end %>
+    <% else %>
+      <p class="text-center my-10">スケジュールを登録しましょう</p>
+    <% end %>
+
+    <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
+      スケジュールを追加
+    <% end %>
+  </div>
 </div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,10 +1,13 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to travel_book_schedules_path(@travel_book) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <h1 class="text-center flex-1 text-lg font-bold">スケジュールを追加</h1>
-  </div>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
 
-  <%= render "form", schedule: @schedule, travel_book: @travel_book %>
+    <div class="relative flex items-center justify-center">
+      <%= link_to travel_book_schedules_path(@travel_book), class: "absolute left-0" do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3>スケジュールを追加</h3>
+    </div>
+
+    <%= render "form", schedule: @schedule, travel_book: @travel_book %>
+  </div>
 </div>


### PR DESCRIPTION
# 概要
スケジュール一覧画面でスケジュールを全日程、日毎に表示する機能を実装

## 実施内容
- [x] スケジュール一覧画面で日毎にスケジュール表示するためにdaisyUIのタブを組み込み
- [x] scheduleモデルでスケジュールを日毎にグループ化するためのクラスメソッドを定義
- [x] しおりやスケジュール画面で使用するビューロジックをヘルパーメソッドとして追加、整理
- [x] スケジュール新規追加、フォーム画面のUI調整
- [x] スケジュールアイコンを黒丸アイコンに変更
- [x] スケジュール一覧で全日程を表示するALLタブの場合は日付も含めたスケジュール表示にするように修正
- [x] 年月日で表示するヘルパーメソッドを/(スラッシュ)区切りに修正(※例：%Y/%-m/%-d(%a))

## 未実施内容

## 補足
スケジュール一覧では、ALL(全日程)、日付未定、スケジュールの開始日もしくは終了日ごとにタブで表示を分けました。
スケジュールの開始日と終了日がどちらも登録されている場合は開始日が優先されます。

スケジュールアイコンは仮で電車アイコンを設定していましたが、紛らわしいため黒丸アイコンに変更しました。

## 関連issue
#28 