### PR TITLE
Fix/Dockerボリュームの設定ミスを修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
       TZ: Asia/Tokyo
       POSTGRES_PASSWORD: password
     volumes:
-      - postgresql_data:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     healthcheck:


### PR DESCRIPTION
# 概要
compose.ymlのvolumesの設定を修正しました。

## 実施内容
- [x] compose.ymlのdbのvolumesの修正
修正前：`postgresql_data:/var/lib/postgresql`
修正後：`postgresql_data:/var/lib/postgresql/data`

## 未実施内容
なし

## 補足
ローカル環境で上記volumesの設定ミスによりコンテナを停止(docker compose down)したときに
DBのデータが削除されていたため、データ永続化のために修正しました。

ローカルでは対象のvolumeを削除し、コンテナを起動させることでvolumeを再作成しました。