### PR TITLE
Fix/公開されたしおり一覧へ表示するしおりデータを修正

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -56,7 +56,7 @@ class TravelBooksController < ApplicationController
   end
 
   def public_travel_books
-    @travel_books = TravelBook.includes(:users).order(:created_at).page(params[:page])
+    @travel_books = TravelBook.where(is_public: true).includes(:users).order(:created_at).page(params[:page])
   end
 
   private

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -52,11 +52,11 @@
     <%= f.label :is_public, TravelBook.human_attribute_name(:is_public), class: "label" %>
     <div class="flex items-center gap-3">
       <div class="flex items-center gap-1">
-        <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary" %>
+        <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary", checked: f.object.is_public? %>
         <%= f.label :is_public_true, t(".is_public.true"), for: "is_public_true" %>
       </div>
       <div class="flex items-center gap-1">
-        <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: "checked" %>
+        <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: !f.object.is_public? %>
         <%= f.label :is_public_false, t(".is_public.false"), for: "is_public_false" %>
       </div>
     </div>


### PR DESCRIPTION
# 概要
公開されたしおり一覧(しおり検索)へ表示するしおりに未公開設定のしおりを含んでいたため修正しました。
また、しおりの編集時にしおりの公開設定のラジオボタンには登録済みの公開設定にチェックを入れるように修正しました。

## 実施内容
- [x] 公開されたしおり一覧に公開設定したしおりのみ表示するように修正
- [x] しおり編集時のラジオボタンに登録済みの公開設定の方にチェックを入れるように修正

## 未実施内容

## 補足
自分が所有するしおりは公開・未公開の設定に関わらず「マイしおり」の一覧に表示されます。
自分が所有していないしおりは公開設定されているしおりのみ「しおり検索」の一覧に表示されます。

## 関連issue
#117 