### PR TITLE
Feature/しおりのidをuuidに変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ module ApplicationHelper
   def display_bottom_nav_on_travel_book
     return false if current_user.nil?
     return false if controller_name == "home"
-    (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(id: params[:id]))||
+    (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(uuid: params[:id]))||
     (controller_name == "schedules")||
     (controller_name == "check_lists") ||
     (controller_name == "list_items")

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,10 +3,15 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 
 document.addEventListener("turbo:load", () => {
-  // mapの表示領域か場所名のinputがある場合のみinitMapを実行
   let map = document.getElementById("map")
   const inputSpotName = document.getElementById("spotName");
-  if(map || inputSpotName){
+
+  // mapの表示領域がある場合はinitMap実行
+  if(map){
     initMap();
+  }
+  // 場所名のinputフォームがある場合はinitAutocompleteを実行
+  if(inputSpotName){
+    initAutocomplete();
   }
 });

--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -1,5 +1,5 @@
 class CheckList < ApplicationRecord
-  belongs_to :travel_book
+  belongs_to :travel_book, foreign_key: :travel_book_uuid
   has_many :list_items, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,5 @@
 class Schedule < ApplicationRecord
-  belongs_to :travel_book
+  belongs_to :travel_book, foreign_key: :travel_book_uuid
   has_one :spot, dependent: :destroy
 
   def self.group_by_date(schedules)

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -4,10 +4,10 @@ class TravelBook < ApplicationRecord
   belongs_to :area, optional: true
   belongs_to :traveler_type, optional: true
   belongs_to :creator, class_name: "User"
-  has_many :user_travel_books, dependent: :destroy
+  has_many :user_travel_books, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :users, through: :user_travel_books
-  has_many :schedules, dependent: :destroy
-  has_many :check_lists, dependent: :destroy
+  has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
+  has_many :check_lists, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   mount_uploader :icon_image, UserUploader
   has_many :user_travel_books, dependent: :destroy
-  has_many :travel_books, through: :user_travel_books
+  has_many :travel_books, primary_key: :uuid, foreign_key: :travel_book_uuid, through: :user_travel_books
   has_many :created_travel_books, class_name: "TravelBook", foreign_key: "creator_id", dependent: :destroy
 
   # Include default devise modules. Others available are:

--- a/app/models/user_travel_book.rb
+++ b/app/models/user_travel_book.rb
@@ -1,6 +1,6 @@
 class UserTravelBook < ApplicationRecord
   belongs_to :user
-  belongs_to :travel_book
+  belongs_to :travel_book, foreign_key: :travel_book_uuid
 
-  validates :user_id, uniqueness: { scope: :travel_book_id }
+  validates :user_id, uniqueness: { scope: :travel_book_uuid }
 end

--- a/app/views/schedules/_autocomplete.html.erb
+++ b/app/views/schedules/_autocomplete.html.erb
@@ -1,6 +1,5 @@
 <script>
-
-function initMap() {
+function initAutocomplete() {
   // 場所名と住所のフォームにオートコンプリートをつける処理
   // 場所名,電話番号, 住所
   const inputSpotName = document.getElementById("spotName");
@@ -22,11 +21,7 @@ function initMap() {
     });
   }
 
-  if(inputSpotName){
-    setAutocomplete(inputSpotName);
-  }
-  if(inputAddress){
-    setAutocomplete(inputAddress);
-  }
+  setAutocomplete(inputSpotName);
+  setAutocomplete(inputAddress);
 }
 </script>

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -3,28 +3,27 @@ function initMap() {
   // Mapを表示してmarkerをつける処理
   // Mapの表示領域
   let map = document.getElementById("map")
-  if (map) {
-    // Railsから渡されたスポットデータをJSで扱えるようにパース
-    const spots = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name]) %>;
 
-    // @spotsが空でない場合、最初のスポットをセンターにする
-    const position = Array.isArray(spots) && spots.length > 0
-      ? { lat: parseFloat(spots[0].latitude), lng: parseFloat(spots[0].longitude) }
-      : { lat: 35.6803997, lng: 139.7690174 }; // デフォルトの位置（東京駅）
+  // Railsから渡されたスポットデータをJSで扱えるようにパース
+  const spots = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name]) %>;
 
