### PR TITLE
Feature/チェックリストのCRUD画面をturboで実装

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -21,7 +21,7 @@ class CheckListsController < ApplicationController
   end
 
   def show
-    @list_items = @check_list.list_items.order(created_at: :asc) # 既存のリストアイテム
+    @list_items = @check_list.list_items.order(created_at: :asc)
   end
 
 

--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -21,14 +21,11 @@ class CheckListsController < ApplicationController
   end
 
   def show
-    @travel_book = @check_list.travel_book
-    @list_items = @check_list.list_items
-    @list_item = @check_list.list_items.build
+    @list_items = @check_list.list_items.order(created_at: :asc) # 既存のリストアイテム
   end
 
-  def edit
-    @travel_book = @check_list.travel_book
-  end
+
+  def edit; end
 
   def update
     if @check_list.update(check_list_param)
@@ -39,7 +36,6 @@ class CheckListsController < ApplicationController
   end
 
   def destroy
-    @travel_book = @check_list.travel_book
     @check_list.destroy!
     redirect_to travel_book_check_lists_path(@travel_book)
   end
@@ -52,6 +48,7 @@ class CheckListsController < ApplicationController
 
   def set_check_list
     @check_list = CheckList.find(params[:id])
+    @travel_book = @check_list.travel_book
   end
 
   def check_list_param

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,11 +1,12 @@
 class ListItemsController < ApplicationController
+  before_action :set_check_list, only: %i[ new create ]
+  before_action :set_list_item, only: %i[ edit update destroy]
+
   def new
-    @check_list = CheckList.find(params[:check_list_id])
     @list_item = @check_list.list_items.new
   end
 
   def create
-    @check_list = CheckList.find(params[:check_list_id])
     @list_item = @check_list.list_items.build(list_item_params)
 
     if @list_item.save
@@ -16,12 +17,9 @@ class ListItemsController < ApplicationController
     end
   end
 
-  def edit
-    @list_item = ListItem.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @list_item = ListItem.find(params[:id])
     if @list_item.update(list_item_params)
       flash.now[:notice] = "成功"
     else
@@ -30,7 +28,19 @@ class ListItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @list_item.destroy!
+  end
+
   private
+
+  def set_check_list
+    @check_list = CheckList.find(params[:check_list_id])
+  end
+
+  def set_list_item
+    @list_item = ListItem.find(params[:id])
+  end
 
   def list_item_params
     params.require(:list_item).permit(:title, :completed)

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -32,6 +32,20 @@ class ListItemsController < ApplicationController
     @list_item.destroy!
   end
 
+  def cancel
+    respond_to do |format|
+      if params[:id].present?
+        # 編集時（edit）のキャンセル
+        @list_item = ListItem.find(params[:id])
+        format.turbo_stream
+      else
+        # 新規作成時（new）のキャンセル
+        @check_list = CheckList.find(params[:check_list_id])
+        format.turbo_stream { render "cancel_new" }
+      end
+    end
+  end
+
   private
 
   def set_check_list

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,6 +1,6 @@
 class ListItemsController < ApplicationController
   before_action :set_check_list, only: %i[ new create ]
-  before_action :set_list_item, only: %i[ edit update destroy]
+  before_action :set_list_item, only: %i[ edit update destroy toggle]
 
   def new
     @list_item = @check_list.list_items.new
@@ -44,6 +44,11 @@ class ListItemsController < ApplicationController
         format.turbo_stream { render "cancel_new" }
       end
     end
+  end
+
+  def toggle
+    @list_item.update(completed: !@list_item.completed)
+    render turbo_stream: turbo_stream.replace(@list_item, partial: "list_item", locals: { list_item: @list_item })
   end
 
   private

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -16,6 +16,20 @@ class ListItemsController < ApplicationController
     end
   end
 
