### PR TITLE
Feature/i18n対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "fog-aws"
 gem "draper"
 
 # i18n
-gem 'rails-i18n', "~> 7.0.0"
+gem "rails-i18n", "~> 7.0.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "fog-aws"
 # デコレーター
 gem "draper"
 
+# i18n
+gem 'rails-i18n', "~> 7.0.0"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -372,6 +375,7 @@ DEPENDENCIES
   pry-byebug
   puma (>= 5.0)
   rails (~> 7.2.1)
+  rails-i18n (~> 7.0.0)
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -1,15 +1,11 @@
 module SchedulesHelper
-  def sum_budgets(schedules)
-    schedules.sum { | schedule | schedule.budged.to_i }
-  end
-
   def fmt_schedule_date(date)
     return "" if date.nil?
     date.strftime("%Y/%-m/%-d/(%a) %-H:%M")
   end
 
-  def fmt_simple_date(date)
-    return date if date.is_a?(String)  # 文字列ならそのまま返す
+  def fmt_date_with_day(date)
+    return date if date.is_a?(String)
     date.strftime("%-m/%-d(%a)")
   end
 
@@ -29,36 +25,33 @@ module SchedulesHelper
     elsif schedule.start_date || schedule.end_date
       "#{fmt_schedule_date(schedule.start_date)} - #{fmt_schedule_date(schedule.end_date)}".strip
     else
-      "未定"
+      t("helpers.undecided")
     end
   end
 
   def fmt_schedule_datetime_duration(schedule)
-    if schedule.start_date && schedule.end_date
-      "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
-    elsif schedule.start_date || schedule.end_date
-      "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}".strip
-    else
-      "未定"
-    end
+    return t("helpers.undecided") unless schedule.start_date || schedule.end_date
+    "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
   end
 
   def fmt_all_day_schedule_datetime_duration(schedule)
-    if schedule.start_date && schedule.end_date
-      "#{fmt_date_with_datetime(schedule.start_date)} - #{fmt_date_with_datetime(schedule.end_date)}"
-    elsif schedule.start_date || schedule.end_date
-      "#{fmt_date_with_datetime(schedule.start_date)} - #{fmt_date_with_datetime(schedule.end_date)}".strip
-    else
-      "未定"
-    end
+    return t("helpers.undecided") unless schedule.start_date || schedule.end_date
+    "#{fmt_date_with_datetime(schedule.start_date)} - #{fmt_date_with_datetime(schedule.end_date)}"
   end
 
-  def desplay_value(data)
-    data.presence || ""
+
+  def schedule_spot_info(data)
+    return content_tag(:li, t(".no_data")) if data.nil?
+    content = []
+    content << content_tag(:li, data.name) if data.name.present?
+    content << content_tag(:li, data.telephone) if data.telephone.present?
+    content << content_tag(:li, data.address) if data.address.present?
+    safe_join(content)
   end
 
-  def display_memo(data)
-    data == "" ? "メモはありません" : data
+
+  def schedule_memo(data)
+    data.blank? ? t("schedules.helpers.no_memo") : data
   end
 
   def total_budget(schedules)

--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -1,5 +1,5 @@
 module TravelBooksHelper
-  def travel_book_desctiption(travel_book)
+  def travel_book_description(travel_book)
     travel_book.description || ""
   end
 
@@ -9,19 +9,19 @@ module TravelBooksHelper
     elsif travel_book.start_date || travel_book.end_date
       "#{fmt_date(travel_book.start_date) || ''} #{fmt_date(travel_book.end_date) || ''}".strip
     else
-      "未定"
+       t("helpers.undecided")
     end
   end
 
   def area_name(travel_book)
-    travel_book.area&.name || "未設定"
+    travel_book.area&.name || t("helpers.undecided")
   end
 
   def traveler_type_name(travel_book)
-    travel_book.traveler_type&.name || "未設定"
+    travel_book.traveler_type&.name || t("helpers.undecided")
   end
 
   def travel_book_is_public(travel_book)
-    travel_book.is_public ? "公開" : "未公開"
+    travel_book.is_public ? t("helpers.public") : t("helpers.unpublic")
   end
 end

--- a/app/views/check_lists/_form.html.erb
+++ b/app/views/check_lists/_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.label :title, class: "w-full" do %>
       <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
     <% end %>
-    <%= f.text_field :title, autofocus: true, placeholder: "購入品リスト", class: "input input-bordered w-full" %>
+    <%= f.text_field :title, autofocus: true, placeholder: t("check_lists.form.placeholder.title"), class: "input input-bordered w-full" %>
   </div>
   <div class="flex justify-end mt-5">
     <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -4,7 +4,7 @@
       <%= link_to travel_book_check_lists_path(@travel_book) do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3 class="flex-grow text-center">チェックリストを編集</h1>
+      <h3 class="flex-grow text-center"><%= t(".title") %></h1>
     </div>
     <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>

--- a/app/views/check_lists/index.html.erb
+++ b/app/views/check_lists/index.html.erb
@@ -2,9 +2,9 @@
   <% if @check_lists.present? %>
     <%= render @check_lists %>
   <% else %>
-    チェックリストはありません
+    <%= t(".no_data")%>
   <% end %>
 </div>
 <%= link_to new_travel_book_check_list_path, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-  新規作成
+  <%= t(".new_button")%>
 <% end %>

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -4,7 +4,7 @@
       <%= link_to travel_book_check_lists_path(@travel_book) do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3 class="flex-grow text-center">チェックリストを追加</h3>
+      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
     </div>
     <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -10,7 +10,7 @@
         <%= link_to edit_check_list_path(@check_list) do %>
           <i class="fa-solid fa-pen"></i>
         <% end %>
-        <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+        <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5" do %>
           <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>
