### PR TITLE
Feature/flashメッセージ機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  add_flash_types :success, :error
 
   def set_travel_book
     @travel_book = TravelBook.find(params[:id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-  add_flash_types :success, :error
 
   def set_travel_book
     @travel_book = TravelBook.find(params[:id])

--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -16,7 +16,7 @@ class CheckListsController < ApplicationController
     if @check_list.save
       redirect_to travel_book_check_lists_path(@travel_book), success: t("defaults.flash_message.created", item: CheckList.model_name.human)
     else
-      flash.now[:error] = t("defaults.flash_message.not_created", item: CheckList.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: CheckList.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -32,7 +32,7 @@ class CheckListsController < ApplicationController
     if @check_list.update(check_list_param)
       redirect_to check_list_path(@check_list), success: t("defaults.flash_message.updated", item: CheckList.model_name.human)
     else
-      flash.now[:error] = t("defaults.flash_message.not_updated", item: CheckList.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: CheckList.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -14,8 +14,9 @@ class CheckListsController < ApplicationController
     @check_list = @travel_book.check_lists.build(check_list_param)
 
     if @check_list.save
-      redirect_to travel_book_check_lists_path(@travel_book)
+      redirect_to travel_book_check_lists_path(@travel_book), success: t("defaults.flash_message.created", item: CheckList.model_name.human)
     else
+      flash.now[:error] = t("defaults.flash_message.not_created", item: CheckList.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -29,15 +30,16 @@ class CheckListsController < ApplicationController
 
   def update
     if @check_list.update(check_list_param)
-      redirect_to check_list_path(@check_list)
+      redirect_to check_list_path(@check_list), success: t("defaults.flash_message.updated", item: CheckList.model_name.human)
     else
+      flash.now[:error] = t("defaults.flash_message.not_updated", item: CheckList.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @check_list.destroy!
-    redirect_to travel_book_check_lists_path(@travel_book)
+    redirect_to travel_book_check_lists_path(@travel_book), success: t("defaults.flash_message.deleted", item: CheckList.model_name.human)
   end
 
   private

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -8,27 +8,31 @@ class ListItemsController < ApplicationController
 
   def create
     @list_item = @check_list.list_items.build(list_item_params)
-
-    if @list_item.save
-      flash.now[:notice] = "成功"
-    else
-      flash.now[:alert] = "失敗"
-      render :new, status: :unprocessable_entity
+    respond_to do |format|
+      if @list_item.save
+        format.turbo_stream { flash.now[:success] = t("defaults.flash_message.created", item: ListItem.model_name.human) }
+      else
+        flash.now[:error] = t("defaults.flash_message.not_created", item: ListItem.model_name.human)
+        format.turbo_stream { render :new, status: :unprocessable_entity }
+      end
     end
   end
 
   def edit; end
 
   def update
-    if @list_item.update(list_item_params)
-      flash.now[:notice] = "成功"
-    else
-      flash.now[:alert] = "失敗"
-      render :edit, status: :unprocessable_entity
+    respond_to do |format|
+      if @list_item.update(list_item_params)
+        format.turbo_stream { flash.now[:success] = t("defaults.flash_message.updated", item: ListItem.model_name.human) }
+      else
+        flash.now[:error] = t("defaults.flash_message.not_updated", item: ListItem.model_name.human)
+        format.turbo_stream { render :edit, status: :unprocessable_entity }
+      end
     end
   end
 
   def destroy
+    flash.now[:success] = t("defaults.flash_message.deleted", item: ListItem.model_name.human)
     @list_item.destroy!
   end
 

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -10,9 +10,9 @@ class ListItemsController < ApplicationController
     @list_item = @check_list.list_items.build(list_item_params)
     respond_to do |format|
       if @list_item.save
-        format.turbo_stream { flash.now[:success] = t("defaults.flash_message.created", item: ListItem.model_name.human) }
+        format.turbo_stream { flash.now[:notice] = t("defaults.flash_message.created", item: ListItem.model_name.human) }
       else
-        flash.now[:error] = t("defaults.flash_message.not_created", item: ListItem.model_name.human)
+        flash.now[:alert] = t("defaults.flash_message.not_created", item: ListItem.model_name.human)
         format.turbo_stream { render :new, status: :unprocessable_entity }
       end
     end
@@ -23,16 +23,16 @@ class ListItemsController < ApplicationController
   def update
     respond_to do |format|
       if @list_item.update(list_item_params)
-        format.turbo_stream { flash.now[:success] = t("defaults.flash_message.updated", item: ListItem.model_name.human) }
+        format.turbo_stream { flash.now[:notice] = t("defaults.flash_message.updated", item: ListItem.model_name.human) }
       else
-        flash.now[:error] = t("defaults.flash_message.not_updated", item: ListItem.model_name.human)
+        flash.now[:alert] = t("defaults.flash_message.not_updated", item: ListItem.model_name.human)
         format.turbo_stream { render :edit, status: :unprocessable_entity }
       end
     end
   end
 
   def destroy
-    flash.now[:success] = t("defaults.flash_message.deleted", item: ListItem.model_name.human)
+    flash.now[:notice] = t("defaults.flash_message.deleted", item: ListItem.model_name.human)
     @list_item.destroy!
   end
 

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -16,7 +16,7 @@ class SchedulesController < ApplicationController
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else
-      flash.now[:error] = t("defaults.flash_message.not_created", item: Schedule.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Schedule.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -34,7 +34,7 @@ class SchedulesController < ApplicationController
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.updated", item: Schedule.model_name.human)
     else
-      flash.now[:error] = t("defaults.flash_message.not_updated", item: Schedule.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: Schedule.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -14,8 +14,9 @@ class SchedulesController < ApplicationController
   def create
     @schedule_form = ScheduleForm.new(schedule_params)
     if @schedule_form.save
-      redirect_to travel_book_schedules_path(@travel_book)
+      redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else
+      flash.now[:error] = t("defaults.flash_message.not_created", item: Schedule.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -31,16 +32,16 @@ class SchedulesController < ApplicationController
     @spot = @schedule.spot
     @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
     if @schedule_form.update(schedule_params)
-      redirect_to schedule_path(@schedule), notice: "登録成功"
+      redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.updated", item: Schedule.model_name.human)
     else
-      flash.now[:alert] = "編集失敗"
+      flash.now[:error] = t("defaults.flash_message.not_updated", item: Schedule.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @schedule.destroy!
-    redirect_to travel_book_schedules_path(@travel_book), notice: "削除成功"
+    redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
   end
 
   private

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -21,9 +21,9 @@ class TravelBooksController < ApplicationController
     if @travel_book.save
       # 中間テーブルに関連付けを追加
       current_user.user_travel_books.create(travel_book: @travel_book)
-      redirect_to travel_books_path, notice: "作成成功"
+      redirect_to travel_books_path, success: t("defaults.flash_message.created", item: TravelBook.model_name.human)
     else
-      flash.now[:alert] = "作成失敗"
+      flash.now[:error] = t("defaults.flash_message.not_created", item: TravelBook.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -40,9 +40,9 @@ class TravelBooksController < ApplicationController
     @travel_book = current_user.travel_books.find(params[:id])
 
     if @travel_book.update(travel_book_param)
-      redirect_to travel_books_path(@travel_book), notice: "編集成功"
+      redirect_to travel_books_path(@travel_book), success: t("defaults.flash_message.updated", item: TravelBook.model_name.human)
     else
-      flash.now[:alert] = "編集失敗"
+      flash.now[:error] = t("defaults.flash_message.not_updated", item: TravelBook.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -50,14 +50,14 @@ class TravelBooksController < ApplicationController
   def destroy
     travel_book = current_user.travel_books.find(params[:id])
     travel_book.destroy!
-    redirect_to travel_books_path, notice: "削除成功"
+    redirect_to travel_books_path, success: t("defaults.flash_message.deleted", item: TravelBook.model_name.human)
   end
 
   def delete_image
     @travel_book = TravelBook.find(params[:id])
     @travel_book.remove_travel_book_image! # CarrierWaveのメソッドを使って画像を削除
     @travel_book.save
-    redirect_to edit_travel_book_path(@travel_book), notice: "削除しました"
+    redirect_to edit_travel_book_path(@travel_book), success: t("defaults.flash_message.deleted", item: TravelBook.model_name.human)
   end
 
   private

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -23,7 +23,7 @@ class TravelBooksController < ApplicationController
       current_user.user_travel_books.create(travel_book: @travel_book)
       redirect_to travel_books_path, success: t("defaults.flash_message.created", item: TravelBook.model_name.human)
     else
-      flash.now[:error] = t("defaults.flash_message.not_created", item: TravelBook.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: TravelBook.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -42,7 +42,7 @@ class TravelBooksController < ApplicationController
     if @travel_book.update(travel_book_param)
       redirect_to travel_books_path(@travel_book), success: t("defaults.flash_message.updated", item: TravelBook.model_name.human)
     else
-      flash.now[:error] = t("defaults.flash_message.not_updated", item: TravelBook.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: TravelBook.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,4 +22,12 @@ module ApplicationHelper
     return "未定" if date.nil?
     date.strftime("%Y/%-m/%-d(%a)")
   end
+
+  def flash_mesage_color(type)
+    case type.to_sym
+    when :success then "alert-success"
+    when :error then "alert-error"
+    else "bg-gray-300"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,11 +23,13 @@ module ApplicationHelper
     date.strftime("%Y/%-m/%-d(%a)")
   end
 
-  def flash_mesage_color(type)
-    case type.to_sym
-    when :success then "alert-success"
-    when :error then "alert-error"
-    else "bg-gray-300"
-    end
+  def flash_message_color(type)
+    colors = {
+      success: "alert-success",
+      notice: "alert-success",
+      error: "alert-error",
+      alert: "alert-error"
+    }
+    colors[type.to_sym] || "bg-gray-300"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,12 +24,6 @@ module ApplicationHelper
   end
 
   def flash_message_color(type)
-    colors = {
-      success: "alert-success",
-      notice: "alert-success",
-      error: "alert-error",
-      alert: "alert-error"
-    }
-    colors[type.to_sym] || "bg-gray-300"
+    type.to_sym == :notice ? "alert-success" : "alert-error"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
 
   <body class="bg-base-200 min-h-screen">
     <%= render "shared/header" %>
+    <%= render "shared/flash_message" %>
     <%= yield %>
     <% if display_bottom_nav? %>
       <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
 
   <body class="bg-base-200 min-h-screen">
     <%= render "shared/header" %>
+    <div id="flash_messages"></div>
     <%= render "shared/flash_message" %>
     <%= yield %>
     <% if display_bottom_nav? %>

--- a/app/views/list_items/cancel.turbo_stream.erb
+++ b/app/views/list_items/cancel.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
   <%= render "list_items/list_item", list_item: @list_item %>
 <% end %>

--- a/app/views/list_items/cancel_new.turbo_stream.erb
+++ b/app/views/list_items/cancel_new.turbo_stream.erb
@@ -1,4 +1,7 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.update "list_item_form", "" %>
+
 <%= turbo_stream.update "add_list_item_button" do %>
   <%= render "list_items/add_button" %>
 <% end %>

--- a/app/views/list_items/create.turbo_stream.erb
+++ b/app/views/list_items/create.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.append "list_item" do %>
   <%= render "list_items/list_item", list_item: @list_item %>
 <% end %>

--- a/app/views/list_items/destroy.turbo_stream.erb
+++ b/app/views/list_items/destroy.turbo_stream.erb
@@ -1,1 +1,3 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.remove @list_item %>

--- a/app/views/list_items/edit.turbo_stream.erb
+++ b/app/views/list_items/edit.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
   <%= render "list_items/form", list_item: @list_item %>
 <% end %>

--- a/app/views/list_items/new.turbo_stream.erb
+++ b/app/views/list_items/new.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.append "list_item_form" do %>
   <%= render "list_items/form", list_item: @list_item %>
 <% end %>

--- a/app/views/list_items/update.turbo_stream.erb
+++ b/app/views/list_items/update.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
+
 <%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
   <%= render "list_items/list_item", list_item: @list_item %>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div role="alert" class="alert <%= flash_mesage_color(message_type) %>">
+  <div role="alert" class="alert <%= flash_message_color(message_type) %>">
     <span><%= message %></span>
   </div>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div role="alert" class="alert">
+    <span><%= message %></span>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div role="alert" class="alert">
+  <div role="alert" class="alert <%= flash_mesage_color(message_type) %>">
     <span><%= message %></span>
   </div>
 <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,12 @@ ja:
     unpublic: 未公開
   defaults:
     delete_confirm: 削除しますか？
+    flash_message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成できませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新できませんでした"
+      deleted: "%{item}を削除しました"
   users:
     form:
       placeholder:


### PR DESCRIPTION
# 概要
以下のタイミングでflashメッセージが表示されるように修正
しおり,スケジュール,チェックリスト,リストアイテム(チェックリスト内のアイテム)の作成、編集、削除

## 実施内容
~~- ApplicationControllerでflashメッセージのtypeにsuccess,errorを追加~~
- [x] flashメッセージのパーシャルを作成
- [x] i18n対応のja.ymlファイル追記
- [x] ApplicationHelperでflashのtypeごとにクラスを指定するためのメソッド定義
- [x] application.html.erbにパーシャルを組み込み
- [x] turboを使用している箇所(list_item)でパーシャルを組み込み

## 未実施内容
- フラッシュメッセージのデザイン調整

## 補足
deviseではflashのtypeがデフォルトでnotice,alertで作成されていいたため、
今回先に作成したsuccess,errorもnotice,alertに統一しました。

## 関連issue
#24 