### PR TITLE
Feature/場所情報入力フォームのオートコンプリート機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "rails-i18n", "~> 7.0.0"
 # pagination
 gem "kaminari"
 
+# .envファイルで環境変数を管理
+gem "dotenv-rails"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem "kaminari"
 # .envファイルで環境変数を管理
 gem "dotenv-rails"
 
+# Geocoding
+gem "geocoder"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -379,6 +383,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  dotenv-rails
   draper
   fog-aws
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.2)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -155,6 +156,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -386,6 +390,7 @@ DEPENDENCIES
   dotenv-rails
   draper
   fog-aws
+  geocoder
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -94,7 +94,7 @@ class ScheduleForm
 
   def end_date_after_start_date
     if start_date.present? && end_date.present? && end_date < start_date
-      errors.add(:end_date, "must be after start date")
+      errors.add(:end_date, :after_start_date)
       false
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./place_autocomplete"

--- a/app/javascript/place_autocomplete.js
+++ b/app/javascript/place_autocomplete.js
@@ -1,0 +1,39 @@
+document.addEventListener("turbo:load", function() {
+  console.log("turbo:load");
+  initMap();
+});
+
+function initMap() {
+  // 場所名
+  const inputSpotName = document.getElementById("spotName");
+  // 電話番号
+  const inputPhoneNumber = document.getElementById("phoneNumber");
+  // 住所
+  const inputAddress = document.getElementById("address");
+
+
+  function setAutocomplete(inputElement){
+    const options = {
+      componentRestrictions: { country: 'JP' }
+    };
+    const autocomplete = new google.maps.places.Autocomplete(inputElement, options);
+
+    autocomplete.addListener("place_changed", function() {
+      const place = autocomplete.getPlace();
+      // 場所名、電話番号、住所を更新する(nilかundefinedの場合は空文字)
+      inputSpotName.value = place.name ?? "";
+      inputPhoneNumber.value = place.formatted_phone_number ?? "";
+      inputAddress.value = place.formatted_address ?? "";
+    });
+  }
+  // 場所名のオートコンプリート
+  if(inputSpotName){
+    setAutocomplete(inputSpotName);
+  }
+  // 住所のオートコンプリート
+  if(inputAddress){
+    setAutocomplete(inputAddress);
+  }
+}
+
+window.initMap = initMap;

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,3 +1,6 @@
 class Spot < ApplicationRecord
   belongs_to :schedule, optional: true
+
+  geocoded_by :address
+  after_validation :geocode
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,9 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <script src="https://kit.fontawesome.com/db3944d085.js" crossorigin="anonymous"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script async
+      src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&loading=async&libraries=places&callback=initMap">
+    </script>
   </head>
 
   <body class="bg-base-200 min-h-screen">

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -5,44 +5,44 @@
     <%= f.label :title, class: "w-full" do %>
       <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
     <% end %>
-    <%= f.text_field :title, autofocus: true, placeholder: t("schedules.form.placeholder.title"), class: "input input-bordered w-full" %>
+    <%= f.text_field :title, autofocus: true, placeholder: t("schedules.form.placeholder.title"), class: "input input-bordered w-full", autocomplete: "off" %>
   </div>
 
   <div class="mt-3 flex flex-col sm:flex-row gap-2">
     <div class="w-full">
       <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
-      <%= f.datetime_field :start_date, class: "input input-bordered w-full" %>
+      <%= f.datetime_field :start_date, class: "input input-bordered w-full", autocomplete: "off" %>
     </div>
     <div class="w-full">
       <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
-      <%= f.datetime_field :end_date, class: "input input-bordered w-full" %>
+      <%= f.datetime_field :end_date, class: "input input-bordered w-full", autocomplete: "off" %>
     </div>
   </div>
 
   <div class="field">
     <%= f.label :name, Spot.human_attribute_name(:name), class: "label" %>
-    <%= f.text_field :name, class: "input input-bordered w-full" %>
+    <%= f.text_field :name, id: "spotName", class: "input input-bordered w-full", autocomplete: "off" %>
   </div>
   <div class="field">
     <%= f.label :telephone, Spot.human_attribute_name(:telephone), class: "label" %>