@@ -23,7 +23,7 @@
             <%= render "list_items/list_item", list_item: list_item %>
           <% end %>
         <% else %>
-          <div>チェックリストは登録されていません</div>
+          <div><%= t(".no_data") %></div>
         <% end %>
       <% end %>
 

--- a/app/views/list_items/_add_button.html.erb
+++ b/app/views/list_items/_add_button.html.erb
@@ -1,5 +1,5 @@
 <div id="add_list_item_button">
   <%= link_to new_check_list_list_item_path(@check_list), class: "btn", data: { turbo_stream: true } do %>
-    <i class="fa-solid fa-circle-plus"></i>リストを追加
+    <i class="fa-solid fa-circle-plus"></i><%= t("list_items._add_button.new_button") %>
   <% end %>
 </div>

--- a/app/views/list_items/_add_button.html.erb
+++ b/app/views/list_items/_add_button.html.erb
@@ -1,5 +1,5 @@
 <div id="add_list_item_button">
   <%= link_to new_check_list_list_item_path(@check_list), class: "btn", data: { turbo_stream: true } do %>
-    <i class="fa-solid fa-circle-plus"></i><%= t("list_items._add_button.new_button") %>
+    <i class="fa-solid fa-circle-plus"></i><%= t(".new_button") %>
   <% end %>
 </div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: @list_item, url: @list_item.new_record? ? check_list_list_items_path(@check_list): list_item_path(@list_item) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
   <div class="flex gap-2">
-      <%= f.text_field :title, autofocus: true, placeholder: "リストのアイテムを追加", class: "input input-bordered w-full" %>
+      <%= f.text_field :title, autofocus: true, placeholder: t("list_items.form.placeholder.title"), class: "input input-bordered w-full" %>
     <div class="flex gap-2">
       <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn", data: { turbo_method: :post } do %>
         <i class="fa-solid fa-xmark"></i>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -10,7 +10,7 @@
           <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:text-base-300" do %>
             <i class="fa-solid fa-pen"></i>
           <% end %>
-          <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:text-base-300" do %>
+          <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "hover:text-base-300" do %>
             <i class="fa-solid fa-trash"></i>
           <% end %>
         <% end %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -21,15 +21,15 @@
 
   <%# 場所情報の登録フォーム %>
   <div class="field">
-    <%= f.label :name, Schedule.human_attribute_name(:name), class: "label" %>
+    <%= f.label :name, Spot.human_attribute_name(:name), class: "label" %>
     <%= f.text_field :name, class: "input input-bordered w-full" %>
   </div>
   <div class="field">
-    <%= f.label :telephone, Schedule.human_attribute_name(:telephone), class: "label" %>
+    <%= f.label :telephone, Spot.human_attribute_name(:telephone), class: "label" %>
     <%= f.text_field :telephone, class: "input input-bordered w-full" %>
   </div>
   <div class="field">
-    <%= f.label :address, Schedule.human_attribute_name(:address), class: "label" %>
+    <%= f.label :address, Spot.human_attribute_name(:address), class: "label" %>
     <%= f.text_field :address, class: "input input-bordered w-full" %>
   </div>
 

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,25 +1,24 @@
 <%= form_with model: @schedule_form, url: url do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
-    <div class="field mt-3">
-      <%= f.label :title, class: "w-full" do %>
-        <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
-      <% end %>
-      <%= f.text_field :title, autofocus: true, placeholder: "待ち合わせ", class: "input input-bordered w-full" %>
-    </div>
+  <div class="field mt-3">
+    <%= f.label :title, class: "w-full" do %>
+      <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
+    <% end %>
+    <%= f.text_field :title, autofocus: true, placeholder: t("schedules.form.placeholder.title"), class: "input input-bordered w-full" %>
+  </div>
 
-    <div class="mt-3 flex flex-col sm:flex-row gap-2">
-      <div class="w-full">
-        <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
-        <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
-      </div>
-      <div class="w-full">
-        <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
-        <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
-      </div>
+  <div class="mt-3 flex flex-col sm:flex-row gap-2">
+    <div class="w-full">
+      <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
+      <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
     </div>
+    <div class="w-full">
+      <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
+      <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
+    </div>
+  </div>
 
-  <%# 場所情報の登録フォーム %>
   <div class="field">
     <%= f.label :name, Spot.human_attribute_name(:name), class: "label" %>
     <%= f.text_field :name, class: "input input-bordered w-full" %>
@@ -37,13 +36,13 @@
     <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>
     <div class="flex items-center">
       <%= f.number_field :budged, class: "input input-bordered w-full" %>
-      <span class="ml-2">円</span>
+      <span class="ml-2"><%= t("helpers.currency_unit") %></span>
     </div>
   </div>
 
   <div class="field mt-3">
     <%= f.label :memo, Schedule.human_attribute_name(:memo), class: "label" %>
-    <%= f.text_area :memo, placeholder: "移動手段や観光地の情報などをメモ", rows: "3", class: "textarea textarea-bordered w-full" %>
+    <%= f.text_area :memo, placeholder: t("schedules.form.placeholder.memo"), rows: "3", class: "textarea textarea-bordered w-full" %>
   </div>
 
   <div class="flex justify-end mt-5">

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -4,7 +4,7 @@
       <%= link_to schedule_path(@schedule) do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3 class="flex-grow text-center">スケジュールを編集</h3>
+      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
     </div>
 
     <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -8,33 +8,33 @@
 
     <% if @schedules.present? %>
       <div role="tablist" class="tabs tabs-bordered">
-        <!-- 全日程タブを追加 -->
+        <!-- Tab for allday -->
         <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="ALL" checked="checked" />
         <div role="tabpanel" class="tab-content p-10">
           <% @schedules.each do |schedule| %>
             <%= render partial: "schedule", locals: { schedule: schedule, all_day: true } %>
           <% end %>
