### PR TITLE
Feature/LINEプッシュ通知のキャンセル(ジョブの削除)

### DIFF
--- a/app/service/job_delete_service.rb
+++ b/app/service/job_delete_service.rb
@@ -1,0 +1,8 @@
+class JobDeleteService
+  def self.call(job_id)
+    Rails.logger.info "「#{job_id}」を削除します"
+    ss = Sidekiq::ScheduledSet.new
+    job = ss.find { |job| job.args[0]["job_id"] == job_id }
+    job.delete if job
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,8 @@
 # Sideliqのサーバーとクライアントが同じRedisサーバーに接続するように設定
 Sidekiq.configure_server do |config|
-  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL", nil) : ENV["REDIS_URL_DEVELOPMENT"] }
+  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL") : "redis://localhost:6379" }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL", nil) : ENV["REDIS_URL_DEVELOPMENT"] }
+  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL") : "redis://localhost:6379" }
 end

--- a/db/migrate/20250305113836_add_job_id_to_reminders.rb
+++ b/db/migrate/20250305113836_add_job_id_to_reminders.rb
@@ -1,0 +1,5 @@
+class AddJobIdToReminders < ActiveRecord::Migration[7.2]
+  def change
+    add_column :reminders, :job_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_02_015549) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_05_113836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,6 +44,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_02_015549) do
     t.bigint "list_item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "job_id"
     t.index ["list_item_id"], name: "index_reminders_on_list_item_id"
   end
 


### PR DESCRIPTION
# 概要
リマインダーの作成・更新時にジョブを設定しているが、
リマインダー時刻の更新時とリマインダー解除にSidekiq APIを使用し、設定されたジョブを削除します。
- リマインダー時刻更新時：設定されたジョブを削除し、新たなジョブを生成
- リマインダー解除時：設定されたジョブを削除

## 実施内容
- [x] Remindersテーブルにjob_idカラムを追加
- [x] RemindersController#create,#updateでjob_idを格納
- [x] RemindersController#update,#clear_reminderでjob_idをもとにSidekiq APIで不要なジョブを削除
- [x] ジョブの削除をService(JobDeleteService)に移行
- [x] Sidekiqの接続先のRedisサーバーを指定するコードを変更

## 未実施内容
- リマインダー設定され、リマインダー時刻が過ぎてもリマインダー時刻は削除、更新されません(※今後要検討)

## 補足
- 合わせて、Sidekiqの接続先のRedisサーバーを指定するコードを変更しました(config/initializers/sidekiq.rb)

## 関連issue
#186 , #177 