### PR TITLE
Feature/マップの詳細情報にスケジュール詳細画面のリンクを動的に設置

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -66,7 +66,7 @@ class SchedulesController < ApplicationController
       :post_code,
       :address,
     ).merge(
-      travel_book_id: @travel_book.id
+      travel_book_uuid: @travel_book.id
     )
   end
 

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -2,7 +2,7 @@ class ScheduleForm
   include ActiveModel::Model # 通常のモデルのようにvalidationなどを使えるようにする
   include ActiveModel::Attributes # ActiveRecordのカラムのような属性を加えられるようにする
   # パラメータの読み書きを許可する
-  attribute :travel_book_id, :integer
+  attribute :travel_book_uuid, :string
   attribute :title, :string
   attribute :start_date, :datetime
   attribute :end_date, :datetime
@@ -13,7 +13,7 @@ class ScheduleForm
   attribute :post_code, :string
   attribute :address, :string
 
-  validates :travel_book_id, presence: true
+  validates :travel_book_uuid, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validate  :end_date_after_start_date
   validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -39,7 +39,7 @@ class ScheduleForm
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id)
+      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
@@ -57,7 +57,7 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id)
+      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,17 +1,3 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
-
-document.addEventListener("turbo:load", () => {
-  let map = document.getElementById("map")
-  const inputSpotName = document.getElementById("spotName");
-
-  // mapの表示領域がある場合はinitMap実行
-  if(map){
-    initMap();
-  }
-  // 場所名のinputフォームがある場合はinitAutocompleteを実行
-  if(inputSpotName){
-    initAutocomplete();
-  }
-});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <script src="https://kit.fontawesome.com/db3944d085.js" crossorigin="anonymous"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    <script async
-      src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&loading=async&libraries=places,marker">
-    </script>
+
   </head>
 
   <body class="bg-base-200 min-h-screen">

--- a/app/views/schedules/_autocomplete.html.erb
+++ b/app/views/schedules/_autocomplete.html.erb
@@ -1,5 +1,5 @@
 <script>
-function initAutocomplete() {
+function initMap() {
   // 場所名と住所のフォームにオートコンプリートをつける処理
   // 場所名,電話番号, 住所
   const inputSpotName = document.getElementById("spotName");
@@ -24,4 +24,7 @@ function initAutocomplete() {
   setAutocomplete(inputSpotName);
   setAutocomplete(inputAddress);
 }
+</script>
+<script async
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&loading=async&libraries=places&callback=initMap">
 </script>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -46,6 +46,37 @@
   </div>
 
   <div class="flex justify-end mt-5">
-    <%= f.button nil, type: 'button', onclick: 'submit();', class: "btn btn-primary w-full mt-6 mx-auto" %>
+    <%= f.button nil, type: 'button', onclick: 'submit();', data: { turbo: false }, class: "btn btn-primary w-full mt-6 mx-auto" %>
   </div>
 <% end %>
+
+<script>
+function initMap() {
+  // 場所名と住所のフォームにオートコンプリートをつける処理
+  // 場所名,電話番号, 住所
+  const inputSpotName = document.getElementById("spotName");
+  const inputPhoneNumber = document.getElementById("phoneNumber");
+  const inputAddress = document.getElementById("address");
+
+  function setAutocomplete(inputElement){
+    const options = {
+      componentRestrictions: { country: 'JP' }
+    };
+    const autocomplete = new google.maps.places.Autocomplete(inputElement, options);
+
+    autocomplete.addListener("place_changed", function() {
+      const place = autocomplete.getPlace();
+      // 場所名、電話番号、住所を更新する(nilかundefinedの場合は空文字)
+      inputSpotName.value = place.name ?? "";
+      inputPhoneNumber.value = place.formatted_phone_number ?? "";
+      inputAddress.value = place.formatted_address ?? "";
+    });
+  }
+
+  setAutocomplete(inputSpotName);
+  setAutocomplete(inputAddress);
+}
+</script>
+<script async
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&loading=async&libraries=places&callback=initMap">
+</script>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @schedule_form, url: url do |f| %>
+<%= form_with model: @schedule_form, url: url, local: true do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
   <div class="field mt-3">

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -6,7 +6,7 @@ function initMap() {
   let map = document.getElementById("map")
 
   // Railsから渡されたスポットデータをJSで扱えるようにパース
-  const spots = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name]) %>;
+  const spots = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name, :schedule_id ]) %>;
 
   // @spotsが空でない場合、最初のスポットをセンターにする
   const position = Array.isArray(spots) && spots.length > 0
