### PR TITLE
Fix/MVP前のCSS調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -33,3 +33,10 @@ h3 {
   text-align: center;
   font-weight: bold;
 }
+
+.bg-image {
+  background-image: url('map.png');
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center top;
+}

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,13 +1,8 @@
 class TravelBooksController < ApplicationController
-  before_action :authenticate_user!, only: [ :new, :edit, :update, :destroy ]
+  before_action :authenticate_user!, only: %i[ index new edit update destroy ]
 
   def index
-    @travel_books =
-    if params[:scope] == "own"
-      current_user ? current_user.travel_books : []
-    else
-      TravelBook.public_travel_books.includes(:users)
-    end
+    @travel_books = current_user.travel_books
   end
 
   def new
@@ -58,6 +53,10 @@ class TravelBooksController < ApplicationController
     @travel_book.remove_travel_book_image! # CarrierWaveのメソッドを使って画像を削除
     @travel_book.save
     redirect_to edit_travel_book_path(@travel_book), success: t("defaults.flash_message.deleted", item: TravelBook.model_name.human)
+  end
+
+  def public_travel_books
+    @travel_books = TravelBook.public_travel_books.includes(:users)
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -54,10 +54,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :icon_image, :icon_image_cache ])
   end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  # アカウント登録後のリダイレクト先
+  def after_sign_up_path_for(resource)
+    travel_books_path
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -24,6 +24,12 @@ class Users::SessionsController < Devise::SessionsController
   def after_sign_in_path_for(resource)
     travel_books_path
   end
+
+  # ログアウト後のリダイレクト先
+  def after_sign_out_path_for(resource)
+    home_index_path
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,6 +20,10 @@ class Users::SessionsController < Devise::SessionsController
 
   # protected
 
+  #ログイン後のリダイレクト先
+  def after_sign_in_path_for(resource)
+    travel_books_path
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,7 @@ class Users::SessionsController < Devise::SessionsController
 
   # protected
 
-  #ログイン後のリダイレクト先
+  # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource)
     travel_books_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,8 @@
 module ApplicationHelper
   # ボトムナビゲーションのだしわけ判定
-  def display_bottom_nav
+  def display_bottom_nav_on_travel_book
     return false if current_user.nil?
+    return false if controller_name == "home"
     (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(id: params[:id]))||
     (controller_name == "schedules")||
     (controller_name == "check_lists") ||

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,20 +1,16 @@
 module ApplicationHelper
-  # ボトムナビゲーションのだしわけ
-  # TravelController#showでユーザーがしおりとリレーションを組んでいる場合true
-  def display_bottom_nav?
+  # ボトムナビゲーションのだしわけ判定
+  def display_bottom_nav
     return false if current_user.nil?
-    (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(id: params[:id]))|| controller_name == "schedules"
+    (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(id: params[:id]))||
+    (controller_name == "schedules")||
+    (controller_name == "check_lists") ||
+    (controller_name == "list_items")
   end
 
   # 指定したパスが現在のページであれば"active"を返す
   def add_active_class(path)
-    if path == travel_books_path && (request.fullpath == root_path || request.fullpath == travel_books_path)
-      "active"
-    elsif request.fullpath == path
-      "active"
-    else
-      ""
-    end
+    current_page?(path) ? "hover:bg-base-200" : "hover:bg-base-200 opacity-50"
   end
 
   # 日付をフォーマットする

--- a/app/views/check_lists/_check_list.html.erb
+++ b/app/views/check_lists/_check_list.html.erb
@@ -1,5 +1,5 @@
 <%= link_to check_list_path(check_list), class: "block" do %>
-  <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:bg-base-300">
+  <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:opacity-50">
     <i class="fa-solid fa-square-check"></i>
     <div class="ml-3"><%= check_list.title %></div>
   </div>

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
       <%= link_to check_list_path(@check_list), class:"hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="form-container bg-white rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_check_lists_path(@travel_book) do %>
+      <%= link_to check_list_path(@check_list), class:"hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h1>

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_check_lists_path(@travel_book) do %>
+      <%= link_to travel_book_check_lists_path(@travel_book), class:"hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h3>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -1,16 +1,16 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_check_lists_path(@travel_book) do %>
+      <%= link_to travel_book_check_lists_path(@travel_book), class:"hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= @check_list.title %></h3>
       <% if @travel_book.owned_by_user?(current_user) %>
