### PR TITLE
Fix/turbo:leload発火時にinitMapを実行するように修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,12 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener("turbo:load", () => {
+  // mapの表示領域か場所名のinputがある場合のみinitMapを実行
+  let map = document.getElementById("map")
+  const inputSpotName = document.getElementById("spotName");
+  if(map || inputSpotName){
+    initMap();
+  }
+});


### PR DESCRIPTION
# 概要
turbo:leload発火時にinitMapを実行するように処理をしないと動作しないことを確認したため、修正いたしました。

## 実施内容
- [x] application.jsでturbo:load発火時にinitMap関数を実行するように修正

## 未実施内容
- デプロイ後の動作確認

## 補足
#128で行った実装の修正です。

## 関連issue
#128