### PR TITLE
Update/スケジュール登録をFormObjectで実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+.DS_Store
+/vendor/bundle

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -16,7 +16,8 @@
 
 .travel-book-image {
   width: 100%;
-  height: 100%;
+  height: 250px;
+  /* height: 100%; */
   object-fit: cover;
   display: block;
 }

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -8,7 +8,7 @@ class SchedulesController < ApplicationController
   end
 
   def new
-    @schedule_form = ScheduleForm.new(travel_book:@travel_book)
+    @schedule_form = ScheduleForm.new(travel_book: @travel_book)
   end
 
   def create

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -7,7 +7,7 @@ class SchedulesController < ApplicationController
   end
 
   def new
-    @schedule_form = ScheduleForm.new
+    @schedule_form = ScheduleForm.new(travel_book:@travel_book)
   end
 
   def create

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,4 +1,5 @@
 class SchedulesController < ApplicationController
+  before_action :authenticate_user!, only: [ :new, :edit, :update, :destroy ]
   before_action :set_travel_book, only: %i[ index new create ]
   before_action :set_schedule, only: %i[ show edit update destroy ]
 

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,4 +1,6 @@
 class TravelBooksController < ApplicationController
+  before_action :authenticate_user!, only: [ :new, :edit, :update, :destroy ]
+
   def index
     @travel_books =
     if params[:scope] == "own"

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -29,7 +29,7 @@ class ScheduleForm
   # ScheduleFormオブジェクトがpersisted?メソッドを呼ぶと、Scheduleオブジェクトのpersisted?メソッドが呼び出される
   delegate :persisted?, to: :schedule
 
-  def initialize(attributes = nil, schedule: Schedule.new, spot: nil,travel_book:nil)
+  def initialize(attributes = nil, schedule: Schedule.new, spot: nil, travel_book: nil)
     @schedule = schedule
     @spot = spot || @schedule.build_spot
     @travel_book = travel_book

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -1,0 +1,102 @@
+class ScheduleForm
+  include ActiveModel::Model # 通常のモデルのようにvalidationなどを使えるようにする
+  include ActiveModel::Attributes # ActiveRecordのカラムのような属性を加えられるようにする
+  # パラメータの読み書きを許可する
+  attribute :travel_book_id, :integer
+  attribute :title, :string
+  attribute :start_date, :datetime
+  attribute :end_date, :datetime
+  attribute :budged, :integer, default: 0
+  attribute :memo, :string
+  attribute :name, :string
+  attribute :telephone, :string
+  attribute :post_code, :string
+  attribute :address, :string
+
+  validates :travel_book_id, presence: true
+  validates :title, presence: true, length: { maximum: 255 }
+  validate  :end_date_after_start_date
+  validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :memo, length: { maximum: 65_535 }
+  validates :name, length: { maximum: 255 }
+  validates :telephone, length: { maximum: 15 }
+  validates :post_code, length: { maximum: 10 }
+  validates :address, length: { maximum: 255 }
+
+  attr_accessor :schedule, :spot
+
+  # フォームのアクションをPOST/PUTCHに切り替える
+  # ScheduleFormオブジェクトがpersisted?メソッドを呼ぶと、Scheduleオブジェクトのpersisted?メソッドが呼び出される
+  delegate :persisted?, to: :schedule
+
+  def initialize(attributes = nil, schedule: Schedule.new, spot: nil)
+    @schedule = schedule
+    @spot = spot || @schedule.build_spot
+
+    attributes ||= default_attributes
+    super(attributes)
+  end
+
+  def save
+    return false if invalid?
+    ActiveRecord::Base.transaction do
+      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id)
+
+      # Spot のデータが存在する場合のみ作成
+      if name.present? || telephone.present? || post_code.present? || address.present?
+        @spot = Spot.create!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: schedule.id)
+      end
+      true
+    end
+    rescue ActiveRecord::RecordInvalid => e
+      e.record.errors.full_messages.each do |message|
+        errors.add(:base, message)
+      end
+    false
+  end
+
+  def update(attributes)
+    return false if invalid?
+    ActiveRecord::Base.transaction do
+      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id)
+
+      # Spot のデータが存在する場合のみ作成
+      if name.present? || telephone.present? || post_code.present? || address.present?
+        @spot.update!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: @schedule.id)
+      else
+        @schedule.spot.destroy
+      end
+    end
+    true
+    rescue ActiveRecord::RecordInvalid => e
+      e.record.errors.full_messages.each do |message|
+        errors.add(:base, message)
+      end
+    false
+  end
+
+  private
+
+  attr_reader :schedule, :spot
+
+  def default_attributes
+    {
+      title: schedule.title,
+      budged: schedule.budged,
+      memo: schedule.memo,
+      start_date: schedule.start_date,
+      end_date: schedule.end_date,
+      name: spot.name,
+      telephone: spot.telephone,
+      post_code: spot.post_code,
+      address: spot.address
+    }
+  end
+
+  def end_date_after_start_date
+    if start_date.present? && end_date.present? && end_date < start_date
+      errors.add(:end_date, "must be after start date")
+      false
+    end
+  end
+end

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -29,11 +29,13 @@ class ScheduleForm
   # ScheduleFormオブジェクトがpersisted?メソッドを呼ぶと、Scheduleオブジェクトのpersisted?メソッドが呼び出される
   delegate :persisted?, to: :schedule
 
