### PR TITLE
Feature/schedulsのidをUUIDに変更

### DIFF
--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -43,7 +43,7 @@ class ScheduleForm
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
-        @spot = Spot.create!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: schedule.id)
+        @spot = Spot.create!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_uuid: schedule.id)
       end
       true
     end
@@ -61,7 +61,7 @@ class ScheduleForm
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
-        @spot.update!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: @schedule.id)
+        @spot.update!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_uuid: @schedule.id)
       else
         @schedule.spot.destroy
       end

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -2,10 +2,11 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="tabs"
 export default class extends Controller {
+  static values = { spots: Array }
 
   changeTab(event){
-    const changeSpots = JSON.parse(event.target.getAttribute("data-spots") || "[]");
-    window.spots = changeSpots;
+    this.spotsValue = JSON.parse(event.target.getAttribute("data-tabs-spots-value"));
+    window.spots = this.spotsValue;
     initMap();
   }
 }

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,6 +1,6 @@
 class Schedule < ApplicationRecord
   belongs_to :travel_book, foreign_key: :travel_book_uuid
-  has_one :spot, dependent: :destroy
+  has_one :spot, primary_key: :uuid, foreign_key: :schedule_uuid, dependent: :destroy
 
   def self.group_by_date(schedules)
     schedules.group_by { |schedule| (schedule.start_date&.to_date || schedule.end_date&.to_date) || "日付未定" }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,5 +1,5 @@
 class Spot < ApplicationRecord
-  belongs_to :schedule, optional: true
+  belongs_to :schedule, optional: true, primary_key: :uuid, foreign_key: :schedule_uuid
 
   geocoded_by :address
   after_validation :geocode

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -4,6 +4,7 @@ class TravelBook < ApplicationRecord
   belongs_to :area, optional: true
   belongs_to :traveler_type, optional: true
   belongs_to :creator, class_name: "User"
+
   has_many :user_travel_books, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :users, through: :user_travel_books
   has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -3,7 +3,7 @@ let popup, Popup;
 let map;
 function initMap() {
   // Railsから渡されたスポットデータをJSで扱えるようにパース
-  const spots = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name, :schedule_id ]) %>;
+  const spots = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name, :schedule_uuid ]) %>;
 
   // 表示するMapの位置を緯度経度で指定
   // @spotsが空の場合、東京駅をセンターにする
