### PR TITLE
Fix/リマインダー登録・編集の不備修正とリファクタリング

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -40,3 +40,7 @@ h3 {
   background-size: cover;
   background-position: center top;
 }
+
+.field_with_errors {
+  display: contents;
+}

--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -22,9 +22,10 @@ class CheckListsController < ApplicationController
   end
 
   def show
-    @list_items = @check_list.list_items.order(created_at: :asc)
-    @list_items.each do |list_item|
+    # 必ずlist_itemにreminderが紐づく
+    @list_items = @check_list.list_items.order(created_at: :asc).map do |list_item|
       list_item.reminder || list_item.build_reminder
+      list_item
     end
   end
 

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -8,6 +8,7 @@ class ListItemsController < ApplicationController
 
   def create
     @list_item = @check_list.list_items.build(list_item_params)
+    @reminder = @list_item.build_reminder
     respond_to do |format|
       if @list_item.save
         format.turbo_stream { flash.now[:notice] = t("defaults.flash_message.created", item: ListItem.model_name.human) }
@@ -52,7 +53,8 @@ class ListItemsController < ApplicationController
 
   def toggle
     @list_item.update(completed: !@list_item.completed)
-    render turbo_stream: turbo_stream.replace(@list_item, partial: "list_item", locals: { list_item: @list_item })
+    @reminder = @list_item.reminder || @list_item.build_reminder
+    render turbo_stream: turbo_stream.replace(@list_item, partial: "list_item", locals: { list_item: @list_item, reminder: @reminder })
   end
 
   private

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -9,26 +9,23 @@ class ListItemsController < ApplicationController
   def create
     @list_item = @check_list.list_items.build(list_item_params)
     @reminder = @list_item.build_reminder
-    respond_to do |format|
-      if @list_item.save
-        format.turbo_stream { flash.now[:notice] = t("defaults.flash_message.created", item: ListItem.model_name.human) }
-      else
-        flash.now[:alert] = t("defaults.flash_message.not_created", item: ListItem.model_name.human)
-        format.turbo_stream { render :new, status: :unprocessable_entity }
-      end
+    if @list_item.save
+      flash.now.notice = t("defaults.flash_message.created", item: ListItem.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: ListItem.model_name.human)
+      render :new, status: :unprocessable_entity
     end
   end
 
   def edit; end
 
   def update
-    respond_to do |format|
-      if @list_item.update(list_item_params)
-        format.turbo_stream { flash.now[:notice] = t("defaults.flash_message.updated", item: ListItem.model_name.human) }
-      else
-        flash.now[:alert] = t("defaults.flash_message.not_updated", item: ListItem.model_name.human)
-        format.turbo_stream { render :edit, status: :unprocessable_entity }
-      end
+    @reminder = @list_item.reminder || @list_item.build_reminder
+    if @list_item.update(list_item_params)
+      flash.now[:notice] = t("defaults.flash_message.updated", item: ListItem.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: ListItem.model_name.human)
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -38,23 +35,21 @@ class ListItemsController < ApplicationController
   end
 
   def cancel
-    respond_to do |format|
-      if params[:id].present?
-        # 編集時（edit）のキャンセル
-        @list_item = ListItem.find(params[:id])
-        format.turbo_stream
-      else
-        # 新規作成時（new）のキャンセル
-        @check_list = CheckList.find(params[:check_list_id])
-        format.turbo_stream { render "cancel_new" }
-      end
+    if params[:id].present?
+      # 編集時（edit）のキャンセル
+      @list_item = ListItem.find(params[:id])
+      @reminder = @list_item.reminder || @list_item.build_reminder
+    else
+      # 新規作成時（new）のキャンセル
+      @check_list = CheckList.find(params[:check_list_id])
+      render "cancel_new"
     end
   end
 
   def toggle
     @list_item.update(completed: !@list_item.completed)
     @reminder = @list_item.reminder || @list_item.build_reminder
