### PR TITLE
Fix/MVPリリースレビューの指摘事項修正

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,11 +7,16 @@
     <h1 class="text-6xl font-bold mb-2">TabiClip</h1>
     <p>旅行のしおりをつくるサービスです</p>
     <div class="flex gap-4 justify-center mt-5">
+      <% if user_signed_in? %>
+        <%= link_to "しおりを作成する", new_travel_book_path, class: "btn btn-primary" %>
+      <% end %>
       <%= link_to "みんなのしおりを見る", public_travel_books_path, class: "btn btn-primary" %>
     </div>
     <div class="flex gap-4 justify-center mt-5">
-      <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary" %>
-      <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+      <% unless user_signed_in? %>
+        <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary" %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+      <% end %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "travel_books#index"
+  root "home#index"
 end


### PR DESCRIPTION
# 概要
MVPリリースレビューの指摘事項修正します。
> ログインしていないユーザーの遷移先が、"[https://tabiclip.onrender.com/users/sign_in"　になっています。上記の挙動と違うため確認お願いいたします。](https://tabiclip.onrender.com/users/sign_in%22%E3%80%80%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%A6%E3%81%84%E3%81%BE%E3%81%99%E3%80%82%E4%B8%8A%E8%A8%98%E3%81%AE%E6%8C%99%E5%8B%95%E3%81%A8%E9%81%95%E3%81%86%E3%81%9F%E3%82%81%E7%A2%BA%E8%AA%8D%E3%81%8A%E9%A1%98%E3%81%84%E3%81%84%E3%81%9F%E3%81%97%E3%81%BE%E3%81%99%E3%80%82)

## 実施内容
- [x] routes.rbのrootにTOPページ(home#index)を指定
- [x] ログインしているかどうかによってTOPページに配置するリンクを変更
  - ログインユーザー：公開されたしおり一覧画面、しおり新規作成画面へのリンク
  - 未ログインユーザー：アカウント登録画面、ログイン画面、公開されたしおり一覧画面へのリンク

## 未実施内容
なし

## 補足
TOPページはログインユーザーもアクセス可能な仕様へと変更します。

## 関連issue
#117 ,#119