-        <%= link_to edit_check_list_path(@check_list) do %>
+        <%= link_to edit_check_list_path(@check_list), class:"hover:opacity-50" do %>
           <i class="fa-solid fa-pen"></i>
         <% end %>
-        <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5" do %>
+        <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
           <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,28 @@
-ここはホームです！
+<div class="min-h-screen relative flex flex-col bg-fixed">
+
+  <div class="bg-image absolute inset-0 opacity-50 z-0"></div>
+
+  <div class="flex flex-col flex-grow items-center justify-center z-10 text-center">
+
+    <h1 class="text-6xl font-bold mb-2">TabiClip</h1>
+    <p>旅行のしおりをつくるサービスです</p>
+    <div class="flex gap-4 justify-center mt-5">
+      <%= link_to "みんなのしおりを見る", public_travel_books_path, class: "btn btn-primary" %>
+    </div>
+    <div class="flex gap-4 justify-center mt-5">
+      <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary" %>
+      <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+    </div>
+  </div>
+
+  <footer class="footer footer-center bg-base-100 p-5 z-10">
+    <nav class="grid grid-flow-col gap-4">
+      <%= link_to "利用規約", "#", class: "link link-hover" %>
+      <%= link_to "お問い合わせ", "#", class: "link link-hover" %>
+      <%= link_to "プライバシーポリシー", "#", class: "link link-hover" %>
+    </nav>
+    <aside>
+      <p>Copyright © 2025 Tabiclip</p>
+    </aside>
+  </footer>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,1 @@
-<h1>Home#index</h1>
-<p class="bg-blue-300">Find me in app/views/home/index.html.erb</p>
+ここはホームです！

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,10 +23,12 @@
     <div id="flash_messages"></div>
     <%= render "shared/flash_message" %>
     <%= yield %>
-    <% if display_bottom_nav? %>
-      <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>
-    <% else %>
-      <%= render "shared/bottom_navigation" %>
+    <% if user_signed_in? %>
+      <% if display_bottom_nav %>
+        <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>
+      <% else %>
+        <%= render "shared/bottom_navigation" %>
+      <% end %>
     <% end %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,12 +23,10 @@
     <div id="flash_messages"></div>
     <%= render "shared/flash_message" %>
     <%= yield %>
-    <% if user_signed_in? %>
-      <% if display_bottom_nav %>
-        <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>
-      <% else %>
-        <%= render "shared/bottom_navigation" %>
-      <% end %>
+    <% if user_signed_in? && display_bottom_nav_on_travel_book %>
+      <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>
+    <% elsif controller_name != "home" %>
+      <%= render "shared/bottom_navigation" %>
     <% end %>
   </body>
 </html>

--- a/app/views/list_items/_add_button.html.erb
+++ b/app/views/list_items/_add_button.html.erb
@@ -1,5 +1,5 @@
 <div id="add_list_item_button">
-  <%= link_to new_check_list_list_item_path(@check_list), class: "btn", data: { turbo_stream: true } do %>
+  <%= link_to new_check_list_list_item_path(@check_list), class: "btn btn-primary", data: { turbo_stream: true } do %>
     <i class="fa-solid fa-circle-plus"></i><%= t(".new_button") %>
   <% end %>
 </div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -4,10 +4,10 @@
   <div class="flex gap-2">
       <%= f.text_field :title, autofocus: true, placeholder: t("list_items.form.placeholder.title"), class: "input input-bordered w-full" %>
     <div class="flex gap-2">
-      <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn", data: { turbo_method: :post } do %>
+      <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn btn-ghoast", data: { turbo_method: :post } do %>
         <i class="fa-solid fa-xmark"></i>
       <% end %>
-      <%= f.submit nil, class: "btn" %>
+      <%= f.submit nil, class: "btn btn-primary" %>
     </div>
   </div>
   <% end %>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -7,10 +7,10 @@
       </div>
       <div class="flex gap-5">
         <% if list_item.persisted? %>
-          <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:text-base-300" do %>
+          <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:opacity-50" do %>
             <i class="fa-solid fa-pen"></i>
           <% end %>
-          <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "hover:text-base-300" do %>
+          <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "hover:opacity-50" do %>
             <i class="fa-solid fa-trash"></i>
           <% end %>
         <% end %>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to schedule_path(@schedule) do %>
