### PR TITLE
Fix/しおりの開始日と終了日のカラムの型を修正

### DIFF
--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -4,13 +4,8 @@ module TravelBooksHelper
   end
 
   def travel_book_duration(travel_book)
-    if travel_book.start_date && travel_book.end_date
-      "#{fmt_date(travel_book.start_date)} - #{fmt_date(travel_book.end_date)}"
-    elsif travel_book.start_date || travel_book.end_date
-      "#{fmt_date(travel_book.start_date) || ''} #{fmt_date(travel_book.end_date) || ''}".strip
-    else
-       t("helpers.undecided")
-    end
+    return t("helpers.undecided") unless travel_book.start_date || travel_book.end_date
+    "#{fmt_date(travel_book.start_date)} - #{fmt_date(travel_book.end_date)}"
   end
 
   def area_name(travel_book)

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -16,11 +16,11 @@
   <div class="mt-3 flex flex-col sm:flex-row gap-2">
     <div class="w-full">
       <%= f.label :start_date, TravelBook.human_attribute_name(:start_date), class: "label" %>
-      <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
+      <%= f.date_field :start_date, class: "input input-bordered w-full" %>
     </div>
     <div class="w-full">
       <%= f.label :end_date, TravelBook.human_attribute_name(:end_date), class: "label" %>
-      <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
+      <%= f.date_field :end_date, class: "input input-bordered w-full" %>
     </div>
   </div>
 

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,6 +3,6 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-# bundle exec rails db:migrate
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
-bundle exec rails db:seed
+bundle exec rails db:migrate
+# DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
+# bundle exec rails db:seed

--- a/db/migrate/20250212130313_change_start_date_column_to_travel_books.rb
+++ b/db/migrate/20250212130313_change_start_date_column_to_travel_books.rb
@@ -1,0 +1,6 @@
+class ChangeStartDateColumnToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    change_column :travel_books, :start_date, :date
+    change_column :travel_books, :end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_07_085338) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_12_130313) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
# 概要
travel_booksテーブルのstart_dateカラムとend_dateカラムをdatetime型からdate型へ修正しました。

## 実施内容
- [x] カラム変更用のマイグレーションファイルを生成
- [x] マイグレーションファイルの適用
- [x] TravelBooksHeperのtravel_book_durationメソッドの不要な処理を削除
- [x] Renderビルドスクリプトを元の内容に戻す

## 未実施内容
なし

## 補足
以前(#23 )で修正したseedを適用するためにビルドスクリプトを書き換えたため、
今回のコミットで元の内容に戻します。

## 関連issue
#111 