@@ -29,14 +29,15 @@ function initMap() {
     // markerがクリックされた時に地図の詳細情報を表示
     marker.addListener("click", ()=> {
       console.log("markerクリック");
-      // `schedule_path` のURLを適切に生成（Railsヘルパーを使う）
+      // URLを生成
       const scheduleUrl = "<%= request.base_url %>/schedules/" + spot.schedule_id;
 
       document.getElementById("popup").innerHTML =
       `<div class="card bg-base-100 w-96 shadow-md">
         <div class="card-body">
           <div class="flex items-center justify-between">
-            <p>${spot.name}</p>
+            <a href="${scheduleUrl}" class="text-blue-500 underline">${spot.name}</a>
+
             <button id="close-btn" class="btn btn-square btn-sm">
               <i class="fa-solid fa-xmark"></i>
             </button>

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -14,7 +14,7 @@ function initMap() {
     : { lat: 35.6803997, lng: 139.7690174 }; // デフォルトの位置（東京駅）
 
   map = new google.maps.Map(document.getElementById("map"),  {
-    zoom: 10,
+    zoom: 11,
     center: position,
     mapId: "DEMO_MAP_ID", // 高度なmarkerを使用するために必要
   });

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -45,11 +45,14 @@ function initMap() {
         </div>
       </div>`;
 
-      // 削除ボタン（×マーク）にクリックイベントを追加
+      // 削除ボタンクリック時にpopupを削除
       document.querySelector("#close-btn").addEventListener("click", () => {
-        document.getElementById("popup").innerHTML = ""; // カードを削除
+        document.getElementById("popup").innerHTML = "";
       });
     });
   });
 }
+</script>
+<script async
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&loading=async&libraries=marker&callback=initMap">
 </script>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to schedule_path(@schedule), class: "hover:opacity-50" do %>
+      <%= link_to schedule_path(@schedule), data: { turbo: false }, class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h3>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -10,4 +10,3 @@
     <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>
   </div>
 </div>
-<%= render "autocomplete" %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -42,7 +42,7 @@
     <% end %>
 
     <% if @travel_book.owned_by_user?(current_user) %>
-      <%= link_to new_travel_book_schedule_path(@travel_book), class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
+      <%= link_to new_travel_book_schedule_path(@travel_book), data: { turbo: false }, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
         <%= t(".new_button") %>
       <% end %>
     <% end %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -11,4 +11,3 @@
     <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>
   </div>
 </div>
-<%= render "autocomplete" %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -2,7 +2,7 @@
   <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <div class="relative flex items-center justify-center">
-      <%= link_to travel_book_schedules_path(@travel_book), class: "hover:opacity-50" do %>
+      <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h3>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -2,12 +2,12 @@
   <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
 
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_schedules_path(@travel_book), class: "hover:opacity-50" do %>
+      <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= @schedule.title %></h3>
       <% if @travel_book.owned_by_user?(current_user) %>
-        <%= link_to edit_schedule_path(@schedule), class: "hover:opacity-50" do %>
+        <%= link_to edit_schedule_path(@schedule), data: { turbo: false }, class: "hover:opacity-50" do %>
           <i class="fa-solid fa-pen"></i>
         <% end %>
         <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -3,11 +3,11 @@
     <i class="fa-regular fa-map"></i>
     <span class="btm-nav-label"><%= t("btm_nav.travel_book_info") %></span>
   <% end %>
-  <%= link_to travel_book_schedules_path(@travel_book), class: "#{add_active_class(travel_book_schedules_path(@travel_book))}" do %>
+  <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "#{add_active_class(travel_book_schedules_path(@travel_book))}" do %>
     <i class="fa-regular fa-clock"></i>
     <span class="btm-nav-label"><%= t("btm_nav.schedule") %></span>
   <% end %>
-  <%= link_to map_travel_book_schedules_path(@travel_book), class: "#{add_active_class(map_travel_book_schedules_path(@travel_book))}" do %>
+  <%= link_to map_travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "#{add_active_class(map_travel_book_schedules_path(@travel_book))}" do %>
   <i class="fa-solid fa-location-dot"></i>
     <span class="btm-nav-label"><%= t("btm_nav.map") %></span>
   <% end %>


### PR DESCRIPTION
# 概要
マップのマーカーをクリックした時に場所名を表示(#145 )し、その場所名をスケジュール詳細画面へ遷移するリンクになるように修正しました。

## 実施内容
- [x] マップ上のマーカーをクリックした際に表示されるポップアップにスケジュール詳細画面のリンクを設置
- [x] scriptをapplication.htmlではなく各viewに記述
- [x] scriptに影響する一部のturboを無効化
- [x] travel_bookでuuidを使用するように修正した際の修正漏れを対処

## 未実施内容
- CSSの調整は最低限のため今後必要に応じて対応

## 補足
- travel_bookでuuidを使用するように修正した際(#133)の修正漏れを対処
ScheduleFormとSchedulesControllerでidのままになっているものがあったため修正しました。

- scriptに影響する一部のturboを無効化
application.html.erbに書いてapplication.jsで読み込み箇所を制御するよりも、画面遷移時にturboの無効化をした方がコードの可読性や保守性が良いと感じたため各ビューに以降しました。

## 関連issue
#148 ,#146