+      <%= link_to schedule_path(@schedule), class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h3>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,9 +1,13 @@
 <div class="container">
   <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-
-    <div class="flex flex-col items-center mb-5">
-      <h3><%= @travel_book.title %></h3>
-      <p><%= travel_book_duration(@travel_book)%></p>
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_path(@travel_book), class: "hover:opacity-50" do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <div class="flex flex-grow flex-col items-center">
+        <h3><%= @travel_book.title %></h3>
+        <p><%= travel_book_duration(@travel_book) %></p>
+      </div>
     </div>
 
     <% if @schedules.present? %>
@@ -30,11 +34,17 @@
       </div>
 
     <% else %>
-      <p class="text-center my-10"><%= t(".no_data") %></p>
+      <% if @travel_book.owned_by_user?(current_user) %>
+        <p class="text-center my-10"><%= t(".no_data") %></p>
+      <% else %>
+        <p class="text-center my-10"><%= t(".no_creator_no_data") %></p>
+      <% end %>
     <% end %>
 
-    <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-      <%= t(".new_button") %>
+    <% if @travel_book.owned_by_user?(current_user) %>
+      <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
+        <%= t(".new_button") %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <div class="flex flex-col items-center mb-5">
       <h3><%= @travel_book.title %></h3>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <div class="relative flex items-center justify-center">
-      <%= link_to travel_book_schedules_path(@travel_book) do %>
+      <%= link_to travel_book_schedules_path(@travel_book), class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h3>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,16 +1,16 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_schedules_path(@travel_book) do %>
+      <%= link_to travel_book_schedules_path(@travel_book), class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= @schedule.title %></h3>
       <% if @travel_book.owned_by_user?(current_user) %>
-        <%= link_to edit_schedule_path(@schedule) do %>
+        <%= link_to edit_schedule_path(@schedule), class: "hover:opacity-50" do %>
           <i class="fa-solid fa-pen"></i>
         <% end %>
-        <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5" do %>
+        <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
           <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,10 +1,10 @@
 <div class="btm-nav">
-  <%= link_to travel_books_path, class: "#{add_active_class(travel_books_path)}" do %>
+  <%= link_to public_travel_books_path, class: "#{add_active_class(travel_books_path)}" do %>
     <i class="fa-solid fa-magnifying-glass"></i>
     <span class="btm-nav-label">しおり検索</span>
   <% end %>
 
-  <%= link_to (user_signed_in? ? travel_books_path(scope: 'own') : new_user_session_path), class: "#{add_active_class(travel_books_path(scope: 'own'))}" do %>
+  <%= link_to travel_books_path, class: "#{add_active_class(travel_books_path(scope: 'own'))}" do %>
     <i class="fa-solid fa-map-location-dot"></i>
     <span class="btm-nav-label">マイしおり</span>
   <% end %>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,16 +1,16 @@
 <div class="btm-nav">
-  <%= link_to public_travel_books_path, class: "#{add_active_class(travel_books_path)}" do %>
+  <%= link_to public_travel_books_path, class: "#{add_active_class(public_travel_books_path)}" do %>
     <i class="fa-solid fa-magnifying-glass"></i>
-    <span class="btm-nav-label">しおり検索</span>
+    <span class="btm-nav-label"><%= t("btm_nav.travel_books_search") %></span>
   <% end %>
 
-  <%= link_to travel_books_path, class: "#{add_active_class(travel_books_path(scope: 'own'))}" do %>
+  <%= link_to new_travel_book_path, class: "#{add_active_class(new_travel_book_path)}" do %>
+    <i class="fa-solid fa-plus"></i>
+    <span class="btm-nav-label"><%= t("btm_nav.travel_book_create") %></span>
+  <% end %>
+
+  <%= link_to travel_books_path, class: "#{add_active_class(travel_books_path)}" do %>
     <i class="fa-solid fa-map-location-dot"></i>
-    <span class="btm-nav-label">マイしおり</span>
-  <% end %>
-
-  <%= link_to (user_signed_in? ? users_profile_path : new_user_session_path), class: "#{add_active_class(users_profile_path)}" do %>
-    <i class="fa-solid fa-circle-user"></i>
-    <span class="btm-nav-label">マイページ</span>
+    <span class="btm-nav-label"><%= t("btm_nav.my_travel_book") %></span>
   <% end %>
 </div>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -1,22 +1,22 @@