-  def initialize(attributes = nil, schedule: Schedule.new, spot: nil)
+  def initialize(attributes = nil, schedule: Schedule.new, spot: nil,travel_book:nil)
     @schedule = schedule
     @spot = spot || @schedule.build_spot
+    @travel_book = travel_book
 
-    attributes ||= default_attributes
+
+    attributes ||= default_attributes(@travel_book)
     super(attributes)
   end
 
@@ -79,13 +81,13 @@ class ScheduleForm
 
   attr_reader :schedule, :spot
 
-  def default_attributes
+  def default_attributes(travel_book)
     {
       title: schedule.title,
       budged: schedule.budged,
       memo: schedule.memo,
-      start_date: schedule.start_date,
-      end_date: schedule.end_date,
+      start_date: schedule.start_date || travel_book&.start_date&.to_datetime || nil,
+      end_date: schedule.start_date || travel_book&.start_date&.to_datetime || nil,
       name: spot.name,
       telephone: spot.telephone,
       post_code: spot.post_code,

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,22 +2,7 @@ class Schedule < ApplicationRecord
   belongs_to :travel_book
   has_one :spot, dependent: :destroy
 
-  accepts_nested_attributes_for :spot, allow_destroy: true, reject_if: :all_blank
-
-  validates :title, presence: true, length: { maximum: 255 }
-  validates :memo, length: { maximum: 65_535 }
-  validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validate :end_date_after_start_date
-
   def self.group_by_date(schedules)
     schedules.group_by { |schedule| (schedule.start_date&.to_date || schedule.end_date&.to_date) || "日付未定" }
-  end
-
-  private
-
-  def end_date_after_start_date
-    if start_date.present? && end_date.present? && end_date < start_date
-      errors.add(:end_date, "must be after start date")
-    end
   end
 end

--- a/app/views/check_lists/_check_list.html.erb
+++ b/app/views/check_lists/_check_list.html.erb
@@ -1,6 +1,6 @@
 <%= link_to check_list_path(check_list), class: "block" do %>
-  <div class="bg-base-100 flex items-center mt-2">
+  <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:bg-base-300">
     <i class="fa-solid fa-square-check"></i>
-    <p class="ml-2"><%= check_list.title %></p>
+    <div class="ml-3"><%= check_list.title %></div>
   </div>
 <% end %>

--- a/app/views/check_lists/_form.html.erb
+++ b/app/views/check_lists/_form.html.erb
@@ -1,6 +1,13 @@
 <%= form_with model: check_list, url: check_list.new_record? ? travel_book_check_lists_path(travel_book) : check_list_path(check_list) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
-  <%= f.label :title %>
-  <%= f.text_field :title %>
-  <%= f.submit nil %>
+
+  <div class="field mt-3">
+    <%= f.label :title, class: "w-full" do %>
+      <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
+    <% end %>
+    <%= f.text_field :title, autofocus: true, placeholder: "購入品リスト", class: "input input-bordered w-full" %>
+  </div>
+  <div class="flex justify-end mt-5">
+    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
+  </div>
 <% end %>

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,9 +1,11 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to travel_book_check_lists_path(@travel_book) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <h1 class="text-center flex-1 text-lg font-bold">チェックリストを編集</h1>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_check_lists_path(@travel_book) do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center">チェックリストを編集</h1>
+    </div>
+    <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>
-  <%= render "form", check_list: @check_list, travel_book: @travel_book %>
 </div>

--- a/app/views/check_lists/index.html.erb
+++ b/app/views/check_lists/index.html.erb
@@ -1,6 +1,6 @@
-<div class="p-6 m-6">
+<div class="container">
   <% if @check_lists.present? %>
-      <%= render @check_lists %>
+    <%= render @check_lists %>
   <% else %>
     チェックリストはありません
   <% end %>

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -1,9 +1,11 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to travel_book_check_lists_path(@travel_book) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <h1 class="text-center flex-1 text-lg font-bold">チェックリストを追加</h1>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_check_lists_path(@travel_book) do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center">チェックリストを追加</h3>
+    </div>
+    <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>
-  <%= render "form", check_list: @check_list, travel_book: @travel_book %>
 </div>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -1,30 +1,31 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to travel_book_check_lists_path(@travel_book) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <div>
-      <%= link_to edit_check_list_path(@check_list) do %>
-        <i class="fa-solid fa-pen"></i>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
+
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_check_lists_path(@travel_book) do %>
+        <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
-        <i class="fa-solid fa-trash-can"></i>
+      <h3 class="flex-grow text-center"><%= @check_list.title %></h3>
+      <% if @travel_book.owned_by_user?(current_user) %>
+        <%= link_to edit_check_list_path(@check_list) do %>
+          <i class="fa-solid fa-pen"></i>
+        <% end %>
+        <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+          <i class="fa-solid fa-trash-can"></i>
+        <% end %>
       <% end %>
     </div>
-  </div>
 
-  <div class="mx-10 mb-5">
-    <div class="mt-5">
-      <h2 class="flex-1 text-lg font-bold"><%= @check_list.title %></h2>
+    <div class="m-10">
+      <% if @list_items.present? %>
+        <%= render @list_items %>
+      <% else %>
+        チェックリストは登録されていません
+      <% end %>
+
+      <button><i class="fa-solid fa-circle-plus"></i></button>
+      <%= render "list_items/form", check_list: @check_list, list_item: @list_item %>
     </div>
+
   </div>
-
-  <% if @list_items.present? %>
-    <%= render @list_items %>
-  <% else %>
-    チェックリストは登録されていません
-  <% end %>
-
-  <button><i class="fa-solid fa-circle-plus"></i></button>
-  <%= render "list_items/form", check_list: @check_list, list_item: @list_item %>
 </div>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -1,4 +1,4 @@
-<div class="flex gap-2" >
+<div class="flex gap-2">
   <div><%= check_box_tag "list_item[completed]", "true", list_item.completed %></div>
   <div><%= list_item.title %></div>
 </div>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: schedule, url: schedule.new_record? ? travel_book_schedules_path(travel_book) : schedule_path(schedule) do |f| %>
+<%= form_with model: @schedule_form, url: url do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
       <div class="field mt-3">
@@ -21,30 +21,24 @@
 
     <%# 場所情報の登録フォーム %>
     <%= f.label :spot_id, class: "label" %>
-    <%= f.fields_for :spot do |spot_form| %>
-      <div class="ml-3">
-        <% if @schedule.spot&.persisted? %>
-          <%= spot_form.label :_destroy, "削除" %>
-          <%= spot_form.check_box :_destroy, class: "checkbox checkbox-primary mr-2" %>
-        <% end %>
-        <div class="field">
-          <%= spot_form.label :name, Schedule.human_attribute_name(:name), class: "label" %>
-          <%= spot_form.text_field :name, class: "input input-bordered w-full" %>
-        </div>
-        <div class="field">
-          <%= spot_form.label :telephone, Schedule.human_attribute_name(:telephone), class: "label" %>
-          <%= spot_form.text_field :telephone, class: "input input-bordered w-full" %>
-        </div>
-        <div class="field">
-          <%= spot_form.label :post_code, Schedule.human_attribute_name(:post_code), class: "label" %>
-          <%= spot_form.text_field :post_code, class: "input input-bordered w-full" %>
-        </div>
-        <div class="field">
-          <%= spot_form.label :address, Schedule.human_attribute_name(:address), class: "label" %>
-          <%= spot_form.text_field :address, class: "input input-bordered w-full" %>
-        </div>
+    <div class="ml-3">
+      <div class="field">
+        <%= f.label :name, Schedule.human_attribute_name(:name), class: "label" %>
+        <%= f.text_field :name, class: "input input-bordered w-full" %>
       </div>
-    <% end %>
+      <div class="field">
+        <%= f.label :telephone, Schedule.human_attribute_name(:telephone), class: "label" %>
+        <%= f.text_field :telephone, class: "input input-bordered w-full" %>
+      </div>
+      <div class="field">
+        <%= f.label :post_code, Schedule.human_attribute_name(:post_code), class: "label" %>
+        <%= f.text_field :post_code, class: "input input-bordered w-full" %>
+      </div>
+      <div class="field">
+        <%= f.label :address, Schedule.human_attribute_name(:address), class: "label" %>
+        <%= f.text_field :address, class: "input input-bordered w-full" %>
+      </div>
+    </div>
 
   <div class="field mt-3">
     <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,12 +1,12 @@
 <%= form_with model: @schedule_form, url: url do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
-      <div class="field mt-3">
-        <%= f.label :title, class: "w-full" do %>
-          <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
-        <% end %>
-        <%= f.text_field :title, autofocus: true, placeholder: "待ち合わせ", class: "input input-bordered w-full" %>
-      </div>
+    <div class="field mt-3">
+      <%= f.label :title, class: "w-full" do %>
+        <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
+      <% end %>
+      <%= f.text_field :title, autofocus: true, placeholder: "待ち合わせ", class: "input input-bordered w-full" %>
+    </div>
 
     <div class="mt-3 flex flex-col sm:flex-row gap-2">
       <div class="w-full">

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -6,5 +6,5 @@
     <h1 class="text-center flex-1 text-lg font-bold">スケジュールを編集</h1>
   </div>
 
-  <%= render "form", schedule: @schedule %>
+  <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>
 </div>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,10 +1,12 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to schedule_path(@schedule) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <h1 class="text-center flex-1 text-lg font-bold">スケジュールを編集</h1>
-  </div>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
+    <div class="flex items-center justify-between">
+      <%= link_to schedule_path(@schedule) do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center">スケジュールを編集</h3>
+    </div>
 
-  <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>
+    <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>
+  </div>
 </div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -2,10 +2,10 @@
   <div class="form-container bg-white rounded-lg shadow-md p-8">
 
     <div class="relative flex items-center justify-center">
-      <%= link_to travel_book_schedules_path(@travel_book), class: "absolute left-0" do %>
+      <%= link_to travel_book_schedules_path(@travel_book) do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3>スケジュールを追加</h3>
+      <h3 class="flex-grow text-center">スケジュールを追加</h3>
     </div>
 
     <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -8,6 +8,6 @@
       <h3>スケジュールを追加</h3>
     </div>
 
-    <%= render "form", schedule: @schedule, travel_book: @travel_book %>
+    <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>
   </div>
 </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,10 +1,11 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
 
-  <div class="flex items-center justify-between">
-    <%= link_to travel_book_schedules_path(@travel_book) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <div>
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_schedules_path(@travel_book) do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center"><%= @schedule.title %></h3>
       <% if @travel_book.owned_by_user?(current_user) %>
         <%= link_to edit_schedule_path(@schedule) do %>
           <i class="fa-solid fa-pen"></i>
@@ -14,40 +15,36 @@
         <% end %>
       <% end %>
     </div>
-  </div>
 
-  <div class="mx-10 mb-5">
-    <div class="mt-5">
-      <h2 class="flex-1 text-lg font-bold"><%= @schedule.title %></h2>
-    </div>
-
-    <div class="mt-5 flex items-center">
-      <i class="fa-regular fa-clock"></i>
-      <p class="ml-2"><%= fmt_schedule_duration(@schedule) %></p>
-    </div>
-
-    <div class="mt-5 flex items-center">
-      <i class="fa-solid fa-location-dot"></i>
-      <div class="ml-2">
-        <% if @schedule.spot.present? %>
-          <p><%= desplay_value(@schedule.spot.name) %></p>
-          <p><%= desplay_value(@schedule.spot.telephone) %></p>
-          <p><%= desplay_value(@schedule.spot.post_code) %></p>
-          <p><%= desplay_value(@schedule.spot.address) %></p>
-        <% else %>
-          <p>場所は登録されていません</p>
-        <% end %>
+    <div class="mx-10 mb-5">
+      <div class="mt-5 flex items-center">
+        <i class="fa-regular fa-clock"></i>
+        <p class="ml-2"><%= fmt_schedule_duration(@schedule) %></p>
       </div>
-    </div>
 
-    <div class="mt-5 flex items-center">
-      <i class="fa-solid fa-wallet"></i>
-      <p class="ml-2"><%= @schedule.budged %>円</p>
-    </div>
+      <div class="mt-5 flex items-center">
+        <i class="fa-solid fa-location-dot"></i>
+        <div class="ml-2">
+          <% if @schedule.spot.present? %>
+            <p><%= desplay_value(@schedule.spot.name) %></p>
+            <p><%= desplay_value(@schedule.spot.telephone) %></p>
+            <p><%= desplay_value(@schedule.spot.post_code) %></p>
+            <p><%= desplay_value(@schedule.spot.address) %></p>
+          <% else %>
+            <p>場所は登録されていません</p>
+          <% end %>
+        </div>
+      </div>
 
-    <div class="mt-5 flex items-start">
-      <i class="fa-solid fa-file-pen mt-1"></i>
-      <p class="ml-2"><%= display_memo(@schedule.memo) %></p>
+      <div class="mt-5 flex items-center">
+        <i class="fa-solid fa-wallet"></i>
+        <p class="ml-2"><%= @schedule.budged %>円</p>
+      </div>
+
+      <div class="mt-5 flex items-start">
+        <i class="fa-solid fa-file-pen mt-1"></i>
+        <p class="ml-2"><%= display_memo(@schedule.memo) %></p>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -5,11 +5,13 @@
       <i class="fa-solid fa-chevron-left"></i>
     <% end %>
     <div>
-      <%= link_to edit_schedule_path(@schedule) do %>
-        <i class="fa-solid fa-pen"></i>
-      <% end %>
-      <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
-        <i class="fa-solid fa-trash-can"></i>
+      <% if @travel_book.owned_by_user?(current_user) %>
+        <%= link_to edit_schedule_path(@schedule) do %>
+          <i class="fa-solid fa-pen"></i>
+        <% end %>
+        <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+          <i class="fa-solid fa-trash-can"></i>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -1,93 +1,68 @@
 <%= form_with model: @travel_book do |f| %>
   <%= render "shared/error_messages", object: f.object %>
-  <div class="space-y-5">
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-4">
-          <%= f.label :title, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-            <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
-              <%= f.text_field :title, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
-            </div>
-          </div>
-        </div>
-      </div>
 
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="col-span-full">
-          <%= f.label :description, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-              <%= f.text_area :description, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-3">
-          <%= f.label :start_date, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.date_field :start_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
-
-        <div class="sm:col-span-3">
-          <%= f.label :end_date, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2">
-              <%= f.date_field :end_date, class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" %>
-          </div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-3">
-          <%= f.label :area_id, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2 grid grid-cols-1">
-            <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
-          </div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-3">
-          <%= f.label :traveler_type_id, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2 grid grid-cols-1">
-            <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" } %>
-          </div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="sm:col-span-3">
-          <%= f.label :travel_book_image, class: "block text-sm/6 font-medium text-gray-900" %>
-          <div class="mt-2 grid grid-cols-1">
-            <%= f.file_field :travel_book_image, accept: "image/*", class: "" %>
-            <%= f.hidden_field :travel_book_image_cache %>
-          </div>
-        </div>
-      </div>
-
-      <div class="mt-2">
-        <% if @travel_book.persisted? %>
-          <% if @travel_book.travel_book_image %>
-            <%= link_to "destroy", delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-ghost rounded-btn" %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-        <div class="space-y-1">
-          <p class="block text-sm/6 font-medium text-gray-900">公開設定</p>
-          <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_public, true, id: "is_public_true", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-            <%= f.label :is_public, "公開", for: "is_public_true" %>
-          </div>
-          <div class="flex items-center gap-x-3">
-            <%= f.radio_button :is_public, false, id: "is_public_false", class: "relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden" %>
-            <%= f.label :is_public, "非公開", for: "is_public_false" %>
-          </div>
-        </div>
-      </div>
+  <div class="field mt-3">
+    <%= f.label :title, class: "w-full" do %>
+      <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
+    <% end %>
+    <%= f.text_field :title, autofocus: true, placeholder: "春の東京観光", class: "input input-bordered w-full" %>
   </div>
-  <div class="mt-6 flex items-center justify-end gap-x-6">
-    <%= f.submit nil, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+
+  <div class="field mt-3">
+    <%= f.label :description, Schedule.human_attribute_name(:description), class: "label" %>
+    <%= f.text_area :description, placeholder: "旅行やおでかけの説明を記入", rows: "1", class: "textarea textarea-bordered w-full" %>
+  </div>
+
+  <div class="mt-3 flex flex-col sm:flex-row gap-2">
+    <div class="w-full">
+      <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
+      <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
+    </div>
+    <div class="w-full">
+      <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
+      <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
+    </div>
+  </div>
+
+  <div class="field mt-3">
+    <%= f.label :area_id, Schedule.human_attribute_name(:area_id), class: "label" %>
+    <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "select select-bordered w-full max-w-xs" } %>
+  </div>
+
+  <div class="field mt-3">
+    <%= f.label :traveler_type_id, Schedule.human_attribute_name(:traveler_type_id), class: "label" %>
+    <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "select select-bordered w-full max-w-xs" } %>
+  </div>
+
+  <div class="field mt-3">
+    <%= f.label :travel_book_image, Schedule.human_attribute_name(:travel_book_image), class: "label" %>
+    <%= f.file_field :travel_book_image, accept: "image/*", class: "file-input file-input-bordered w-full max-w-xs" %>
+    <%= f.hidden_field :travel_book_image_cache %>
+  </div>
+
+  <div class="mt-2 flex flex-row-reverse">
+    <% if @travel_book.persisted? && @travel_book.travel_book_image %>
+      <%= link_to delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } do %>
+        <i class="fa-solid fa-trash"></i>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="field mt-3">
+    <%= f.label :is_public, Schedule.human_attribute_name(:is_public), class: "label" %>
+    <div class="flex items-center gap-3">
+      <div class="flex items-center gap-1">
+        <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary" %>
+        <%= f.label :is_public_true, "公開", for: "is_public_true" %>
+      </div>
+      <div class="flex items-center gap-1">
+        <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: "checked" %>
+        <%= f.label :is_public_false, "非公開", for: "is_public_false" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex justify-end mt-5">
+    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
   </div>
 <% end %>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,10 +1,12 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to travel_book_path(@travel_book) do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <h1 class="text-center flex-1 text-lg font-bold">しおりを編集</h1>