-          <p class="text-right my-5">合計金額：<%= total_budget(@schedules) %>円</p>
+          <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(@schedules)) %><%= t("helpers.currency_unit") %></p>
         </div>
 
-        <!-- 各日付ごとのタブ -->
+        <!-- Tab for each date -->
         <% Schedule.group_by_date(@schedules).each do |date, schedules| %>
-          <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_simple_date(date) %>" />
+          <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
           <div role="tabpanel" class="tab-content p-10">
             <% schedules.each do |schedule| %>
               <%= render partial: "schedule", locals: { schedule: schedule } %>
             <% end %>
-            <p class="text-right my-5">合計金額：<%= total_budget(schedules) %>円</p>
+            <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(schedules)) %><%= t("helpers.currency_unit") %></p>
           </div>
         <% end %>
       </div>
 
     <% else %>
-      <p class="text-center my-10">スケジュールを登録しましょう</p>
+      <p class="text-center my-10"><%= t(".no_data") %></p>
     <% end %>
 
     <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-      スケジュールを追加
+      <%= t(".new_button") %>
     <% end %>
   </div>
 </div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -5,7 +5,7 @@
       <%= link_to travel_book_schedules_path(@travel_book) do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3 class="flex-grow text-center">スケジュールを追加</h3>
+      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
     </div>
 
     <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -10,7 +10,7 @@
         <%= link_to edit_schedule_path(@schedule) do %>
           <i class="fa-solid fa-pen"></i>
         <% end %>
-        <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+        <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5" do %>
           <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>
@@ -22,28 +22,21 @@
         <p class="ml-2"><%= fmt_schedule_duration(@schedule) %></p>
       </div>
 
-      <div class="mt-5 flex items-center">
-        <i class="fa-solid fa-location-dot"></i>
+      <div class="mt-5 flex">
+        <i class="fa-solid fa-location-dot mt-1"></i>
         <div class="ml-2">
-          <% if @schedule.spot.present? %>
-            <p><%= desplay_value(@schedule.spot.name) %></p>
-            <p><%= desplay_value(@schedule.spot.telephone) %></p>
-            <p><%= desplay_value(@schedule.spot.post_code) %></p>
-            <p><%= desplay_value(@schedule.spot.address) %></p>
-          <% else %>
-            <p>場所は登録されていません</p>
-          <% end %>
+          <ul><%= schedule_spot_info(@schedule.spot) %></ul>
         </div>
       </div>
 
       <div class="mt-5 flex items-center">
         <i class="fa-solid fa-wallet"></i>
-        <p class="ml-2"><%= @schedule.budged %>円</p>
+        <p class="ml-2"><%= @schedule.budged %><%= t("helpers.currency_unit") %></p>
       </div>
 
       <div class="mt-5 flex items-start">
         <i class="fa-solid fa-file-pen mt-1"></i>
-        <p class="ml-2"><%= display_memo(@schedule.memo) %></p>
+        <p class="ml-2"><%= schedule_memo(@schedule.memo) %></p>
       </div>
     </div>
   </div>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -5,12 +5,12 @@
     <%= f.label :title, class: "w-full" do %>
       <span class="text-red-400">*</span><%= TravelBook.human_attribute_name(:title) %>
     <% end %>
-    <%= f.text_field :title, autofocus: true, placeholder: t("travel_books.form.placeholder.title"), class: "input input-bordered w-full" %>
+    <%= f.text_field :title, autofocus: true, placeholder: t(".placeholder.title"), class: "input input-bordered w-full" %>
   </div>
 
   <div class="field mt-3">
     <%= f.label :description, TravelBook.human_attribute_name(:description), class: "label" %>
-    <%= f.text_area :description, placeholder: t("travel_books.form.placeholder.description"), rows: "1", class: "textarea textarea-bordered w-full" %>
+    <%= f.text_area :description, placeholder: t(".placeholder.description"), rows: "1", class: "textarea textarea-bordered w-full" %>
   </div>
 
   <div class="mt-3 flex flex-col sm:flex-row gap-2">
@@ -53,11 +53,11 @@
     <div class="flex items-center gap-3">
       <div class="flex items-center gap-1">
         <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary" %>
-        <%= f.label :is_public_true, t("travel_books.form.is_public.true"), for: "is_public_true" %>
+        <%= f.label :is_public_true, t(".is_public.true"), for: "is_public_true" %>
       </div>
       <div class="flex items-center gap-1">
         <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: "checked" %>
-        <%= f.label :is_public_false, t("travel_books.form.is_public.false"), for: "is_public_false" %>
+        <%= f.label :is_public_false, t(".is_public.false"), for: "is_public_false" %>
       </div>
     </div>
   </div>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -3,39 +3,39 @@
 
   <div class="field mt-3">
     <%= f.label :title, class: "w-full" do %>
-      <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
+      <span class="text-red-400">*</span><%= TravelBook.human_attribute_name(:title) %>
     <% end %>
     <%= f.text_field :title, autofocus: true, placeholder: "春の東京観光", class: "input input-bordered w-full" %>
   </div>
 
   <div class="field mt-3">
-    <%= f.label :description, Schedule.human_attribute_name(:description), class: "label" %>
+    <%= f.label :description, TravelBook.human_attribute_name(:description), class: "label" %>
     <%= f.text_area :description, placeholder: "旅行やおでかけの説明を記入", rows: "1", class: "textarea textarea-bordered w-full" %>
   </div>
 
   <div class="mt-3 flex flex-col sm:flex-row gap-2">
     <div class="w-full">
-      <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
+      <%= f.label :start_date, TravelBook.human_attribute_name(:start_date), class: "label" %>
       <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
     </div>
     <div class="w-full">
-      <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
+      <%= f.label :end_date, TravelBook.human_attribute_name(:end_date), class: "label" %>
       <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
     </div>
   </div>
 
   <div class="field mt-3">