-<div class="btm-nav">
+<div class="btm-nav bg-base-100 shadow-sm">
   <%= link_to travel_book_path(@travel_book.id), class: "#{add_active_class(travel_book_path(@travel_book))}" do %>
     <i class="fa-regular fa-map"></i>
-    <span class="btm-nav-label">しおり情報</span>
+    <span class="btm-nav-label"><%= t("btm_nav.travel_book_info") %></span>
   <% end %>
   <%= link_to travel_book_schedules_path(@travel_book), class: "#{add_active_class(travel_book_schedules_path(@travel_book))}" do %>
     <i class="fa-regular fa-clock"></i>
-    <span class="btm-nav-label">スケジュール</span>
+    <span class="btm-nav-label"><%= t("btm_nav.schedule") %></span>
   <% end %>
-  <%= link_to "#" do %>
+  <%= link_to "#", class: "opacity-50" do %>
   <i class="fa-solid fa-location-dot"></i>
-    <span class="btm-nav-label">マップ</span>
+    <span class="btm-nav-label"><%= t("btm_nav.map") %></span>
   <% end %>
-  <%= link_to travel_book_check_lists_path(@travel_book) do %>
+  <%= link_to travel_book_check_lists_path(@travel_book), class: "#{add_active_class(travel_book_check_lists_path(@travel_book))}" do %>
     <i class="fa-solid fa-file-pen"></i>
-    <span class="btm-nav-label">ノート</span>
+    <span class="btm-nav-label"><%= t("btm_nav.note") %></span>
   <% end %>
-  <%= link_to "#" do %>
+  <%= link_to "#", class: "opacity-50" do %>
     <i class="fa-solid fa-image"></i>
-    <span class="btm-nav-label">アルバム</span>
+    <span class="btm-nav-label"><%= t("btm_nav.album") %></span>
   <% end %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-base-100 shadow-sm">
   <div class="flex-1 px-2 lg:flex-none">
-    <%= link_to '/', class: "text-lg font-bold" do %>
+    <%= link_to (user_signed_in? ? travel_books_path : public_travel_books_path), class: "text-lg font-bold hover:opacity-50" do %>
         TabiClip
     <% end %>
   </div>
@@ -29,7 +29,7 @@
         </ul>
       </div>
       <% else %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghoast" %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100 shadow">
+<div class="navbar bg-base-100 shadow-sm">
   <div class="flex-1 px-2 lg:flex-none">
     <%= link_to '/', class: "text-lg font-bold" do %>
         TabiClip
@@ -6,54 +6,31 @@
   </div>
   <div class="flex flex-1 justify-end px-2">
     <div class="flex items-stretch">
-      <% unless user_signed_in? %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost rounded-btn" %>
-      <% end %>
-      <div class="dropdown dropdown-end">
+      <% if user_signed_in? %>
+            <div class="dropdown dropdown-end">
         <div class="flex-none">
-          <button class="btn btn-square btn-ghost">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              class="inline-block h-5 w-5 stroke-current">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h16M4 12h16M4 18h16"></path>
-            </svg>
+          <button>
+            <%= image_tag(current_user.icon_image? ? current_user.icon_image_url : "default_icon.png",
+                class: "mx-auto rounded-full w-10 h-10 mr-2 object-cover shadow-sm border border-base-500 hover:opacity-50") %>
           </button>
         </div>
         <ul
           tabindex="0"
-          class="menu dropdown-content bg-base-100 rounded-box z-[1] mt-4 w-52 p-2 shadow">
-          <% if user_signed_in? %>
+          class="menu dropdown-content bg-base-100 rounded-box z-[1] mt-4 w-52 p-2">
             <li>
-              <%= link_to "logout", destroy_user_session_path, data: { turbo_method: :delete } %>
-            </li>
-          <% else %>
-            <li>
-              <%= link_to "sign up", new_user_registration_path %>
-            </li>
-          <% end %>
-            <li>
-              <%= link_to "how to use", "#" %>
+              <%= link_to "#{current_user.name}", users_profile_path %>
             </li>
             <li>
-              <%= link_to "travel books", "#" %>
+              <%= link_to t("header.how_to_use"), "#" %>
             </li>
             <li>