+  def edit
+    @list_item = ListItem.find(params[:id])
+  end
+
+  def update
+    @list_item = ListItem.find(params[:id])
+    if @list_item.update(list_item_params)
+      flash.now[:notice] = "成功"
+    else
+      flash.now[:alert] = "失敗"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def list_item_params

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,18 +1,24 @@
 class ListItemsController < ApplicationController
+  def new
+    @check_list = CheckList.find(params[:check_list_id])
+    @list_item = @check_list.list_items.new
+  end
+
   def create
     @check_list = CheckList.find(params[:check_list_id])
-    @list_item = @check_list.list_items.build(list_item_param)
+    @list_item = @check_list.list_items.build(list_item_params)
 
     if @list_item.save
-      redirect_to check_list_path(@check_list)
+      flash.now[:notice] = "成功"
     else
-      render "check_lists/show"
+      flash.now[:alert] = "失敗"
+      render :new, status: :unprocessable_entity
     end
   end
 
   private
 
-  def list_item_param
+  def list_item_params
     params.require(:list_item).permit(:title, :completed)
   end
 end

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -23,8 +23,6 @@ class ScheduleForm
   validates :post_code, length: { maximum: 10 }
   validates :address, length: { maximum: 255 }
 
-  attr_accessor :schedule, :spot
-
   # フォームのアクションをPOST/PUTCHに切り替える
   # ScheduleFormオブジェクトがpersisted?メソッドを呼ぶと、Scheduleオブジェクトのpersisted?メソッドが呼び出される
   delegate :persisted?, to: :schedule
@@ -33,7 +31,6 @@ class ScheduleForm
     @schedule = schedule
     @spot = spot || @schedule.build_spot
     @travel_book = travel_book
-
 
     attributes ||= default_attributes(@travel_book)
     super(attributes)

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,3 +1,5 @@
 class ListItem < ApplicationRecord
   belongs_to :check_list
+
+  validates :title, presence: true, length: { maximum: 255 }
 end

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -27,12 +27,10 @@
         <% end %>
       <% end %>
 
-      <div id="list_item_button_field">
-      <%= link_to new_check_list_list_item_path(@check_list), class: "btn", id: "add_list_item_button",data: { turbo_stream: true } do %>
-        <i class="fa-solid fa-circle-plus"></i>リストを追加
-      <% end %>
+      <div id="add_list_item_button" class="my-5">
+        <%= render "list_items/add_button", check_list: @check_list %>
       </div>
-      <div id="list_item_form_field"></div>
+      <div id="list_item_form"></div>
     </div>
   </div>
 </div>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -17,15 +17,22 @@
     </div>
 
     <div class="m-10">
-      <% if @list_items.present? %>
-        <%= render @list_items %>
-      <% else %>
-        チェックリストは登録されていません
+      <%= turbo_frame_tag "list_item" do %>
+        <% if @list_items.present? %>
+          <% @list_items.each do |list_item| %>
+            <%= render "list_items/list_item", list_item: list_item %>
+          <% end %>
+        <% else %>
+          <div>チェックリストは登録されていません</div>
+        <% end %>
       <% end %>
 
-      <button><i class="fa-solid fa-circle-plus"></i></button>
-      <%= render "list_items/form", check_list: @check_list, list_item: @list_item %>
+      <div id="list_item_button_field">
+      <%= link_to new_check_list_list_item_path(@check_list), class: "btn", id: "add_list_item_button",data: { turbo_stream: true } do %>
+        <i class="fa-solid fa-circle-plus"></i>リストを追加
+      <% end %>
+      </div>
+      <div id="list_item_form_field"></div>
     </div>
-
   </div>
 </div>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -11,7 +11,7 @@
           <i class="fa-solid fa-pen"></i>
         <% end %>
         <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
-          <i class="fa-solid fa-trash-can"></i>
+          <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>
     </div>