-    <%= f.text_field :telephone, class: "input input-bordered w-full" %>
+    <%= f.text_field :telephone, id: "phoneNumber", class: "input input-bordered w-full", autocomplete: "off" %>
   </div>
   <div class="field">
     <%= f.label :address, Spot.human_attribute_name(:address), class: "label" %>
-    <%= f.text_field :address, class: "input input-bordered w-full" %>
+    <%= f.text_field :address, id: "address", class: "input input-bordered w-full", autocomplete: "off" %>
   </div>
 
   <div class="field mt-3">
     <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>
     <div class="flex items-center">
-      <%= f.number_field :budged, class: "input input-bordered w-full" %>
+      <%= f.number_field :budged, class: "input input-bordered w-full", autocomplete: "off" %>
       <span class="ml-2"><%= t("helpers.currency_unit") %></span>
     </div>
   </div>
 
   <div class="field mt-3">
     <%= f.label :memo, Schedule.human_attribute_name(:memo), class: "label" %>
-    <%= f.text_area :memo, placeholder: t("schedules.form.placeholder.memo"), rows: "3", class: "textarea textarea-bordered w-full" %>
+    <%= f.text_area :memo, placeholder: t("schedules.form.placeholder.memo"), rows: "3", class: "textarea textarea-bordered w-full", autocomplete: "off" %>
   </div>
 
   <div class="flex justify-end mt-5">

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -46,6 +46,6 @@
   </div>
 
   <div class="flex justify-end mt-5">
-    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
+    <%= f.button nil, type: 'button', onclick: 'submit();', class: "btn btn-primary w-full mt-6 mx-auto" %>
   </div>
 <% end %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,13 +1,13 @@
 Geocoder.configure(
   # Geocoding options
   # timeout: 3,                 # geocoding service timeout (secs)
-  # lookup: :nominatim,         # name of geocoding service (symbol)
+  lookup: :google,         # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code
-  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  # api_key: nil,               # API key for geocoding service
+  api_key: ENV["GOOGLE_MAPS_API_KEY"],               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
 
   # Exceptions that should not be rescued by default

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -1,0 +1,18 @@
+ja:
+  activemodel:
+    attributes:
+      schedule_form:
+        title: タイトル
+        start_date: 開始時刻
+        end_date: 終了時刻
+        name: 場所名
+        telephone: 電話番号
+        address: 住所
+        budged: 予算
+        memo: メモ
+    errors:
+      models:
+        schedule_form:
+          attributes:
+            end_date:
+              after_start_date: "は開始時刻より後の時刻を入力してください"

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -34,5 +34,5 @@ ja:
         address: 住所
       check_list:
         title: タイトル
-      list_items:
+      list_item:
         title: タイトル

--- a/db/migrate/20250217074029_add_latitude_and_longitude_to_spots.rb
+++ b/db/migrate/20250217074029_add_latitude_and_longitude_to_spots.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToSpots < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spots, :latitude, :float
+    add_column :spots, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_12_130313) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_130313) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["schedule_id"], name: "index_spots_on_schedule_id"
   end
 


### PR DESCRIPTION
# 概要
しおりのスケジュールの場所情報を入力するフォームにGoogleのMaps JavaScript APIを使用し、
オートコンプリート機能を実装しました。

## 実施内容
- [x] gem dotenv-railsの導入(環境変数を管理するgem)
- [x] GoogleMapsAPIキーの環境変数を設定
- [x] spotsテーブルにlatitude,longitudeカラム追加
- [x] gem geocoderの導入(住所等から緯度経度を取得するgem)
- [x] geocorderの設定ファイルを作成と設定の投入
- [x] Spotモデルにgeocorderで使用する設定の追記
- [x] APIの組み込み(app/views/layouts/application.html.erb)
- [x] formのsubmitをbuttonに変更(エンターキーで送信されないようにするため)
- [x] formObjectの日本語化のためi18n対応

## 未実施内容
なし

## 補足
[参考ドキュメント](https://developers.google.com/maps/documentation/javascript/place-autocomplete?hl=ja)


## 関連issue