-    <%= f.label :area_id, Schedule.human_attribute_name(:area_id), class: "label" %>
+    <%= f.label :area_id, TravelBook.human_attribute_name(:area), class: "label" %>
     <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "select select-bordered w-full max-w-xs" } %>
   </div>
 
   <div class="field mt-3">
-    <%= f.label :traveler_type_id, Schedule.human_attribute_name(:traveler_type_id), class: "label" %>
+    <%= f.label :traveler_type_id, TravelBook.human_attribute_name(:traveler_type), class: "label" %>
     <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "select select-bordered w-full max-w-xs" } %>
   </div>
 
   <div class="field mt-3">
-    <%= f.label :travel_book_image, Schedule.human_attribute_name(:travel_book_image), class: "label" %>
+    <%= f.label :travel_book_image, TravelBook.human_attribute_name(:travel_book_image), class: "label" %>
     <%= f.file_field :travel_book_image, accept: "image/*", class: "file-input file-input-bordered w-full max-w-xs" %>
     <%= f.hidden_field :travel_book_image_cache %>
   </div>
@@ -49,7 +49,7 @@
   </div>
 
   <div class="field mt-3">
-    <%= f.label :is_public, Schedule.human_attribute_name(:is_public), class: "label" %>
+    <%= f.label :is_public, TravelBook.human_attribute_name(:is_public), class: "label" %>
     <div class="flex items-center gap-3">
       <div class="flex items-center gap-1">
         <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary" %>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -5,12 +5,12 @@
     <%= f.label :title, class: "w-full" do %>
       <span class="text-red-400">*</span><%= TravelBook.human_attribute_name(:title) %>
     <% end %>
-    <%= f.text_field :title, autofocus: true, placeholder: "春の東京観光", class: "input input-bordered w-full" %>
+    <%= f.text_field :title, autofocus: true, placeholder: t("travel_books.form.placeholder.title"), class: "input input-bordered w-full" %>
   </div>
 
   <div class="field mt-3">
     <%= f.label :description, TravelBook.human_attribute_name(:description), class: "label" %>
-    <%= f.text_area :description, placeholder: "旅行やおでかけの説明を記入", rows: "1", class: "textarea textarea-bordered w-full" %>
+    <%= f.text_area :description, placeholder: t("travel_books.form.placeholder.description"), rows: "1", class: "textarea textarea-bordered w-full" %>
   </div>
 
   <div class="mt-3 flex flex-col sm:flex-row gap-2">
@@ -26,12 +26,12 @@
 
   <div class="field mt-3">
     <%= f.label :area_id, TravelBook.human_attribute_name(:area), class: "label" %>
-    <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: "選択してください" }, { class: "select select-bordered w-full max-w-xs" } %>
+    <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: t("helpers.prompt.select") }, { class: "select select-bordered w-full max-w-xs" } %>
   </div>
 
   <div class="field mt-3">
     <%= f.label :traveler_type_id, TravelBook.human_attribute_name(:traveler_type), class: "label" %>
-    <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: "選択してください" }, { class: "select select-bordered w-full max-w-xs" } %>
+    <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: t("helpers.prompt.select") }, { class: "select select-bordered w-full max-w-xs" } %>
   </div>
 
   <div class="field mt-3">
@@ -53,11 +53,11 @@
     <div class="flex items-center gap-3">
       <div class="flex items-center gap-1">
         <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary" %>
-        <%= f.label :is_public_true, "公開", for: "is_public_true" %>
+        <%= f.label :is_public_true, t("travel_books.form.is_public.true"), for: "is_public_true" %>
       </div>
       <div class="flex items-center gap-1">
         <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: "checked" %>
-        <%= f.label :is_public_false, "非公開", for: "is_public_false" %>
+        <%= f.label :is_public_false, t("travel_books.form.is_public.false"), for: "is_public_false" %>
       </div>
     </div>
   </div>

--- a/app/views/travel_books/_my_travel_book.html.erb
+++ b/app/views/travel_books/_my_travel_book.html.erb
@@ -7,11 +7,11 @@
       <div class="card-body flex flex-col items-center justify-center text-center">
         <h2 class="card-title"><%= travel_book.title %></h2>
         <div class="flex items-center justify-center gap-2">
-          <div class="badge">出発</div>
+          <div class="badge"><%= t(".departure") %></div>
           <p><%= fmt_date(travel_book.start_date) %></p>
         </div>
         <div class="flex items-center justify-center gap-2">
-          <div class="badge">到着</div>
+          <div class="badge"><%= t(".arrival") %></div>
           <p><%= fmt_date(travel_book.end_date) %></p>
         </div>
       </div>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -4,7 +4,7 @@
       <%= link_to travel_book_path(@travel_book) do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3 class="flex-grow text-center">しおりを編集</h3>
+      <h3 class="flex-grow text-center"><%= t(".title")%></h3>
     </div>
 
     <%= render "form", travel_book: @travel_book %>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -7,12 +7,12 @@
         <%= render @travel_books %>
       <% end %>
     <% else %>
-      しおりがありません
+      <%= t(".no_data") %>
     <% end %>
   </div>
   <%if params[:scope] == "own" %>
     <%= link_to new_travel_book_path, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-      新規作成
+      <%= t(".new_button") %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -4,7 +4,7 @@
       <%= link_to travel_books_path do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
-      <h3 class="flex-grow text-center">しおりを追加</h3>
+      <h3 class="flex-grow text-center"><%= t(".title")%></h3>
     </div>
 
     <%= render "form", travel_book: @travel_book %>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -13,32 +13,32 @@
               <%= link_to edit_travel_book_path(@travel_book) do %>
                 <i class="fa-solid fa-pen"></i>
               <% end %>