--- a/app/views/list_items/_add_button.html.erb
+++ b/app/views/list_items/_add_button.html.erb
@@ -1,0 +1,5 @@
+<div id="add_list_item_button">
+  <%= link_to new_check_list_list_item_path(@check_list), class: "btn", data: { turbo_stream: true } do %>
+    <i class="fa-solid fa-circle-plus"></i>リストを追加
+  <% end %>
+</div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -1,9 +1,16 @@
-  <%= form_with model: list_item, url: check_list_list_items_path(@check_list) do |f| %>
-    <div>
-      <%= f.label :title %>
-      <%= f.text_field :title %>
+<div id="list_item_form" >
+<%= turbo_frame_tag "list_item_#{list_item.id}" do %>
+  <%= form_with model: @list_item, url: @list_item.new_record? ? check_list_list_items_path(@check_list): list_item_path(@list_item) do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
+  <div class="flex gap-2">
+      <%= f.text_field :title, autofocus: true, placeholder: "リストのアイテムを追加", class: "input input-bordered w-full" %>
+    <div class="flex gap-2">
+      <%= link_to "", class: "btn" do %>
+        <i class="fa-solid fa-xmark"></i>
+      <% end %>
+      <%= f.submit nil, class: "btn" %>
     </div>
-    <div>
-      <%= f.submit 'Add Item' %>
-    </div>
+  </div>
   <% end %>
+<% end %>
+</div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -1,11 +1,10 @@
-<div id="list_item_form" >
 <%= turbo_frame_tag "list_item_#{list_item.id}" do %>
   <%= form_with model: @list_item, url: @list_item.new_record? ? check_list_list_items_path(@check_list): list_item_path(@list_item) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
   <div class="flex gap-2">
       <%= f.text_field :title, autofocus: true, placeholder: "リストのアイテムを追加", class: "input input-bordered w-full" %>
     <div class="flex gap-2">
-      <%= link_to "", class: "btn" do %>
+      <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn", data: { turbo_method: :post } do %>
         <i class="fa-solid fa-xmark"></i>
       <% end %>
       <%= f.submit nil, class: "btn" %>
@@ -13,4 +12,3 @@
   </div>
   <% end %>
 <% end %>
-</div>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -1,18 +1,20 @@
 <%= turbo_frame_tag "list_item_#{list_item.id}" do %>
-  <div class="flex justify-between my-2">
-    <div>
-      <%= check_box_tag "list_item[completed]", "true", list_item.completed %>
-      <%= list_item.title %>
-    </div>
-    <div class="flex gap-3">
-      <% if list_item.persisted? %>
-        <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:text-base-300" do %>
-          <i class="fa-solid fa-pen"></i>
+  <%= form_with model: list_item, url: toggle_list_item_path(list_item) do |f| %>
+    <div class="flex justify-between my-2">
+      <div>
+        <%= f.check_box :completed, onchange: "this.form.requestSubmit()" %>
+        <%= list_item.title %>
+      </div>
+      <div class="flex gap-3">
+        <% if list_item.persisted? %>
+          <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:text-base-300" do %>
+            <i class="fa-solid fa-pen"></i>
+          <% end %>
+          <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:text-base-300" do %>
+            <i class="fa-solid fa-trash"></i>
+          <% end %>
         <% end %>
-        <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:text-base-300" do %>
-          <i class="fa-solid fa-trash"></i>
-        <% end %>
-      <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -1,4 +1,18 @@
-<div class="flex gap-2">
-  <div><%= check_box_tag "list_item[completed]", "true", list_item.completed %></div>
-  <div><%= list_item.title %></div>
-</div>
+<%= turbo_frame_tag "list_item_#{list_item.id}" do %>
+  <div class="flex justify-between my-2">
+    <div>
+      <%= check_box_tag "list_item[completed]", "true", list_item.completed %>
+      <%= list_item.title %>
+    </div>
+    <div class="flex gap-3">
+      <% if list_item.persisted? %>
+        <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:text-base-300" do %>
+          <i class="fa-solid fa-pen"></i>
+        <% end %>
+        <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:text-base-300" do %>
+          <i class="fa-solid fa-trash"></i>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag "list_item_#{list_item.id}" do %>
   <%= form_with model: list_item, url: toggle_list_item_path(list_item) do |f| %>