-    render turbo_stream: turbo_stream.replace(@list_item, partial: "list_item", locals: { list_item: @list_item, reminder: @reminder })
+    render "toggle"
   end
 
   private

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -3,21 +3,42 @@ class RemindersController < ApplicationController
     @list_item = ListItem.find(params[:list_item_id])
     @check_list = @list_item.check_list
     @reminder = @list_item.build_reminder(reminder_params)
-    if @reminder.save
-      redirect_to check_list_path(@check_list), notice: t("defaults.flash_message.created", item: Reminder.model_name.human)
-    else
-      redirect_to check_list_path(@check_list), alert: t("defaults.flash_message.not_created", item: Reminder.model_name.human)
-    end
+      if @reminder.save
+        flash.now.notice = t("defaults.flash_message.created", item: Reminder.model_name.human)
+        render turbo_stream: [
+          # turbo_stream.remove("reminder_modal"),
+          turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }),
+          turbo_stream.update("flash_messages", partial: "shared/flash_message")
+        ]
+      else
+        # flash.now.alert = t("defaults.flash_message.not_created", item: Reminder.model_name.human)
+        render turbo_stream: [
+          turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }),
+          turbo_stream.update("flash_messages", partial: "shared/flash_message"),
+        ]
+      end
   end
 
   def update
-    @list_item = ListItem.find(params[:id])
-    @reminder = @list_item.reminder
+    @reminder = Reminder.find(params[:id])
+    @list_item = @reminder.list_item
     @check_list = @list_item.check_list
+
     if @reminder.update(reminder_params)
-      redirect_to check_list_path(@check_list), notice: t("defaults.flash_message.updated", item: Reminder.model_name.human)
+      flash.now.notice = t("defaults.flash_message.updated", item: Reminder.model_name.human)
+      render turbo_stream: [
+        # turbo_stream.remove("reminder_modal"),
+        turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }),
+        turbo_stream.update("flash_messages", partial: "shared/flash_message")
+      ]
     else
-      redirect_to check_list_path(@check_list), alert: t("defaults.flash_message.not_updated", item: Reminder.model_name.human)
+      # flash.now.alert = t("defaults.flash_message.not_updated", item: Reminder.model_name.human)
+      render turbo_stream: [
+        turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }),
+        turbo_stream.update("flash_messages", partial: "shared/flash_message"),
+        # turbo_stream.replace("modal", partial: "reminders/modal", locals: { list_item: @list_item, reminder: @reminder }),
+        # turbo_stream.update("flash_messages", partial: "shared/flash_message")
+      ]
     end
   end
 

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -3,20 +3,12 @@ class RemindersController < ApplicationController
     @list_item = ListItem.find(params[:list_item_id])
     @check_list = @list_item.check_list
     @reminder = @list_item.build_reminder(reminder_params)
-      if @reminder.save
-        flash.now.notice = t("defaults.flash_message.created", item: Reminder.model_name.human)
-        render turbo_stream: [
-          # turbo_stream.remove("reminder_modal"),
-          turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }),
-          turbo_stream.update("flash_messages", partial: "shared/flash_message")
-        ]
-      else
-        # flash.now.alert = t("defaults.flash_message.not_created", item: Reminder.model_name.human)
-        render turbo_stream: [
-          turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }),
-          turbo_stream.update("flash_messages", partial: "shared/flash_message"),
-        ]
-      end
+
+    if @reminder.save
+      flash.now[:notice] = t("defaults.flash_message.created", item: Reminder.model_name.human)
+    else
+      render "not_create"
+    end
   end
 
   def update
@@ -25,20 +17,9 @@ class RemindersController < ApplicationController
     @check_list = @list_item.check_list
 
     if @reminder.update(reminder_params)
-      flash.now.notice = t("defaults.flash_message.updated", item: Reminder.model_name.human)
-      render turbo_stream: [
-        # turbo_stream.remove("reminder_modal"),
-        turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }),
-        turbo_stream.update("flash_messages", partial: "shared/flash_message")
-      ]
+      flash.now[:notice] = t("defaults.flash_message.updated", item: Reminder.model_name.human)
     else