-              <%= link_to "terms of service", "#" %>
-            </li>
-            <li>
-              <%= link_to "contact", "#" %>
-            </li>
-            <li>
-              <%= link_to "privacy policy", "#" %>
+              <%= link_to t("header.logout"), destroy_user_session_path, data: { turbo_method: :delete } %>
             </li>
         </ul>
       </div>
+      <% else %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -42,7 +42,7 @@
 
   <div class="mt-2 flex flex-row-reverse">
     <% if @travel_book.persisted? && @travel_book.travel_book_image %>
-      <%= link_to delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } do %>
+      <%= link_to delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:opacity-50" do %>
         <i class="fa-solid fa-trash"></i>
       <% end %>
     <% end %>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_path(@travel_book) do %>
+      <%= link_to travel_book_path(@travel_book), class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title")%></h3>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,18 +1,9 @@
 <div class="container">
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <%if @travel_books.present? %>
-      <%if params[:scope] == "own" %>
-        <%= render "my_travel_book", travel_books: @travel_books %>
-      <% else %>
-        <%= render @travel_books %>
-      <% end %>
+      <%= render "my_travel_book", travel_books: @travel_books %>
     <% else %>
       <%= t(".no_data") %>
     <% end %>
   </div>
-  <%if params[:scope] == "own" %>
-    <%= link_to new_travel_book_path, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-      <%= t(".new_button") %>
-    <% end %>
-  <% end %>
 </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to travel_books_path do %>
+      <%= link_to travel_books_path, class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title")%></h3>

--- a/app/views/travel_books/public_travel_books.html.erb
+++ b/app/views/travel_books/public_travel_books.html.erb
@@ -1,0 +1,5 @@
+<div class="container">
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <%= render @travel_books %>
+  </div>
+</div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -7,10 +7,10 @@
 
       <div class="card-body">
         <div class="card-actions items-center justify-between">
-        <%= link_to travel_books_path, class: "hover:opacity-50" do %>
-          <i class="fa-solid fa-chevron-left"></i>
-        <% end %>
-          <h2 class="card-title"><%= @travel_book.title %></h2>
+          <%= link_to (user_signed_in? ? travel_books_path : public_travel_books_path), class: "hover:opacity-50" do %>
+            <i class="fa-solid fa-chevron-left"></i>
+          <% end %>
+          <h3 class="flex-grow text-center"><%= @travel_book.title %></h3>
           <% if @travel_book.owned_by_user?(current_user) %>
             <div class="justify-end">
               <%= link_to edit_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
@@ -47,6 +47,12 @@
           <div class="font-bold"><%= TravelBook.human_attribute_name(:is_public) %></div>
           <div><%= travel_book_is_public(@travel_book) %></div>
         </div>
+
+        <% unless @travel_book.owned_by_user?(current_user) %>
+          <%= link_to travel_book_schedules_path(@travel_book), class: "btn btn-primary hover:opacity-50" do %>
+            スケジュールを見る
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -7,20 +7,26 @@
 
       <div class="card-body">
         <div class="card-actions items-center justify-between">
+        <%= link_to travel_books_path, class: "hover:opacity-50" do %>
+          <i class="fa-solid fa-chevron-left"></i>
+        <% end %>
           <h2 class="card-title"><%= @travel_book.title %></h2>
           <% if @travel_book.owned_by_user?(current_user) %>
             <div class="justify-end">
-              <%= link_to edit_travel_book_path(@travel_book) do %>
+              <%= link_to edit_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
                 <i class="fa-solid fa-pen"></i>
               <% end %>
-              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5" do %>
+              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
                 <i class="fa-solid fa-trash"></i>
               <% end %>
             </div>
           <% end %>
         </div>
 
-        <div><%= travel_book_description(@travel_book) %></div>
+        <div class="mt-6">
+          <div class="font-bold"><%= TravelBook.human_attribute_name(:description) %></div>
+          <%= travel_book_description(@travel_book) %>
+        </div>
 
         <div class="mt-3">
           <div class="font-bold"><%= t(".duration") %></div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container rounded-lg shadow-md bg-white p-8">
+  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
     <h2><%= t(".title") %></h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <h3><%= t(".title") %></h3>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container rounded-lg shadow-md bg-white p-8">
+  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
     <h2><%= t(".title") %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container rounded-lg shadow-md bg-white p-8">
