### PR TITLE
Feature/チェックリストのidをuuidに変更

### DIFF
--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -1,6 +1,6 @@
 class CheckList < ApplicationRecord
   belongs_to :travel_book, foreign_key: :travel_book_uuid
-  has_many :list_items, dependent: :destroy
+  has_many :list_items, primary_key: :uuid, foreign_key: :check_list_uuid, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,5 +1,5 @@
 class ListItem < ApplicationRecord
-  belongs_to :check_list
+  belongs_to :check_list, foreign_key: :check_list_uuid
 
   validates :title, presence: true, length: { maximum: 255 }
 end

--- a/db/migrate/20250221055118_add_uuid_to_check_lists.rb
+++ b/db/migrate/20250221055118_add_uuid_to_check_lists.rb
@@ -1,0 +1,9 @@
+class AddUuidToCheckLists < ActiveRecord::Migration[7.2]
+  def change
+    add_column :check_lists, :uuid, :uuid, default: "gen_random_uuid()", null: false
+    add_index :check_lists, :uuid, unique: true
+
+    CheckList.reset_column_information
+    CheckList.find_each { |check_list| check_list.update_column(:uuid, SecureRandom.uuid) }
+  end
+end

--- a/db/migrate/20250221055752_add_check_list_uuid_foreign_key.rb
+++ b/db/migrate/20250221055752_add_check_list_uuid_foreign_key.rb
@@ -1,0 +1,10 @@
+class AddCheckListUuidForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    add_column :list_items, :check_list_uuid, :uuid
+
+    ListItem.reset_column_information
+    ListItem.find_each { |li| li.update_column(:check_list_uuid, CheckList.find(li.check_list_id).uuid) }
+
+    change_column_null :list_items, :check_list_uuid, false
+  end
+end

--- a/db/migrate/20250221061204_change_check_list_primary_key.rb
+++ b/db/migrate/20250221061204_change_check_list_primary_key.rb
@@ -1,0 +1,10 @@
+class ChangeCheckListPrimaryKey < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :list_items, :check_lists
+
+    execute "ALTER TABLE check_lists DROP CONSTRAINT check_lists_pkey;"
+    execute "ALTER TABLE check_lists ADD PRIMARY KEY (uuid);"
+
+    add_foreign_key :list_items, :check_lists, column: :check_list_uuid, primary_key: :uuid
+  end
+end

--- a/db/migrate/20250221061741_change_check_list_index.rb
+++ b/db/migrate/20250221061741_change_check_list_index.rb
@@ -1,0 +1,7 @@
+class ChangeCheckListIndex < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :list_items, name: "index_list_items_on_check_list_id"
+
+    add_index :list_items, :check_list_uuid
+  end
+end

--- a/db/migrate/20250221062404_delete_check_list_id.rb
+++ b/db/migrate/20250221062404_delete_check_list_id.rb
@@ -1,0 +1,6 @@
+class DeleteCheckListId < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :list_items, :check_list_id, :bigint
+    remove_column :check_lists, :id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_055752) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_21_061741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,12 +20,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_055752) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "check_lists", force: :cascade do |t|
+  create_table "check_lists", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigserial "id", null: false
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "travel_book_uuid", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["travel_book_uuid"], name: "index_check_lists_on_travel_book_uuid"
     t.index ["uuid"], name: "index_check_lists_on_uuid", unique: true
   end
@@ -37,7 +37,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_055752) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "check_list_uuid", null: false
-    t.index ["check_list_id"], name: "index_list_items_on_check_list_id"
+    t.index ["check_list_uuid"], name: "index_list_items_on_check_list_uuid"
   end
 
   create_table "schedules", force: :cascade do |t|
@@ -113,7 +113,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_055752) do
   end
 
   add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
-  add_foreign_key "list_items", "check_lists"
+  add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
   add_foreign_key "schedules", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "spots", "schedules"
   add_foreign_key "travel_books", "areas"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_055118) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_21_055752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_055118) do
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "check_list_uuid", null: false
     t.index ["check_list_id"], name: "index_list_items_on_check_list_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_061741) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_21_062404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,7 +21,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_061741) do
   end
 
   create_table "check_lists", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigserial "id", null: false
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -31,7 +30,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_061741) do
   end
 
   create_table "list_items", force: :cascade do |t|
-    t.bigint "check_list_id", null: false
     t.string "title", null: false
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_041915) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_21_055118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,7 +25,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_041915) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "travel_book_uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["travel_book_uuid"], name: "index_check_lists_on_travel_book_uuid"
+    t.index ["uuid"], name: "index_check_lists_on_uuid", unique: true
   end
 
   create_table "list_items", force: :cascade do |t|


### PR DESCRIPTION
# 概要
チェックリスト(check_lists)のidをuuidを使用するように修正しました。

## 実施内容
- [x] check_listsテーブルにuuidカラムを追加
- [x] 外部キー制約されている(list_itemsテーブル)にcheck_list_uuidカラムを追加
- [x] プライマリーキーをuuidにして外部キーを変更
- [x] indexを変更
- [x] idカラムを削除
- [x] モデルファイルの修正

## 未実施内容
なし

## 補足
現状URLから投稿のidを使用すると非公開設定している投稿も見れる状況のため、
uuidを使用し、URLを推測しづらいものへと変更します。

## 関連issue
#136 