-      # flash.now.alert = t("defaults.flash_message.not_updated", item: Reminder.model_name.human)
-      render turbo_stream: [
-        turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }),
-        turbo_stream.update("flash_messages", partial: "shared/flash_message"),
-        # turbo_stream.replace("modal", partial: "reminders/modal", locals: { list_item: @list_item, reminder: @reminder }),
-        # turbo_stream.update("flash_messages", partial: "shared/flash_message")
-      ]
+      render "not_update"
     end
   end
 

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -6,7 +6,7 @@ class Reminder < ApplicationRecord
 
   def reminder_date_cannot_be_in_the_past
     if reminder_date.present? && reminder_date < Time.zone.now
-      errors.add(:reminder_date, "過去の日時は設定できません")
+      errors.add(:reminder_date, :reminder_date_cannot_be_in_the_past)
     end
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -2,4 +2,11 @@ class Reminder < ApplicationRecord
   belongs_to :list_item, optional: true
 
   validates :reminder_date, presence: true
+  validate :reminder_date_cannot_be_in_the_past
+
+  def reminder_date_cannot_be_in_the_past
+    if reminder_date.present? && reminder_date < Time.zone.now
+      errors.add(:reminder_date, "過去の日時は設定できません")
+    end
+  end
 end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -29,7 +29,7 @@ class TravelBook < ApplicationRecord
 
   def end_date_after_start_date
     if start_date.present? && end_date.present? && end_date < start_date
-      errors.add(:end_date, "must be after start date")
+      errors.add(:end_date, :end_date_after_start_date)
     end
   end
 end

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -20,10 +20,6 @@
       <%= turbo_frame_tag "list_item" do %>
         <% if @list_items.present? %>
           <% @list_items.each do |list_item| %>
-            <!-- リマインダー用エラーメッセージ -->
-            <div id="error_messages_<%= list_item.id %>">
-              <%= render "shared/error_messages", object: list_item.reminder || list_item.build_reminder %>
-            </div>
             <%= render "list_items/list_item", list_item: list_item %>
           <% end %>
         <% else %>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -24,5 +24,8 @@
       </div>
     </div>
   <% end %>
+
+  <div id="reminder_modal">
+    <%= render "reminders/modal", list_item: list_item, reminder: list_item.reminder %>
+  </div>
 <% end %>
-<%= render "reminders/modal", list_item: list_item %>

--- a/app/views/list_items/toggle.turbo_stream.erb
+++ b/app/views/list_items/toggle.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace(@list_item, partial: "list_item", locals: { list_item: @list_item, reminder: @reminder }) %>

--- a/app/views/reminders/_form.html.erb
+++ b/app/views/reminders/_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: reminder, url: reminder.new_record? ? list_item_reminders_path(list_item) : reminder_path(reminder) do |f| %>
+  <% if reminder.errors.any? %>
+  <div class="mt-5">
+    <ul>
+      <% reminder.errors.each do | error | %>
+        <li class="text-red-500"><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+  <% end %>
+  <div class="flex gap-2">
+    <%= f.datetime_field :reminder_date, value: reminder.reminder_date, class: "input input-bordered w-full" %>
+    <%= f.submit nil, class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/reminders/_modal.html.erb
+++ b/app/views/reminders/_modal.html.erb
@@ -4,18 +4,16 @@
       <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
     </form>
     <h3 class="text-lg font-bold">リマインダー設定</h3>
-    <% if list_item.reminder&.reminder_date %>
-      <p class="text-center m-5"><%= fmt_schedule_date(list_item.reminder.reminder_date) %>にリマインダーの設定がされています</p>
-    <% else %>
-      <p class="text-center m-5">リマインダーの設定はされていません</p>
-    <% end %>
-    <div class="m-5">
-      <%= form_with model: list_item.reminder, data: { turbo: false }, url: list_item.reminder.new_record? ? list_item_reminders_path(list_item) : reminder_path(list_item, list_item.reminder) do |f| %>
-        <div class="flex gap-2">
-          <%= f.datetime_field :reminder_date, value: list_item.reminder.reminder_date, class: "input input-bordered w-full" %>
-          <%= f.submit nil, class: "btn btn-primary" %>
-        </div>
+    <div class="m-5 text-center">
+      <p><%= list_item.title %></p>
+      <% if reminder&.persisted? %>
+        <p><%= fmt_schedule_date(list_item.reminder.reminder_date) %>にリマインダーの設定がされています</p>
+      <% else %>
+        <p>リマインダーの設定はされていません</p>
       <% end %>
