### PR TITLE
Fix/リマインダーを解除するときはバリデーションをスキップするように修正

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -22,7 +22,9 @@ class RemindersController < ApplicationController
   end
 
   def clear_reminder
-    if @reminder.update(reminder_date: nil)
+    @reminder.assign_attributes(reminder_date: nil)
+    # バリデーションをスキップ
+    if @reminder.save(validate: false)
       flash.now[:notice] = t("flash_message.reminder.canceled", item: Reminder.model_name.human)
     else
       flash.now[:alert] = t("flash_message.reminder.not_canceled", item: Reminder.model_name.human)


### PR DESCRIPTION
# 概要
リマインダーを解除する際にバリデーションエラーのためフラッシュメッセージが表示されていたため、
バリデーションをスキップするように修正しました。

## 実施内容
- [x] ReminderController#clear_reminderの時はバリデーションをスキップするように設定

## 未実施内容
なし

## 補足
リマインダー設定formで空の日付を送信された場合はバリデーションエラーを表示したかったため、Remindersテーブルのreminder_dateはpresence:trueのバリデーションを入れていますが、リマインダー解除する際はreminder_dateをnullにするため、clear_reminderアクションの場合のみバリデーションを解除するように修正しました。

## 関連issue
#165 