-    <div class="flex justify-between my-2">
-      <div>
-        <%= f.check_box :completed, onchange: "this.form.requestSubmit()" %>
+    <div class="flex items-center justify-between my-3">
+      <div class="flex items-center gap-2">
+        <%= f.check_box :completed, onchange: "this.form.requestSubmit()", class: "checkbox" %>
         <%= list_item.title %>
       </div>
-      <div class="flex gap-3">
+      <div class="flex gap-5">
         <% if list_item.persisted? %>
           <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:text-base-300" do %>
             <i class="fa-solid fa-pen"></i>

--- a/app/views/list_items/cancel.turbo_stream.erb
+++ b/app/views/list_items/cancel.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
+  <%= render "list_items/list_item", list_item: @list_item %>
+<% end %>

--- a/app/views/list_items/cancel_new.turbo_stream.erb
+++ b/app/views/list_items/cancel_new.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.update "list_item_form", "" %>
+<%= turbo_stream.update "add_list_item_button" do %>
+  <%= render "list_items/add_button" %>
+<% end %>

--- a/app/views/list_items/create.turbo_stream.erb
+++ b/app/views/list_items/create.turbo_stream.erb
@@ -2,5 +2,8 @@
   <%= render "list_items/list_item", list_item: @list_item %>
 <% end %>
 
-<%# formを削除 %>
-<%= turbo_stream.replace "list_item_form", "" %>
+<%= turbo_stream.update "list_item_form", "" %>
+
+<%= turbo_stream.update "add_list_item_button" do %>
+  <%= render "list_items/add_button", check_list: @check_list %>
+<% end %>

--- a/app/views/list_items/create.turbo_stream.erb
+++ b/app/views/list_items/create.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.append "list_item" do %>
+  <%= render "list_items/list_item", list_item: @list_item %>
+<% end %>
+
+<%# formを削除 %>
+<%= turbo_stream.replace "list_item_form", "" %>

--- a/app/views/list_items/destroy.turbo_stream.erb
+++ b/app/views/list_items/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @list_item %>

--- a/app/views/list_items/edit.turbo_stream.erb
+++ b/app/views/list_items/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
+  <%= render "list_items/form", list_item: @list_item %>
+<% end %>

--- a/app/views/list_items/new.turbo_stream.erb
+++ b/app/views/list_items/new.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.append "list_item_form_field" do %>
+  <%= render "list_items/form", list_item: @list_item %>
+<% end %>
+<%#= turbo_stream.remove "add_list_item_button" %>

--- a/app/views/list_items/new.turbo_stream.erb
+++ b/app/views/list_items/new.turbo_stream.erb
@@ -1,4 +1,5 @@
-<%= turbo_stream.append "list_item_form_field" do %>
+<%= turbo_stream.append "list_item_form" do %>
   <%= render "list_items/form", list_item: @list_item %>
 <% end %>
-<%#= turbo_stream.remove "add_list_item_button" %>
+
+<%= turbo_stream.update "add_list_item_button", "" %>

--- a/app/views/list_items/update.turbo_stream.erb
+++ b/app/views/list_items/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
+  <%= render "list_items/list_item", list_item: @list_item %>
+<% end %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -19,26 +19,19 @@
       </div>
     </div>
 
