### PR TITLE
Fix/MVPリリースレビューの指摘事項修正_v2

### DIFF
--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -11,12 +11,14 @@
   <i class="fa-solid fa-location-dot"></i>
     <span class="btm-nav-label"><%= t("btm_nav.map") %></span>
   <% end %>
-  <%= link_to travel_book_check_lists_path(@travel_book), class: "#{add_active_class(travel_book_check_lists_path(@travel_book))}" do %>
-    <i class="fa-solid fa-file-pen"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.note") %></span>
-  <% end %>
-  <%= link_to "#", class: "opacity-50" do %>
-    <i class="fa-solid fa-image"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.album") %></span>
+  <% if @travel_book.owned_by_user?(current_user) %>
+    <%= link_to travel_book_check_lists_path(@travel_book), class: "#{add_active_class(travel_book_check_lists_path(@travel_book))}" do %>
+      <i class="fa-solid fa-file-pen"></i>
+      <span class="btm-nav-label"><%= t("btm_nav.note") %></span>
+    <% end %>
+    <%= link_to "#", class: "opacity-50" do %>
+      <i class="fa-solid fa-image"></i>
+      <span class="btm-nav-label"><%= t("btm_nav.album") %></span>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
# 概要
他人のしおり閲覧時にボトムナビゲーションの「ノート」ボタン押下後のエラーを対処いたしました。
対処としては、他人のしおり閲覧時はボトムナビゲーションにノートとアルバムを表示しないように修正しております。

## 実施内容
- [x] 他人のしおり閲覧時はボトムナビゲーションにノートとアルバムを表示しないように修正

## 未実施内容
なし

## 補足
他人のしおり閲覧時にボトムナビゲーションのノートボタンとアルバムボタンは表示されない仕様です。
ノートとアルバムは自分が所有するしおりにのみ紐付けして登録、編集、削除を行うことができます。

## 関連issue
#117 ,#119