-  </div>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_path(@travel_book) do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center">しおりを編集</h3>
+    </div>
 
-  <%= render "form", travel_book: @travel_book %>
+    <%= render "form", travel_book: @travel_book %>
+  </div>
 </div>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,4 +1,4 @@
-<div class="p-4">
+<div class="container">
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <%if @travel_books.present? %>
       <%if params[:scope] == "own" %>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,10 +1,12 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6">
-  <div class="flex items-center justify-between">
-    <%= link_to travel_books_path do %>
-      <i class="fa-solid fa-chevron-left"></i>
-    <% end %>
-    <h1 class="text-center flex-1 text-lg font-bold">しおりを追加</h1>
-  </div>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
+    <div class="flex items-center justify-between">
+      <%= link_to travel_books_path do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center">しおりを追加</h3>
+    </div>
 
-  <%= render "form", travel_book: @travel_book %>
+    <%= render "form", travel_book: @travel_book %>
+  </div>
 </div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,45 +1,47 @@
-<div class="card bg-base-100 shadow-md m-6">
-  <figure>
-    <%= image_tag(@travel_book.travel_book_image? ? @travel_book.travel_book_image_url : "default_travel_book_image.jpg") %>
-  </figure>
+<div class="container">
+  <div class="form-container">
+    <div class="card bg-base-100 shadow-md m-6">
+      <figure>
+        <%= image_tag(@travel_book.travel_book_image? ? @travel_book.travel_book_image_url : "default_travel_book_image.jpg", class: "travel-book-image") %>
+      </figure>
 