-    <%# 場所情報の登録フォーム %>
-    <%= f.label :spot_id, class: "label" %>
-    <div class="ml-3">
-      <div class="field">
-        <%= f.label :name, Schedule.human_attribute_name(:name), class: "label" %>
-        <%= f.text_field :name, class: "input input-bordered w-full" %>
-      </div>
-      <div class="field">
-        <%= f.label :telephone, Schedule.human_attribute_name(:telephone), class: "label" %>
-        <%= f.text_field :telephone, class: "input input-bordered w-full" %>
-      </div>
-      <div class="field">
-        <%= f.label :post_code, Schedule.human_attribute_name(:post_code), class: "label" %>
-        <%= f.text_field :post_code, class: "input input-bordered w-full" %>
-      </div>
-      <div class="field">
-        <%= f.label :address, Schedule.human_attribute_name(:address), class: "label" %>
-        <%= f.text_field :address, class: "input input-bordered w-full" %>
-      </div>
-    </div>
+  <%# 場所情報の登録フォーム %>
+  <div class="field">
+    <%= f.label :name, Schedule.human_attribute_name(:name), class: "label" %>
+    <%= f.text_field :name, class: "input input-bordered w-full" %>
+  </div>
+  <div class="field">
+    <%= f.label :telephone, Schedule.human_attribute_name(:telephone), class: "label" %>
+    <%= f.text_field :telephone, class: "input input-bordered w-full" %>
+  </div>
+  <div class="field">
+    <%= f.label :address, Schedule.human_attribute_name(:address), class: "label" %>
+    <%= f.text_field :address, class: "input input-bordered w-full" %>
+  </div>
 
   <div class="field mt-3">
     <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -11,7 +11,7 @@
           <i class="fa-solid fa-pen"></i>
         <% end %>
         <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
-          <i class="fa-solid fa-trash-can"></i>
+          <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>
     </div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -14,7 +14,7 @@
                 <i class="fa-solid fa-pen"></i>
               <% end %>
               <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
-                <i class="fa-solid fa-trash-can"></i>
+                <i class="fa-solid fa-trash"></i>
               <% end %>
             </div>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     delete "delete_image", on: :member
     resources :schedules, shallow: true
     resources :check_lists, shallow: true do
-      resources :list_items do
+      resources :list_items, only: %i[ new create edit update destroy toggle ] do
         collection do
           post :cancel # new 用
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,14 @@ Rails.application.routes.draw do
     delete "delete_image", on: :member
     resources :schedules, shallow: true
     resources :check_lists, shallow: true do
-      resources :list_items
+      resources :list_items do
+        collection do
+          post :cancel # new 用
+        end
+        member do
+          post :cancel # edit 用
+        end
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
         end
         member do
           post :cancel # edit 用
+          patch :toggle
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     delete "delete_image", on: :member
     resources :schedules, shallow: true
     resources :check_lists, shallow: true do
-      resources :list_items, only: %i[ create ]
+      resources :list_items
     end
   end
 


### PR DESCRIPTION
# 概要
チェックリストのリストアイテムの登録/編集/削除画面をturboで実装するように修正しました。

## 実施内容
- [x] ListItemモデルにtitleのバリデーションを定義
- [x] ListItemのルーティングのアクション制限
- [x] リストアイテムの登録
  - リストアイテムを追加ボタンクリック時、登録フォームを表示し、追加ボタン非表示にする
  - リストアイテムの登録が成功したらリストアイテム一覧に追加する
  - キャンセルボタンクリック時、フォームを非表示にし、追加ボタンを表示する
- [x] リストアイテムの編集
  - 編集ボタンクリック時、フォームを表示する
  - キャンセルボタンクリック時、フォームを非表示にし、追加ボタンを表示する
- [x] リストアイテムの削除
  - 削除ボタンクリック時、対象のリストアイテムを削除する
- [x] リストアイテムのステータスを更新
  - チェックボックスクリック時、サーバーに完了/未完了のステータスを送信する
- [x] リストアイテム(_list_item.html.erb)のCSSの調整
- [x] ルーティング(listi_tems)のアクションの制限を設定
- [x] 不要なコードの削除

## 未実施内容
なし

## 補足
アプリ上で表示しているゴミ箱アイコンのデザインが2種類あったため、統一しました。
FormObjectの実装(#106)で記述していた　`attr_accessor`が不要だったため削除しました。

## 関連issue
#99 ,#106(FormObject)