### PR TITLE
Feature/Map表示画面の実装

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,6 +1,6 @@
 class SchedulesController < ApplicationController
   before_action :authenticate_user!, only: [ :new, :edit, :update, :destroy ]
-  before_action :set_travel_book, only: %i[ index new create ]
+  before_action :set_travel_book, only: %i[ index new create map ]
   before_action :set_schedule, only: %i[ show edit update destroy ]
 
   def index
@@ -44,6 +44,12 @@ class SchedulesController < ApplicationController
   def destroy
     @schedule.destroy!
     redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
+  end
+
+  def map
+    @schedules = @travel_book.sorted_schedules
+    # scheduleには0もしくは1のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
+    @spots = @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }
   end
 
   private

--- a/app/views/schedules/map.html.erb
+++ b/app/views/schedules/map.html.erb
@@ -1,0 +1,2 @@
+<div id="map" class="h-screen"></div>
+<%= render "map" %>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -7,7 +7,7 @@
     <i class="fa-regular fa-clock"></i>
     <span class="btm-nav-label"><%= t("btm_nav.schedule") %></span>
   <% end %>
-  <%= link_to "#", class: "opacity-50" do %>
+  <%= link_to map_travel_book_schedules_path(@travel_book), class: "#{add_active_class(map_travel_book_schedules_path(@travel_book))}" do %>
   <i class="fa-solid fa-location-dot"></i>
     <span class="btm-nav-label"><%= t("btm_nav.map") %></span>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,11 @@ Rails.application.routes.draw do
       get "public", action: :public_travel_books
     end
     delete "delete_image", on: :member
-    resources :schedules, shallow: true
+    resources :schedules, shallow: true do
+      collection do
+        get :map
+      end
+    end
     resources :check_lists, shallow: true do
       resources :list_items, only: %i[ new create edit update destroy toggle ] do
         collection do


### PR DESCRIPTION
# 概要
スケジュールで登録された場所をGoogleMapのピンで表示する機能を実装しました。

## 実施内容
- [x] mapアクション用ルーティング定義
- [x] mapアクション定義
- [x] map用ビュー作成
- [x] ボトムスナビゲーションへmap画面へのリンク追加

## 未実施内容
なし

## 補足
スケジュールコントローラーにmapアクションを定義して実装しました。

## 関連issue
#129 