-              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "ml-5" do %>
+              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5" do %>
                 <i class="fa-solid fa-trash"></i>
               <% end %>
             </div>
           <% end %>
         </div>
 
-        <div><%= travel_book_desctiption(@travel_book) %></div>
+        <div><%= travel_book_description(@travel_book) %></div>
 
         <div class="mt-3">
-          <div class="font-bold">期間</div>
+          <div class="font-bold"><%= t(".duration") %></div>
           <div><%= travel_book_duration(@travel_book)%></div>
         </div>
 
         <div class="mt-3">
-          <div class="font-bold">エリア</div>
+          <div class="font-bold"><%= TravelBook.human_attribute_name(:area) %></div>
           <div><%= area_name(@travel_book) %></div>
         </div>
 
         <div class="mt-3">
-          <div class="font-bold">旅行タイプ</div>
+          <div class="font-bold"><%= TravelBook.human_attribute_name(:traveler_type) %></div>
           <div><%= traveler_type_name(@travel_book) %></div>
         </div>
 
         <div class="mt-3">
-          <div class="font-bold">公開設定</div>
+          <div class="font-bold"><%= TravelBook.human_attribute_name(:is_public) %></div>
           <div><%= travel_book_is_public(@travel_book) %></div>
         </div>
       </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="form-container rounded-lg shadow-md bg-white p-8">
-    <h2>Forgot your password?</h2>
+    <h2><%= t(".title") %></h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
       <%= render "users/shared/error_messages", resource: resource %>
@@ -14,10 +14,14 @@
       </div>
 
       <div class="actions">
-        <%= f.submit "Send me reset password instructions", class: "btn btn-primary w-full mt-6 mx-auto" %>
+        <%= f.submit t(".send"), class: "btn btn-primary w-full mt-6 mx-auto" %>
       </div>
     <% end %>
 
-    <%= render "users/shared/links" %>
+    <%- if controller_name != 'sessions' %>
+      <div class="text-center my-3">
+        <%= link_to t(".login_page"), new_session_path(resource_name), class: "underline" %><br />
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,37 +1,36 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6 flex flex-col items-center">
-  <h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
 
-   <%= image_tag(@user.icon_image? ? @user.icon_image_url : "default_icon.png",
-    class: "mt-10 rounded-full w-20 h-20 shadow-md object-cover border border-gray-200") %>
+    <h3><%= t(".title") %></h3>
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+    <%= image_tag(@user.icon_image? ? @user.icon_image_url : "default_icon.png",
+      class: "mx-auto mt-10 rounded-full w-20 h-20 shadow-md object-cover border border-gray-200") %>
 
-    <div class="mt-5 grid grid-cols-1">
-        <%= f.label :icon_image, class: "block text-sm/6 font-medium text-gray-900" %>
-        <div class="mt-2 grid grid-cols-1">
-          <%= f.file_field :icon_image, accept: "image/*", class: "" %>
-          <%= f.hidden_field :icon_image_cache %>
-        </div>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "users/shared/error_messages", resource: resource %>
+
+    <div class="field mt-3">
+      <%= f.label :icon_image, User.human_attribute_name(:icon_image), class: "label" %>
+      <%= f.file_field :icon_image, accept: "image/*", class: "file-input file-input-bordered w-full max-w-xs" %>
+      <%= f.hidden_field :icon_image_cache %>
     </div>
 
-    <div class="mt-10 grid grid-cols-1">
-      <%= f.label :name, class: "block text-sm/6 font-medium text-gray-900" %>
-      <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
-        <%= f.text_field :name, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
-      </div>
+    <div class="field mt-3">
+      <%= f.label :name, class: "w-full" do %>
+        <span class="text-red-400">*</span><%= User.human_attribute_name(:name) %><i class="fa-solid fa-user ml-1"></i>
+      <% end %>
+      <%= f.text_field :name, placeholder: t("users.form.placeholder.name"), class: "input input-bordered w-full" %>
     </div>
 
-    <div class="mt-10 grid grid-cols-1">
-      <%= f.label :email, class: "block text-sm/6 font-medium text-gray-900" %>
-      <div class="flex items-center rounded-md bg-white pl-3 outline outline-1 -outline-offset-1 outline-gray-300 focus-within:outline focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600">
-        <%= f.email_field :email, class: "block min-w-0 grow py-1.5 pl-1 pr-3 text-base text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-0 sm:text-sm/6" %>
-      </div>
+    <div class="field mt-3">
+      <%= f.label :email, class: "w-full" do %>
+        <span class="text-red-400">*</span><%= User.human_attribute_name(:email) %><i class="fa-solid fa-envelope"></i>
+      <% end %>
+      <%= f.email_field :email, placeholder: t("users.form.placeholder.email"), class: "input input-bordered w-full" %>
     </div>
 
-  <div class="mt-10 flex gap-2 justify-center">
-    <%= link_to "Back", :back, class: "btn" %>
-    <%= f.submit "Update", class: "btn" %><% end %>
+      <%= f.submit nil, class: "btn btn-primary w-full mt-3 mx-auto" %>
+      <%= link_to t("helpers.back"), :back, class: "btn btn-ghost border-primary w-full mt-3 mx-auto" %>
+    <% end %>
   </div>
-
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,44 +1,44 @@
 <div class="container">
   <div class="form-container rounded-lg shadow-md bg-white p-8">
-    <h2>アカウント登録</h2>
+    <h2><%= t(".title") %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render "users/shared/error_messages", resource: resource %>
 
       <div class="field mt-3">
         <div class="flex items-center gap-1">
-          <%= f.label :name, class: "label" %>
+          <%= f.label :name, User.human_attribute_name(:name), class: "label" %>
           <i class="fa-solid fa-user"></i>
         </div>