-  <div class="card-body">
-    <div class="card-actions items-center justify-between">
-      <h2 class="card-title"><%= @travel_book.title %></h2>
-      <div>
-        <% if @travel_book.owned_by_user?(current_user) %>
-          <div class="justify-end">
-            <%= link_to edit_travel_book_path(@travel_book) do %>
-              <i class="fa-solid fa-pen"></i>
-            <% end %>
-            <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
-              <i class="fa-solid fa-trash-can"></i>
-            <% end %>
-          </div>
-        <% end %>
+      <div class="card-body">
+        <div class="card-actions items-center justify-between">
+          <h2 class="card-title"><%= @travel_book.title %></h2>
+          <% if @travel_book.owned_by_user?(current_user) %>
+            <div class="justify-end">
+              <%= link_to edit_travel_book_path(@travel_book) do %>
+                <i class="fa-solid fa-pen"></i>
+              <% end %>
+              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+                <i class="fa-solid fa-trash-can"></i>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+        <div><%= travel_book_desctiption(@travel_book) %></div>
+
+        <div class="mt-3">
+          <div class="font-bold">期間</div>
+          <div><%= travel_book_duration(@travel_book)%></div>
+        </div>
+
+        <div class="mt-3">
+          <div class="font-bold">エリア</div>
+          <div><%= area_name(@travel_book) %></div>
+        </div>
+
+        <div class="mt-3">
+          <div class="font-bold">旅行タイプ</div>
+          <div><%= traveler_type_name(@travel_book) %></div>
+        </div>
+
+        <div class="mt-3">
+          <div class="font-bold">公開設定</div>
+          <div><%= travel_book_is_public(@travel_book) %></div>
+        </div>
       </div>