-    map = new google.maps.Map(document.getElementById("map"),  {
-      zoom: 10,
-      center: position,
-      mapId: "DEMO_MAP_ID", // 高度なmarkerを使用するために必要
+  // @spotsが空でない場合、最初のスポットをセンターにする
+  const position = Array.isArray(spots) && spots.length > 0
+    ? { lat: parseFloat(spots[0].latitude), lng: parseFloat(spots[0].longitude) }
+    : { lat: 35.6803997, lng: 139.7690174 }; // デフォルトの位置（東京駅）
+
+  map = new google.maps.Map(document.getElementById("map"),  {
+    zoom: 10,
+    center: position,
+    mapId: "DEMO_MAP_ID", // 高度なmarkerを使用するために必要
+  });
+  // markerの設定
+  spots.forEach((spot) =>{
+    const marker = new google.maps.marker.AdvancedMarkerElement({
+      position: {lat: parseFloat(spot.latitude), lng: parseFloat(spot.longitude)},
+      map: map,
+      title: spot.name
     });
-
-    spots.forEach((spot) =>{
-      const marker = new google.maps.marker.AdvancedMarkerElement({
-        position: {lat: parseFloat(spot.latitude), lng: parseFloat(spot.longitude)},
-        map: map,
-        title: spot.name
-      });
-    });
-  }
+  });
 }
 </script>

--- a/db/migrate/20250221020501_add_uuid_to_travel_books.rb
+++ b/db/migrate/20250221020501_add_uuid_to_travel_books.rb
@@ -1,0 +1,9 @@
+class AddUuidToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :travel_books, :uuid, :uuid, default: "gen_random_uuid()", null: false
+    add_index :travel_books, :uuid, unique: true
+
+    TravelBook.reset_column_information
+    TravelBook.find_each { |travel_book| travel_book.update_column(:uuid, SecureRandom.uuid) }
+  end
+end

--- a/db/migrate/20250221021131_add_travel_book_uuid_foreign_key.rb
+++ b/db/migrate/20250221021131_add_travel_book_uuid_foreign_key.rb
@@ -5,13 +5,13 @@ class AddTravelBookUuidForeignKey < ActiveRecord::Migration[7.2]
     add_column :user_travel_books, :travel_book_uuid, :uuid
 
     Schedule.reset_column_information
-    Schedule.find_each { |s| s.update_column(:travel_book_uuid, TravelBook.find(s.travel_book_id).uuid)}
+    Schedule.find_each { |s| s.update_column(:travel_book_uuid, TravelBook.find(s.travel_book_id).uuid) }
 
     CheckList.reset_column_information
-    CheckList.find_each { |c| c.update_column(:travel_book_uuid, TravelBook.find(c.travel_book_id).uuid)}
+    CheckList.find_each { |c| c.update_column(:travel_book_uuid, TravelBook.find(c.travel_book_id).uuid) }
 
     UserTravelBook.reset_column_information
-    UserTravelBook.find_each { |ut| ut.update_column(:travel_book_uuid, TravelBook.find(ut.travel_book_id).uuid)}
+    UserTravelBook.find_each { |ut| ut.update_column(:travel_book_uuid, TravelBook.find(ut.travel_book_id).uuid) }
 
     change_column_null :schedules, :travel_book_uuid, false
     change_column_null :check_lists, :travel_book_uuid, false

--- a/db/migrate/20250221021131_add_travel_book_uuid_foreign_key.rb
+++ b/db/migrate/20250221021131_add_travel_book_uuid_foreign_key.rb
@@ -1,0 +1,20 @@
+class AddTravelBookUuidForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schedules, :travel_book_uuid, :uuid
+    add_column :check_lists, :travel_book_uuid, :uuid
+    add_column :user_travel_books, :travel_book_uuid, :uuid
+
+    Schedule.reset_column_information
+    Schedule.find_each { |s| s.update_column(:travel_book_uuid, TravelBook.find(s.travel_book_id).uuid)}
+
+    CheckList.reset_column_information
+    CheckList.find_each { |c| c.update_column(:travel_book_uuid, TravelBook.find(c.travel_book_id).uuid)}
+
+    UserTravelBook.reset_column_information
+    UserTravelBook.find_each { |ut| ut.update_column(:travel_book_uuid, TravelBook.find(ut.travel_book_id).uuid)}
+
+    change_column_null :schedules, :travel_book_uuid, false
+    change_column_null :check_lists, :travel_book_uuid, false
+    change_column_null :user_travel_books, :travel_book_uuid, false
+  end
+end

--- a/db/migrate/20250221023136_change_travel_book_primary_key.rb
+++ b/db/migrate/20250221023136_change_travel_book_primary_key.rb
@@ -1,0 +1,14 @@
+class ChangeTravelBookPrimaryKey < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :schedules, :travel_books
+    remove_foreign_key :check_lists, :travel_books
+    remove_foreign_key :user_travel_books, :travel_books
+
+    execute "ALTER TABLE travel_books DROP CONSTRAINT travel_books_pkey;"
+    execute "ALTER TABLE travel_books ADD PRIMARY KEY (uuid);"
+
+    add_foreign_key :schedules, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_foreign_key :check_lists, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_foreign_key :user_travel_books, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+  end
+end