-        <%= f.text_field :name, placeholder: "アカウント名", class: "input input-bordered w-full" %>
+        <%= f.text_field :name, placeholder: t("users.form.placeholder.name"), class: "input input-bordered w-full" %>
       </div>
 
       <div class="field mt-3">
         <div class="flex items-center gap-1">
-          <%= f.label :email, class: "label" %>
+          <%= f.label :email, User.human_attribute_name(:email), class: "label" %>
           <i class="fa-solid fa-envelope"></i>
         </div>
-        <%= f.email_field :email, autocomplete: "email", placeholder: "tabiclip@example.com", class: "input input-bordered w-full" %>
+        <%= f.email_field :email, autocomplete: "email", placeholder: t("users.form.placeholder.email"), class: "input input-bordered w-full" %>
       </div>
 
       <div class="field mt-3">
         <div class="flex items-center gap-1">
-          <%= f.label :password, class: "label" %>
+          <%= f.label :password, User.human_attribute_name(:password), class: "label" %>
           <i class="fa-solid fa-key"></i>
         </div>
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "半角英数6文字以上", class: "input input-bordered w-full" %>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: t("users.form.placeholder.password"), class: "input input-bordered w-full" %>
       </div>
 
       <div class="field mt-3">
         <div class="flex items-center gap-1">
-          <%= f.label :password_confirmation, class: "label" %>
+          <%= f.label :password_confirmation, User.human_attribute_name(:password_confirmation), class: "label" %>
           <i class="fa-solid fa-key"></i>
         </div>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "半角英数6文字以上", class: "input input-bordered w-full" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: t("users.form.placeholder.password"), class: "input input-bordered w-full" %>
       </div>
 
       <div class="actions">
-        <%= f.submit "Sign up", class: "btn btn-primary w-full mt-6 mx-auto" %>
+        <%= f.submit t(".submit"), class: "btn btn-primary w-full mt-6 mx-auto" %>
       </div>
     <% end %>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="form-container rounded-lg shadow-md bg-white p-8">
-    <h2>ログイン</h2>
+    <h2><%= t(".title") %></h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
@@ -9,7 +9,7 @@
           <%= f.label :email, class: "label" %>
           <i class="fa-solid fa-envelope"></i>
         </div>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "tabiclip@example.com", class: "input input-bordered w-full" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: t("users.form.placeholder.email"), class: "input input-bordered w-full" %>
       </div>
 
       <div class="field mt-3">
@@ -17,7 +17,7 @@
           <%= f.label :password, class: "label" %>
           <i class="fa-solid fa-key"></i>
         </div>
-        <%= f.password_field :password, autocomplete: "current-password", placeholder: "半角英数6文字以上", class: "input input-bordered w-full" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full" %>
       </div>
 
       <% if devise_mapping.rememberable? %>
@@ -28,10 +28,9 @@
       <% end %>
 
       <div class="actions">
-        <%= f.submit "Log in", class: "btn btn-primary w-full mt-6 mx-auto" %>
+        <%= f.submit t(".submit"), class: "btn btn-primary w-full mt-6 mx-auto" %>
       </div>
     <% end %>
-
     <%= render "users/shared/links" %>
   </div>
 </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,16 +1,16 @@
 <%- if controller_name != 'sessions' %>
   <div class="text-center my-3">
-    <%= link_to "ログインページはこちら", new_session_path(resource_name), class: "underline" %><br />
+    <%= link_to t(".login_page"), new_session_path(resource_name), class: "underline" %><br />
   </div>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: "btn btn-ghost border-primary w-full my-3 mx-auto" %><br />
+  <%= link_to t(".signup"), new_registration_path(resource_name), class: "btn btn-ghost border-primary w-full my-3 mx-auto" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <div class="text-center my-3">
-    <%= link_to "Forgot your password?", new_password_path(resource_name), class: "underline" %><br />
+    <%= link_to t(".forgot_pass"), new_password_path(resource_name), class: "underline" %><br />
   </div>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,16 +1,18 @@
-<div class="bg-white rounded-lg shadow-md p-6 m-6 flex flex-col items-center">
+<div class="container">
+  <div class="form-container bg-white rounded-lg shadow-md p-8">
 
-  <%= image_tag(@user.icon_image? ? @user.icon_image_url : "default_icon.png",
-    class: "rounded-full w-24 h-24 shadow-md object-cover border border-gray-200") %>
+    <%= image_tag(@user.icon_image? ? @user.icon_image_url : "default_icon.png",
+      class: "mx-auto rounded-full w-20 h-20 shadow-md object-cover border border-gray-200") %>
 
-  <h1 class="mt-2 text-center text-lg font-bold"><%= @user.name %></h2>
+    <h1 class="mt-2 text-center text-lg font-bold"><%= @user.name %></h2>
 
-  <div class="mt-5 flex gap-2">
-    <p>メールアドレス</p>
-    <p><%= @user.email %></p>
-  </div>
+    <div class="mt-5 flex justify-center gap-2">
+      <p><%= User.human_attribute_name(:email) %></p>
+      <p><%= @user.email %></p>
+    </div>
 
-  <div class="mt-10 text-center">
-    <%= link_to "edit", edit_user_registration_path, class: "btn rounded-btn" %>
+    <div class="mt-5">
+      <%= link_to t(".profile_button"), edit_user_registration_path, class: "btn btn-primary w-full mt-6 mx-auto" %>
+    </div>
   </div>
 </div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,6 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate
+# bundle exec rails db:migrate
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
+bundle exec rake db:seed

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,5 +4,5 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 # bundle exec rails db:migrate
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
-bundle exec rake db:seed
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
+bundle exec rails db:seed

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module Myapp
       g.helper false
       g.test_framework nil
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,44 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      travel_book: しおり
+      schedule: スケジュール
+      spot: 場所
+      area: エリア
+      check_list: チェックリスト
+      list_item: リストアイテム
+      traveler_type: 旅行スタイル
+    attributes:
+      user:
+        name: 名前
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード確認
+      travel_book:
+        title: タイトル
+        description: 旅行の説明
+        is_public: 公開設定
+        start_date: 開始日
+        end_date: 終了日
+        travel_book_image: 画像
+        area: エリア
+        traveler_type: 旅行スタイル
+      area:
+        name: エリア名
+      traveler_type:
+        name: 旅行スタイル
+      schedule:
+        title: タイトル
+        budged: 予算
+        memo: メモ
+        start_date: 開始時刻
+        end_date: 終了時刻
+      spot:
+        name: 場所名
+        telephone: 電話番号
+        address: 住所
+      check_list:
+        title: タイトル
+      list_items:
+        title: タイトル

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,7 +1,6 @@
 ja:
   activerecord:
     models:
-      user: ユーザー
       travel_book: しおり
       schedule: スケジュール
       spot: 場所
@@ -10,11 +9,6 @@ ja:
       list_item: リストアイテム
       traveler_type: 旅行スタイル
     attributes:
-      user:
-        name: 名前
-        email: メールアドレス
-        password: パスワード
-        password_confirmation: パスワード確認
       travel_book:
         title: タイトル
         description: 旅行の説明

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,70 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        name: ユーザー名
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        icon_image: アイコン
+        remember_me: ログイン状態を保持
+  devise:
+    failure:
+      already_authenticated: "すでにログインしています"
+      inactive: "アカウントが有効化されていません"
+      invalid: "%{authentication_keys} またはパスワードが無効です"
+      locked: "アカウントがロックされています"
+      last_attempt: "アカウントがロックされる前にあと1回試行できます"
+      not_found_in_database: "%{authentication_keys} またはパスワードが無効です"
+      timeout: "セッションが期限切れのため再度ログインが必要です"
+      unauthenticated: "ログインが必要です"
+      unconfirmed: "メールアドレスの確認後に続行できます"
+    mailer:
+      confirmation_instructions:
+        subject: "確認手順"
+      reset_password_instructions:
+        subject: "パスワードリセット手順"
+      unlock_instructions:
+        subject: "ロック解除手順"
+      email_changed:
+        subject: "メールアドレスを変更しました"
+      password_change:
+        subject: "パスワードを変更しました"
+    omniauth_callbacks:
+      failure: '%{kind} アカウントでログインできませんでした: \"%{reason}\"'
+      success: "%{kind} アカウントでログインしました"
+    passwords:
+      no_token: "パスワード再設定メールからアクセス可能なページです。提供された完全なURLを使用したことを確認してください。"
+      send_instructions: "パスワード再設定の手順を数分以内にメールで送信します"
+      send_paranoid_instructions: "パスワード再設定の手順を数分以内にメールで送信します"
+      updated: "パスワードを変更しました"
+      updated_not_active: "パスワードを変更しました"
+    registrations:
+      destroyed: "アカウントを削除しました"
+      signed_up: "アカウントを作成しました"
+      signed_up_but_inactive: "アカウントを作成しましたが、アカウントが有効化されていないためログインできませんでした"
+      signed_up_but_locked: "アカウントを作成しましたが、アカウントがロックされているためログインできませんでした"
+      signed_up_but_unconfirmed: "送信されたメールの確認リンクをクリックしてアカウントを有効化してください"
+      update_needs_confirmation: "アカウントを更新したので、新しいメールアドレスの確認が必要です。送信されたメールの確認リンクを開いてください。"
+      updated: "アカウントを更新しました"
+      updated_but_not_signed_in: "パスワードが変更されたため再度ログインしてください"
+    sessions:
+      signed_in: "ログインしました"
+      signed_out: "ログアウトしました"
+      already_signed_out: "ログアウトしました"
+    unlocks:
+      send_instructions: "アカウントのロック解除手順を数分以内にメールで送信します"
+      send_paranoid_instructions: "アカウントのロック解除手順を数分以内にメールで送信します"
+      unlocked: "アカウントのロックを解除したため、ログインしてください"
+  errors:
+    messages:
+      already_confirmed: "すでに確認されているため、ログインをお試しください"
+      confirmation_period_expired: "確認は %{period} 内に完了する必要があるため、新しい確認リンクをリクエストしてください"
+      expired: "期限が切れたため、新しいリンクをリクエストしてください"
+      not_found: "見つかりませんでした"
+      not_locked: "ロックされていません"
+      not_saved:
+        one: "%{resource} は保存されませんでした: 1つのエラーがあります"
+        other: "%{resource} は保存されませんでした: %{count} のエラーがあります"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,8 @@ ja:
     submit:
       create: 登録
       update: 更新
+      submit: 保存
+    back: 前の画面に戻る
     total_amount: "合計金額：%{amount}"
     currency_unit: 円
     undecided: 未定
@@ -13,6 +15,33 @@ ja:
   defaults:
     delete_confirm: 削除しますか？
   users:
+    form:
+      placeholder:
+        name: アカウント名
+        email: tabiclip@example.com
+        password: 半角英数6文字以上
+    shared:
+      links:
+        signup: アカウントを作成
+        forgot_pass: パスワードをお忘れの方はこちら
+        login_page: ログインページはこちら
+    sessions:
+      new:
+        title: ログイン
+        submit: ログイン
+    registrations:
+      new:
+        title: アカウント登録
+        submit: アカウントを作成
+      edit:
+        title: プロフィール編集
+    passwords:
+      new:
+        title: パスワード再設定
+        send: 送信
+        login_page: ログインページはこちら
+    show:
+      profile_button: プロフィールを編集
   travel_books:
     index:
       no_data: しおりがありません
@@ -23,7 +52,7 @@ ja:
       title: しおり作成
     edit:
       title: しおり編集