@@ -40,7 +40,7 @@ function initMap() {
     // markerがクリックされた時に地図の詳細情報を表示
     markerViewGlyphText.addListener("click", ()=> {
       // URLを生成
-      const scheduleUrl = "<%= request.base_url %>/schedules/" + spot.schedule_id;
+      const scheduleUrl = "<%= request.base_url %>/schedules/" + spot.schedule_uuid;
       // popupを表示
       document.getElementById("popup").innerHTML =
       `<div class="card bg-base-100 w-96 shadow-md">

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -14,10 +14,7 @@
           <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
         </td>
         <td class="p-4">
-          <% if defined?(index) && index %>
-            <% index = index +1 %>
-          <% end %>
-
+          <% index = index +1 if defined?(index) && index %>
           <% if schedule.spot&.latitude %>
             <div class="relative inline-block">
               <i class="fa-solid fa-location-pin text-2xl text-red-500"></i>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -62,7 +62,7 @@ let popup, Popup;
 let map;
 function initMap() {
   // Railsから渡されたスポットデータをJSで扱えるようにJSON形式に変換
-  const initSpotsJsonData = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name, :schedule_id ]) %>;
+  const initSpotsJsonData = <%= raw @spots.to_json(only: [:id, :latitude, :longitude, :name, :schedule_uuid ]) %>;
   // tabをクリックしたらグローバル変数のspotsが更新されるためそれを取得
   const spots = window.spots || initSpotsJsonData;
 
@@ -95,7 +95,7 @@ function initMap() {
     // markerがクリックされた時に地図の詳細情報を表示
     markerViewGlyphText.addListener("click", ()=> {
       // URLを生成
-      const scheduleUrl = "<%= request.base_url %>/schedules/" + spot.schedule_id;
+      const scheduleUrl = "<%= request.base_url %>/schedules/" + spot.schedule_uuid;
       // popupを表示
       document.getElementById("popup").innerHTML =
       `<div class="card bg-base-100 w-96 shadow-md">

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -14,7 +14,7 @@
       <div role="tablist" class="tabs tabs-bordered">
         <!-- Tab for allday -->
           <input type="radio" data-action="change->tabs#changeTab"
-            data-spots="<%= @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
+            data-tabs-spots-value="<%= @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
             name="my_tabs_1" role="tab" class="tab" aria-label="ALL" checked="checked"/>
           <div role="tabpanel" class="tab-content p-10">
             <% @schedules.each_with_index do |schedule, i| %>
@@ -26,7 +26,7 @@
         <!-- Tab for each date -->
         <% Schedule.group_by_date(@schedules).each do |date, schedules| %>
           <input type="radio" data-action="change->tabs#changeTab"
-            data-spots="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
+            data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
           <div role="tabpanel" class="tab-content p-10">
             <% schedules.each_with_index do |schedule, i| %>
               <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>

--- a/db/migrate/20250225033328_add_uuid_to_schedules.rb
+++ b/db/migrate/20250225033328_add_uuid_to_schedules.rb
@@ -1,0 +1,9 @@
+class AddUuidToSchedules < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schedules, :uuid, :uuid, default: "gen_random_uuid()", null: false
+    add_index :schedules, :uuid, unique: true
+
+    Schedule.reset_column_information
+    Schedule.find_each { |schedule| schedule.update_column(:uuid, SecureRandom.uuid) }
+  end
+end

--- a/db/migrate/20250225034342_add_schedule_uuid_foreign_key.rb
+++ b/db/migrate/20250225034342_add_schedule_uuid_foreign_key.rb
@@ -1,0 +1,10 @@
+class AddScheduleUuidForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spots, :schedule_uuid, :uuid
+
+    Spot.reset_column_information
+    Spot.find_each { |s| s.update_column(:schedule_uuid, Schedule.find(s.schedule_id).uuid) }
+
+    change_column_null :spots, :schedule_uuid, false
+  end
+end

--- a/db/migrate/20250225035258_change_schedule_primary_key.rb
+++ b/db/migrate/20250225035258_change_schedule_primary_key.rb
@@ -1,0 +1,10 @@
+class ChangeSchedulePrimaryKey < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :spots, :schedules
+
+    execute "ALTER TABLE schedules DROP CONSTRAINT schedules_pkey;"
+    execute "ALTER TABLE schedules ADD PRIMARY KEY (uuid);"
+
+    add_foreign_key :spots, :schedules, column: :schedule_uuid, primary_key: :uuid
+  end
+end

--- a/db/migrate/20250225035642_change_schedule_index.rb
+++ b/db/migrate/20250225035642_change_schedule_index.rb
@@ -1,0 +1,7 @@
+class ChangeScheduleIndex < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :spots, name: "index_spots_on_schedule_id"
+
+    add_index :spots, :schedule_uuid
+  end
+end

--- a/db/migrate/20250225040043_delete_schedule_id.rb
+++ b/db/migrate/20250225040043_delete_schedule_id.rb
@@ -1,0 +1,7 @@
+class DeleteScheduleId < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :spots, :schedule_id, :bigint
+
+    remove_column :schedules, :id, :bigserial
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_062404) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_25_040043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,7 +38,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_062404) do
     t.index ["check_list_uuid"], name: "index_list_items_on_check_list_uuid"
   end
 
-  create_table "schedules", force: :cascade do |t|
+  create_table "schedules", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "budged", default: 0
     t.text "memo"
@@ -48,10 +48,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_062404) do
     t.datetime "updated_at", null: false
     t.uuid "travel_book_uuid", null: false
     t.index ["travel_book_uuid"], name: "index_schedules_on_travel_book_uuid"
+    t.index ["uuid"], name: "index_schedules_on_uuid", unique: true
   end
 
   create_table "spots", force: :cascade do |t|
-    t.bigint "schedule_id"
     t.string "name"
     t.string "telephone"
     t.string "post_code"
@@ -60,7 +60,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_062404) do
     t.datetime "updated_at", null: false
     t.float "latitude"
     t.float "longitude"
-    t.index ["schedule_id"], name: "index_spots_on_schedule_id"
+    t.uuid "schedule_uuid", null: false
+    t.index ["schedule_uuid"], name: "index_spots_on_schedule_uuid"
   end
 
   create_table "travel_books", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -113,7 +114,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_062404) do
   add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
   add_foreign_key "schedules", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
-  add_foreign_key "spots", "schedules"
+  add_foreign_key "spots", "schedules", column: "schedule_uuid", primary_key: "uuid"
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "travel_books", "users", column: "creator_id"


### PR DESCRIPTION
# 概要
スケジュール(schedules)のidをuuidを使用するように修正しました。

## 実施内容
- [x] schedulesテーブルにuuidカラムを追加
- [x] 外部キー制約されている(spotsテーブル)にschedule_uuidカラムを追加
- [x] プライマリーキーをuuidにして外部キーを変更
- [x] indexを変更
- [x] idカラムを削除
- [x] モデルファイルの修正
- [ ] stimulusのコード(変数)を修正
- [ ] スケジュールのパーシャル(_schedule.html.erb)内で使用するindexのコード簡略化

## 未実施内容
なし

## 補足
現状URLから投稿のidを使用すると非公開設定している投稿も見れる状況のため、
uuidを使用し、URLを推測しづらいものへと変更します。

## 関連issue
#154 