+  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
     <h2><%= t(".title") %></h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="form-container bg-white rounded-lg shadow-md p-8">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <%= image_tag(@user.icon_image? ? @user.icon_image_url : "default_icon.png",
       class: "mx-auto rounded-full w-20 h-20 shadow-md object-cover border border-gray-200") %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,8 +87,9 @@ ja:
     index:
       new_button: スケジュール作成
       no_data: スケジュールを登録しましょう
+      no_creator_no_data: スケジュールが登録されていません
     show:
-      no_data: 場所の登録はありません
+      no_data: 場所が登録されていません
     new:
       title: スケジュール作成
     edit:
@@ -101,11 +102,11 @@ ja:
         true: 公開
         false: 非公開
     helpers:
-      no_memo: メモはありません
+      no_memo: メモは登録されていません
   check_lists:
     index:
       new_button: チェックリスト作成
-      no_data: チェックリストはありません
+      no_data: チェックリストは登録されていません
     show:
       no_data: チェックリストに項目を追加しましょう
     new:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,21 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
+  header:
+    logout: ログアウト
+    how_to_use: 使い方
+    terms_of_service: 利用規約
+    contact: お問い合わせ
+    privacy_policy: プライバシーポリシー
+  btm_nav:
+    travel_books_search: しおり検索
+    travel_book_create: しおり作成
+    my_travel_book: マイしおり
+    travel_book_info: しおり情報
+    schedule: スケジュール
+    map: マップ
+    note: ノート
+    album: アルバム
   users:
     form:
       placeholder:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   get "users/profile" => "users#show"
   get "home/index"
   resources :travel_books do
+    collection do
+      get "public", action: :public_travel_books
+    end
     delete "delete_image", on: :member
     resources :schedules, shallow: true
     resources :check_lists, shallow: true do
@@ -33,5 +36,6 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "travel_books#index"
+  # root "travel_books#index"
+  root "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "travel_books#index"
-  root "home#index"
+  root "travel_books#index"
 end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,5 +5,8 @@ module.exports = {
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
   ],
-  plugins: [require("daisyui")]
+  plugins: [require("daisyui")],
+  daisyui: {
+    themes: ["cupcake"],
+  },
 }


### PR DESCRIPTION
# 概要
MVP前にアプリ全体のCSSを調整しました。
ログインしていないユーザーに公開するTOPページを作成しました。

## 実施内容
- [x] daisyuiのテーマを設定(cupcake)
- [x] ログインユーザーのしおり一覧(マイしおり)と公開されたしおり一覧(しおり検索)のルーティングを分離しビューをそれぞれ作成
- [x] アカウント登録後、ログイン後、ログアウト後のリダイレクト先を設定
  - アカウント登録後：ログインユーザーのしおり一覧(マイしおり)
  - ログイン後：ログインユーザーのしおり一覧(マイしおり)
  - ログアウト後：TOPページ
- [x] ボトムナビゲーションのi18n対応とCSS調整
- [x] ボトムナビゲーションの表示切り替え
  - TOPページ,ログイン,アカウント登録画面：ボトムナビゲーションを表示しない
  - しおりの画面：ボトムナビゲーション(_bottom_navigation.html.erb )を表示
  - しおりに紐づく画面：ボトムナビゲーション(_bottom_navigation_on_travel_book.html.erb )を表示
 - [x]  ログインユーザーかどうかによって設置するリンクを切り替え
   - ヘッダー：
     - 公開されたしおり一覧かマイしおり一覧か切り替え
     - ログイン後にユーザーアイコンを表示し、ドロップダウンリスト内のメニューを整理
   - しおり詳細画面：
     - しおり一覧へ戻るリンクは公開されたしおり一覧かマイしおり一覧か切り替え
     - スケジュール一覧へ進むリンクの表示切り替え
 - [x] CSSクラスの修正
   - bg-whiteをbg-base-100に修正
   - リンク、ボタンにhover:opacity-50を付与
   - ボタンの色指定方法を統一(btn-primary,btn-ghoast)

## 未実施内容
- ボトムナビゲーションでスケジュールとチェックリスト(ノート)のindex以外のビューを開いた時に、ボトムナビゲーションがの対象のメニューにactiveであることがわかるようにクラスを付与する※別isseueを作成予定
- TOPページのCSS調整(footerが一部隠れる)※別isseueを作成予定

## 補足
チェックリスト編集画面からチェックリスト詳細画面へ戻るリンクを間違えていたのでpathを修正しました。,

## 関連issue
#114