-    _my_travel_book:
+    my_travel_book:
       departure: 出発
       arrival: 到着
     form:
@@ -69,5 +98,5 @@ ja:
     form:
       placeholder:
         title: 項目名を記入
-    _add_button:
+    add_button:
       new_button: 項目を追加

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,35 @@
+ja:
+  helpers:
+    prompt:
+      select: 選択してください
+    submit:
+      create: 登録
+      update: 更新
+    total_amount: "合計金額：%{amount}"
+    currency_unit: 円
+    undecided: 未定
+    public: 公開
+    unpublic: 未公開
+  defaults:
+    delete_confirm: 削除しますか？
+  users:
+  travel_books:
+    index:
+      no_data: しおりがありません
+      new_button: しおり作成
+    show:
+      duration: 期間
+    new:
+      title: しおり作成
+    edit:
+      title: しおり編集
+    _my_travel_book:
+      departure: 出発
+      arrival: 到着
+    form:
+      placeholder:
+        title: 旅行のタイトルを記入
+        description: 旅行の説明を記入
+      is_public:
+        true: 公開
+        false: 非公開

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,3 +33,22 @@ ja:
       is_public:
         true: 公開
         false: 非公開
+  schedules:
+    index:
+      new_button: スケジュール作成
+      no_data: スケジュールを登録しましょう
+    show:
+      no_data: 場所の登録はありません
+    new:
+      title: スケジュール作成
+    edit:
+      title: スケジュール編集
+    form:
+      placeholder:
+        title: スケジュールのタイトルを記入
+        memo: 移動手段や観光地の情報などのメモを記入
+      is_public:
+        true: 公開
+        false: 非公開
+    helpers:
+      no_memo: メモはありません

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -52,3 +52,16 @@ ja:
         false: 非公開
     helpers:
       no_memo: メモはありません
+  check_lists:
+    index:
+      new_button: チェックリスト作成
+      no_data: チェックリストはありません
+    show:
+      no_data: チェックリストに項目を追加しましょう
+    new:
+      title: チェックリスト作成
+    edit:
+      title: チェックリスト編集
+    form:
+      placeholder:
+        title: チェックリストのタイトルを記入

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -65,3 +65,9 @@ ja:
     form:
       placeholder:
         title: チェックリストのタイトルを記入
+  list_items:
+    form:
+      placeholder:
+        title: 項目名を記入
+    _add_button:
+      new_button: 項目を追加

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions",
-    passwords: "users/passwords",
+    passwords: "users/passwords"
   }
   get "users/profile" => "users#show"
   get "home/index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
-    sessions: "users/sessions"
+    sessions: "users/sessions",
+    passwords: "users/passwords",
   }
   get "users/profile" => "users#show"
   get "home/index"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,19 +11,19 @@
 # Areasテーブルに値を格納
 ApplicationRecord.transaction do
 areas = [
-  { id: 1, name: "Hokkaido" },
-  { id: 2, name: "Tohoku" },
-  { id: 3, name: "KitaKanto" },
-  { id: 4, name: "Syutoken" },
-  { id: 5, name: "Koshinetsu" },
-  { id: 6, name: "Tokai" },
-  { id: 7, name: "Hokuriku" },
-  { id: 8, name: "Kinki" },
-  { id: 9, name: "SaninSanyou" },
-  { id: 10, name: "Shikoku" },
-  { id: 11, name: "Kyushu" },
-  { id: 12, name: "Okinawa" },
-  { id: 13, name: "other" }
+  { id: 1, name: "北海道" },
+  { id: 2, name: "東北" },
+  { id: 3, name: "北関東" },
+  { id: 4, name: "首都圏" },
+  { id: 5, name: "甲信越" },
+  { id: 6, name: "東海" },
+  { id: 7, name: "北陸" },
+  { id: 8, name: "近畿" },
+  { id: 9, name: "山陰・山陽" },
+  { id: 10, name: "四国" },
+  { id: 11, name: "九州" },
+  { id: 12, name: "沖縄" },
+  { id: 13, name: "その他" }
 ]
 
   areas.each do |area|
@@ -34,11 +34,11 @@ areas = [
 
   # TravelerTypesテーブルに値を格納
   traveler_types = [
-    { id: 1, name: "family" },
-    { id: 2, name: "friends" },
-    { id: 3, name: "alone" },
-    { id: 4, name: "couple" },
-    { id: 5, name: "other" }
+    { id: 1, name: "家族" },
+    { id: 2, name: "友人" },
+    { id: 3, name: "一人旅" },
+    { id: 4, name: "夫婦・カップル" },
+    { id: 5, name: "その他" }
   ]
 
   traveler_types.each do | traveler_type |


### PR DESCRIPTION
# 概要
i18nを導入し、日本語に対応させます。

## 実施内容
- [x] gem i18n ~> 7.0.0をインストール
- [x] i18nのデフォルト言語設定
- [x] config/locales/activerecord/ja.ymlの作成とformへの反映
- [x] config/locales/views/ja.ymlの作成と以下ビューファイルのi18n対応
  - travel_books
  - schedules
  - check_lists
  - list_items
  - devise関連
    - config/locales/devise.ja.yml の作成
    - registrations
    - passwords
    - sessions
    - shared
    - users
- [x] seedファイル内のデータを日本語に修正
- [x] Renderのビルドスクリプト(bin/render-build.sh)でDBのリセットとseedファイルの適用設定

## 未実施内容
- ヘッダーのi18n対応
- ボトムナビゲーションのi18n対応

## 補足
ヘッダーとボトムナビゲーションはこの後変更予定のため、i18n対応しておりません。

seedファイル内のデータを日本語に修正したため、今回のデプロイで本番環境のRenderのDBをリセットしてseedを適用します。(次のデプロイでビルドスクリプトをもとに戻します)

## 関連issue
#23 