+      <div id="reminder_form_<%= list_item.id %>" class="mt-5">
+        <%= render "reminders/form", list_item: list_item, reminder: reminder %>
+      </div>
     </div>
   </div>
 </dialog>

--- a/app/views/reminders/create.turbo_stream.erb
+++ b/app/views/reminders/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }) %>
+
+<%= turbo_stream.update("flash_messages", partial: "shared/flash_message") %>

--- a/app/views/reminders/not_create.turbo_stream.erb
+++ b/app/views/reminders/not_create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }) %>
+
+<%= turbo_stream.update("flash_messages", partial: "shared/flash_message") %>

--- a/app/views/reminders/not_update.turbo_stream.erb
+++ b/app/views/reminders/not_update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }) %>
+
+<%= turbo_stream.update("flash_messages", partial: "shared/flash_message") %>

--- a/app/views/reminders/update.turbo_stream.erb
+++ b/app/views/reminders/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }) %>
+
+<%= turbo_stream.update("flash_messages", partial: "shared/flash_message") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,6 @@ module Myapp
     end
 
     config.i18n.default_locale = :ja
+    config.time_zone = "Tokyo"
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,6 +8,7 @@ ja:
       check_list: チェックリスト
       list_item: リストアイテム
       traveler_type: 旅行スタイル
+      reminder: リマインダー
     attributes:
       travel_book:
         title: タイトル
@@ -36,3 +37,11 @@ ja:
         title: タイトル
       list_item:
         title: タイトル
+      reminder:
+        reminder_date: リマインドする時間
+    errors:
+      models:
+        reminder:
+          attributes:
+            reminder_date:
+              reminder_date_cannot_be_in_the_past: "に過去の日時は設定できません"

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -41,6 +41,10 @@ ja:
         reminder_date: リマインドする時間
     errors:
       models:
+        travel_book:
+          attributes:
+            end_date:
+              end_date_after_start_date: "は開始日以降の日付を入力してください"
         reminder:
           attributes:
             reminder_date:


### PR DESCRIPTION
# 概要
#163 で行ったリマインダー登録・編集機能に不備があったため修正しました。
リマインダーの登録はturboを使用するように修正しました。
リマインダー設定用のmodalではリストアイテムのタイトルとバリデーションエラーを表示するように修正。
また、i18n対応を行いました。

## 実施内容
- [x] ReminderController#create,#updateでturboで部分更新するように修正
  - リマインダー設定用のformをパーシャル化
- [x] リマインダー設定用modalでリストアイテムのタイトルとバリデーションエラーを表示
- [x] アプリのタイムゾーン設定(Tokyo)
- [x] リストアイテムの作成・チェックボックスの更新時にreminderがnilであることによるエラーを解消
  - ListItemsController#create,#update,#cancel,#toggleでlist_itemにreminderが紐づいていない場合build_reminderする
- [x] i18n対応

### 修正前
[![Image from Gyazo](https://i.gyazo.com/eb6b7b3cfad0323c431af635eb2f5173.gif)](https://gyazo.com/eb6b7b3cfad0323c431af635eb2f5173)

### 修正後
[![Image from Gyazo](https://i.gyazo.com/1c9d433637928985ba8be1f7e6be2dcd.gif)](https://gyazo.com/1c9d433637928985ba8be1f7e6be2dcd)

バリデーションエラー
[![Image from Gyazo](https://i.gyazo.com/2d9cf41a4f50f15dcd47de84f3e07a70.gif)](https://gyazo.com/2d9cf41a4f50f15dcd47de84f3e07a70)

## 未実施内容
なし

## 補足
- しおり作成時のカスタムバリデーションのエラーメッセージも合わせてi18n対応しました。

## 関連issue
#160 