### PR TITLE
fix/ヘッダーロゴリンクの遷移先修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-base-100 shadow-sm">
   <div class="flex-1 px-2 lg:flex-none">
-    <%= link_to (user_signed_in? ? travel_books_path : public_travel_books_path), class: "text-lg font-bold hover:opacity-50" do %>
+    <%= link_to (user_signed_in? ? travel_books_path : home_index_path), class: "text-lg font-bold hover:opacity-50" do %>
         TabiClip
     <% end %>
   </div>


### PR DESCRIPTION
# 概要
ログインしていないユーザーの場合ヘッダーのロゴクリック時TOP画面へ遷移するように修正しました。

## 実施内容
- [x] _header.html.erbの修正

## 未実施内容
なし

## 補足
なし

## 関連issue
なし