-    </div>
-
-    <p><%= travel_book_desctiption(@travel_book) %></p>
-
-    <div class="mb-6">
-      <p>期間</p>
-      <p class="text-gray-700"><%= travel_book_duration(@travel_book)%></p>
-    </div>
-
-    <div class="mb-6">
-      <p>エリア</p>
-      <p class="text-gray-700"><%= area_name(@travel_book) %></p>
-    </div>
-
-    <div class="mb-6">
-      <p>旅行タイプ</p>
-      <p class="text-gray-700"><%= traveler_type_name(@travel_book) %></p>
-    </div>
-
-    <div class="mb-6">
-      <p>公開設定</p>
-      <p class="text-gray-700"><%= travel_book_is_public(@travel_book) %></p>
     </div>
   </div>
 </div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,9 +1,6 @@
-#!/usr/bin/env bash
+set -o errexit
 
-set -e
-
-# データベースのマイグレーション
-bin/rails db:migrate
-
-# seedsデータの適用
-# bin/rails db:seed
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+bundle exec rails db:migrate

--- a/db/migrate/20250207085338_change_name_column_to_null_on_spots.rb
+++ b/db/migrate/20250207085338_change_name_column_to_null_on_spots.rb
@@ -1,0 +1,5 @@
+class ChangeNameColumnToNullOnSpots < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :spots, :name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_27_092638) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_085338) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_27_092638) do
 
   create_table "spots", force: :cascade do |t|
     t.bigint "schedule_id"
