### PR TITLE
Fix/RemindersControllerのcreateアクションを定義

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,6 +1,18 @@
 class RemindersController < ApplicationController
   before_action :set_reminder, only: %i[ update clear_reminder ]
 
+  def create
+    @list_item = ListItem.find(params[:list_item_id])
+    @check_list = @list_item.check_list
+    @reminder = @list_item.build_reminder(reminder_params)
+
+    if @reminder.save
+      flash.now[:notice] = t("flash_message.reminder.created", item: Reminder.model_name.human)
+    else
+      render "not_create"
+    end
+  end
+
   def update
     if @reminder.update(reminder_params)
       flash.now[:notice] = t("flash_message.reminder.updated", item: Reminder.model_name.human)

--- a/app/views/reminders/create.turbo_stream.erb
+++ b/app/views/reminders/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace("list_item_#{@list_item.id}", partial: "list_items/list_item", locals: { list_item: @list_item, reminder: @reminder }) %>
+<%= turbo_stream.update("flash_messages", partial: "shared/flash_message") %>

--- a/app/views/reminders/not_create.turbo_stream.erb
+++ b/app/views/reminders/not_create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update("reminder_form_#{@list_item.id}", partial: "reminders/form", locals: { list_item: @list_item, reminder: @reminder }) %>
+<%= turbo_stream.update("flash_messages", partial: "shared/flash_message") %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -26,6 +26,7 @@ ja:
       deleted: "%{item}を削除しました"
   flash_message:
     reminder:
+      created: "%{item}を設定しました"
       updated: "%{item}を設定しました"
       canceled: "%{item}設定を解除しました"
       not_canceled: "%{item}設定を解除できませんでした"


### PR DESCRIPTION
# 概要
#165 でRemindersControllerのcreateアクションを削除してしまったため追記修正しました。

## 実施内容
- [x] RemindersController#createを定義
- [x] turboでレンダリングするビューファイルを生成
- [x] ja.ymlファイルにflashメッセージを追記

## 未実施内容
なし

## 補足
#165 の修正です。

## 関連issue
#165 