--- a/db/migrate/20250221040635_change_travel_book_index.rb
+++ b/db/migrate/20250221040635_change_travel_book_index.rb
@@ -1,0 +1,11 @@
+class ChangeTravelBookIndex < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :schedules, name: "index_schedules_on_travel_book_id"
+    remove_index :check_lists, name: "index_check_lists_on_travel_book_id"
+    remove_index :user_travel_books, name: "index_user_travel_books_on_travel_book_id"
+
+    add_index :schedules, :travel_book_uuid
+    add_index :check_lists, :travel_book_uuid
+    add_index :user_travel_books, :travel_book_uuid
+  end
+end

--- a/db/migrate/20250221041915_delete_travel_book_id.rb
+++ b/db/migrate/20250221041915_delete_travel_book_id.rb
@@ -1,0 +1,8 @@
+class DeleteTravelBookId < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :schedules, :travel_book_id, :bigint
+    remove_column :check_lists, :travel_book_id, :bigint
+    remove_column :user_travel_books, :travel_book_id, :bigint
+    remove_column :travel_books, :id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_21_041915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,11 +21,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
   end
 
   create_table "check_lists", force: :cascade do |t|
-    t.bigint "travel_book_id", null: false
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["travel_book_id"], name: "index_check_lists_on_travel_book_id"
+    t.uuid "travel_book_uuid", null: false
+    t.index ["travel_book_uuid"], name: "index_check_lists_on_travel_book_uuid"
   end
 
   create_table "list_items", force: :cascade do |t|
@@ -38,7 +38,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
   end
 
   create_table "schedules", force: :cascade do |t|
-    t.bigint "travel_book_id", null: false
     t.string "title", null: false
     t.integer "budged", default: 0
     t.text "memo"
@@ -46,7 +45,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
     t.datetime "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["travel_book_id"], name: "index_schedules_on_travel_book_id"
+    t.uuid "travel_book_uuid", null: false
+    t.index ["travel_book_uuid"], name: "index_schedules_on_travel_book_uuid"
   end
 
   create_table "spots", force: :cascade do |t|
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
     t.index ["schedule_id"], name: "index_spots_on_schedule_id"
   end
 
-  create_table "travel_books", force: :cascade do |t|
+  create_table "travel_books", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
     t.boolean "is_public", default: false, null: false
@@ -77,6 +77,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
     t.index ["area_id"], name: "index_travel_books_on_area_id"
     t.index ["creator_id"], name: "index_travel_books_on_creator_id"
     t.index ["traveler_type_id"], name: "index_travel_books_on_traveler_type_id"
+    t.index ["uuid"], name: "index_travel_books_on_uuid", unique: true
   end
 
   create_table "traveler_types", force: :cascade do |t|
@@ -87,11 +88,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
 
   create_table "user_travel_books", force: :cascade do |t|
     t.bigint "user_id"
-    t.bigint "travel_book_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["travel_book_id"], name: "index_user_travel_books_on_travel_book_id"
-    t.index ["user_id", "travel_book_id"], name: "index_user_travel_books_on_user_id_and_travel_book_id", unique: true
+    t.uuid "travel_book_uuid", null: false
+    t.index ["travel_book_uuid"], name: "index_user_travel_books_on_travel_book_uuid"
     t.index ["user_id"], name: "index_user_travel_books_on_user_id"
   end
 
@@ -109,13 +109,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_17_074029) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "check_lists", "travel_books"
+  add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "list_items", "check_lists"
-  add_foreign_key "schedules", "travel_books"
+  add_foreign_key "schedules", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "spots", "schedules"
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "travel_books", "users", column: "creator_id"
-  add_foreign_key "user_travel_books", "travel_books"
+  add_foreign_key "user_travel_books", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "user_travel_books", "users"
 end


### PR DESCRIPTION
# 概要
しおり(travel_books)のidをuuidを使用するように修正しました。

## 実施内容
- [x] travel_booksテーブルにuuidカラムを追加
- [x] 外部キー制約されている(user_travel_books,schedules,check_listsテーブル)にtravel_book_uuidカラムを追加
- [x] プライマリーキーをuuidにして外部キーを変更
- [x] indexを変更
- [x] idカラムを削除
- [x] モデルファイルの修正
- [x] current_userとtravel_bookが紐づいているか確認するメソッド内(display_bottom_nav_on_travel_book)のカラムをidからuuidに変更

## 未実施内容
なし

## 補足
現状URLから投稿のidを使用すると非公開設定している投稿も見れる状況のため、
uuidを使用し、URLを推測しづらいものへと変更します。

## 関連issue
#133 