-    t.string "name", null: false
+    t.string "name"
     t.string "telephone"
     t.string "post_code"
     t.string "address"


### PR DESCRIPTION
# 概要
スケジュールモデルとスポットモデルを1つのフォームで扱うためのFormObjectを実装しました。

## 実施内容
- [x] spotsテーブルのnameカラムのNotNull制約を解除
- [x] FormObjectへの切り替え
- [x] スケジュール新規登録時のデフォルト値を設定
- [x] gitignoreに追記
- [x] Renderのスクリプトファイルの修正
- [x] 未ログインユーザーの場合、操作を一部制限（しおりとスケジュール）
- [x] しおりの所有者にのみ編集・削除ボタンを表示
- [x] しおり画像のサイズ修正

## 未実施内容
しおりの画像アップロード時のサイズ変更は別のPRで実施予定です。

## 補足
Scheduleモデルで`accepts_nested_attributes_for`を使用しSpotを登録・編集していたため、FormObjectに修正しました。
スケジュールとスポットは1対0または1の関係であり、スケジュール登録時に必ずスポットが存在する必要がないため、カラムのNotNull制約を解除しました。

以下FormObjectとは関係がない箇所も不備に気づいたため修正しています。
- CSSの調整(しおり、スケジュール、チェックリストのビュー)
- gitignoreに不足していたファイルを追記
- Renderのスクリプトファイルの修正
- 未ログインユーザーの場合、操作を一部制限（しおり、スケジュール）
- しおりの所有者にのみ編集・削除ボタンを表示
- しおり画像のサイズ修正

## 関連issue
#106 