### PR TITLE
Feature/LINE友だち追加ボタンの設置とLINEアカウント連携機能

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -21,8 +21,10 @@ class LinebotController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           handle_message_event(event)
         when Line::Bot::Event::MessageType::Follow #友だち追加
-          userId = event["source"]["userId"]
-          Rails.logger.info "#{userId}が友だち追加されました"
+          # userId = event["source"]["userId"]
+          # Rails.logger.info "#{userId}が友だち追加されました"
+          # LINE Developersで挨拶メッセージを登録しています
+          # reply(event, "友だち登録ありがとうございます！LINEアカウントとTabiClipアカウントを連携すると、リマインダー機能を使用することができます！アカウント連携するためには、マイページのアカウント連携tokenをコピーして送信してください！")
         when Line::Bot::Event::MessageType::Unfollow #友だち削除
           userId = event["source"]["userId"]
           user = User.find_by(uid: userId)
@@ -41,7 +43,7 @@ class LinebotController < ApplicationController
     line_user_id = event["source"]["userId"]
 
     # 送信されたテキストがパターンマッチしない場合
-    return reply(event, "マイページのアカウント連携tokenをコピーして送信してね！") unless received_text.match?(/\A連携:[a-f0-9]{32}\z/)
+    return reply(event, "マイページのアカウント連携tokenをコピーして送信してください！") unless received_text.match?(/\A連携:[a-f0-9]{32}\z/)
 
     # received_textからtokenを取り出す(連携:の文字を削除)
     token = received_text.sub("連携:","")

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,0 +1,72 @@
+class LinebotController < ApplicationController
+  # gem 'line-bot-api'
+  require "line/bot"
+
+  # callbackアクションのCSRFトークン認証を無効
+  protect_from_forgery except: :callback
+
+  def callback
+    body = request.body.read
+    # リクエストヘッダーの署名を検証しLINEプラットフォームからのリクエストであることを確認
+    signature = request.env["HTTP_X_LINE_SIGNATURE"]
+    unless LINE_CLIENT.validate_signature(body, signature)
+      error 400 do "Bad Request" end
+    end
+
+    events = LINE_CLIENT.parse_events_from(body)
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message
+        case event.type
+        when Line::Bot::Event::MessageType::Text
+          handle_message_event(event)
+        when Line::Bot::Event::MessageType::Follow #友だち追加
+          userId = event["source"]["userId"]
+          Rails.logger.info "#{userId}が友だち追加されました"
+        when Line::Bot::Event::MessageType::Unfollow #友だち削除
+          userId = event["source"]["userId"]
+          user = User.find_by(uid: userId)
+          user.update(uid: nil) if user
+        end
+      end
+    end
+    # Don't forget to return a successful response
+    head :ok
+  end
+
+  private
+
+  def handle_message_event(event)
+    received_text = event["message"]["text"]
+    line_user_id = event["source"]["userId"]
+
+    # 送信されたテキストがパターンマッチしない場合
+    return reply(event, "マイページのアカウント連携tokenをコピーして送信してね！") unless received_text.match?(/\A連携:[a-f0-9]{32}\z/)
+
+    # received_textからtokenを取り出す(連携:の文字を削除)
+    token = received_text.sub("連携:","")
+    # tokenでUserを取得
+    user = User.find_by(token: token)
+
+    # tokenでuserが特定できない場合
+    return reply(event, "無効なtokenです。マイページのアカウント連携tokenを確認してください！") unless user
+
+    # すでにユーザーのuidが登録されている場合
+    return reply(event, "LINEアカウントとTabiClipアカウントの連携が完了しています！ぜひリマインダー設定してみてくださいね！※LINEログインを利用している場合はすでにアカウントが連携されています") if user.uid
+
+    # ユーザーのuidを更新
+    if user.update(uid: line_user_id)
+      reply(event, "LINEアカウントとTabiClipのアカウント連携が完了しました！")
+    else
+      reply(event, "LINEアカウントとTabiClipのアカウント連携に失敗しました。もう一度tokenを送信してください！")
+    end
+  end
+
+  def reply(event, text)
+    message = {
+      type: "text",
+      text: text
+    }
+    return LINE_CLIENT.reply_message(event["replyToken"], message)
+  end
+end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -20,12 +20,12 @@ class LinebotController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           handle_message_event(event)
-        when Line::Bot::Event::MessageType::Follow #友だち追加
+        when Line::Bot::Event::MessageType::Follow # 友だち追加
           # userId = event["source"]["userId"]
           # Rails.logger.info "#{userId}が友だち追加されました"
           # LINE Developersで挨拶メッセージを登録しています
           # reply(event, "友だち登録ありがとうございます！LINEアカウントとTabiClipアカウントを連携すると、リマインダー機能を使用することができます！アカウント連携するためには、マイページのアカウント連携tokenをコピーして送信してください！")
-        when Line::Bot::Event::MessageType::Unfollow #友だち削除
+        when Line::Bot::Event::MessageType::Unfollow # 友だち削除
           userId = event["source"]["userId"]
           user = User.find_by(uid: userId)
           user.update(uid: nil) if user
@@ -46,7 +46,7 @@ class LinebotController < ApplicationController
     return reply(event, "マイページのアカウント連携tokenをコピーして送信してください！") unless received_text.match?(/\A連携:[a-f0-9]{32}\z/)
 
     # received_textからtokenを取り出す(連携:の文字を削除)
-    token = received_text.sub("連携:","")
+    token = received_text.sub("連携:", "")
     # tokenでUserを取得
     user = User.find_by(token: token)
 
@@ -69,6 +69,6 @@ class LinebotController < ApplicationController
       type: "text",
       text: text
     }
-    return LINE_CLIENT.reply_message(event["replyToken"], message)
+    LINE_CLIENT.reply_message(event["replyToken"], message)
   end
 end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,4 +1,5 @@
 class ListItemsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_check_list, only: %i[ new create ]
   before_action :set_list_item, only: %i[ edit update destroy toggle]
 

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,4 +1,5 @@
 class RemindersController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_reminder, only: %i[ update clear_reminder ]
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+
   def show
     @user = current_user
   end

--- a/app/decorators/line_bot_decorator.rb
+++ b/app/decorators/line_bot_decorator.rb
@@ -1,0 +1,12 @@
+class LineBotDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,15 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[ line ]
 
+  before_create :generate_unique_token
+
+  def generate_unique_token
+    self.token = loop do
+      random_token = SecureRandom.hex(16)
+      break random_token unless User.exists?(token: random_token)
+    end
+  end
+
   def social_profile(provider)
     social_profiles.select { |sp| sp.provider == provider.to_s }.first
   end

--- a/app/views/check_lists/_check_list.html.erb
+++ b/app/views/check_lists/_check_list.html.erb
@@ -1,4 +1,4 @@
-<%= link_to check_list_path(check_list), class: "block" do %>
+<%= link_to check_list_path(check_list), data: { turbo: false }, class: "block" do %>
   <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:opacity-50">
     <i class="fa-solid fa-square-check"></i>
     <div class="ml-3"><%= check_list.title %></div>

--- a/app/views/check_lists/_form.html.erb
+++ b/app/views/check_lists/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: check_list, url: check_list.new_record? ? travel_book_check_lists_path(travel_book) : check_list_path(check_list) do |f| %>
+<%= form_with model: check_list, url: check_list.new_record? ? travel_book_check_lists_path(travel_book) : check_list_path(check_list), data: { turbo: false } do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
   <div class="field mt-3">

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
     <div class="flex items-center justify-between">
-      <%= link_to check_list_path(@check_list), class:"hover:opacity-50" do %>
+      <%= link_to check_list_path(@check_list), data: { turbo: false }, class:"hover:opacity-50" do %>
         <i class="fa-solid fa-chevron-left"></i>
       <% end %>
       <h3 class="flex-grow text-center"><%= t(".title") %></h1>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -32,5 +32,15 @@
       </div>
       <div id="list_item_form"></div>
     </div>
+
+    <div role="alert" class="alert alert-vertical sm:alert-horizontal">
+      <i class="fa-solid fa-circle-info text-primary"></i>
+
+      <span>LINEの友だち追加すると<i class="fa-solid fa-bell"></i>で設定した時刻にLINEでリマインダーが届きます</span>
+      <div>
+        <div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@450oywta" style="display: none;"></div>
+        <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,24 @@
       <p><%= @user.email %></p>
     </div>
 
+    <% unless @user.uid %>
+      <div class="mt-5 flex justify-center">
+        <button class="btn text-white bg-[#06C755] hover:bg-[#06C755] hover:opacity-50" onclick="link_line_modal.showModal()">LINEアカウント連携</button>
+      </div>
+      <dialog id="link_line_modal" class="modal">
+        <div class="modal-box">
+          <form method="dialog">
+            <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+          </form>
+          <h3 class="text-lg font-bold">LINEアカウント連携用トークン</h3>
+          <div class="m-5 text-center">
+            <p>以下のtokenをTabiClip公式LINEに送信してください</p>
+            <p>連携:<%= @user.token %></p>
+          </div>
+        </div>
+      </dialog>
+    <% end %>
+
     <div class="mt-5">
       <%= link_to t(".profile_button"), edit_user_registration_path, class: "btn btn-primary w-full mt-6 mx-auto" %>
     </div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,6 +3,8 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate
-# DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
-# bundle exec rails db:seed
+# 通常
+# bundle exec rails db:migrate
+# DBをリセットする際に実行
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
+bundle exec rails db:seed

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,8 @@
 # Sideliqのサーバーとクライアントが同じRedisサーバーに接続するように設定
 Sidekiq.configure_server do |config|
-  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL") : "redis://localhost:6379" }
+  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL", nil) : ENV["REDIS_URL_DEVELOPMENT"] }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL") : "redis://localhost:6379" }
+  config.redis = { url: Rails.env.production? ? ENV.fetch("REDIS_URL", nil) : ENV["REDIS_URL_DEVELOPMENT"] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     passwords: "users/passwords",
     omniauth_callbacks: "users/omniauth_callbacks"
   }
+  post "/callback" => "linebot#callback"
   get "users/profile" => "users#show"
   get "home/index"
   resources :travel_books do

--- a/db/migrate/20250307073014_add_token_to_users.rb
+++ b/db/migrate/20250307073014_add_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddTokenToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :token, :string
+    add_index :users, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_05_113836) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_07_073014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -119,8 +119,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_05_113836) do
     t.string "icon_image"
     t.string "provider"
     t.string "uid"
+    t.string "token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["token"], name: "index_users_on_token", unique: true
   end
 
   add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"


### PR DESCRIPTION
# 概要
TabiClip公式LINEの友だち追加ボタンを設置しました。
また、LINEログインを利用していないユーザー向けに、TabiClipのアカウントとLINEアカウントを連携する機能を実装しました。

**なぜTabiClipのアカウントとLINEアカウントを連携する必要があるのか？**
TabiClipで作成したチェックリストのリマインダー機能を利用してもらうため。
リマインダー時刻を設定することで、LINEプッシュ通知が送信される。

## 実施内容
- [x] チェックリストの画面にLINE友だち追加ボタンを設置
- [x] LINE友だち追加ボタン表示のため一部turboを無効化
- [x] Usersテーブルにtokenカラム追加
- [x] アカウント登録時にtokenの発行
- [x] webhook用ルーティング追加
- [x] webhookでアクションを追加
  - LINEでメッセージ(token)を受け取った際にTabiClipアカウントとLINEアカウントを連携
  - LINE友だち解除された際にTabiClipのアカウントからuidを削除
- [x] LINE Developersで友だち追加された際のあいさつメッセージを編集
- [x] マイページにLINE連携用token表示(uidが登録されていない場合)
- [x] ログインが必要なアクションのコントローラーにbefore_actionを追加
- [x] 本番用DBのリセット

### 実装イメージ

- LINE友だち追加ボタン
[![Image from Gyazo](https://i.gyazo.com/a447d623a629dad0565c88eca1ecbe6c.png)](https://gyazo.com/a447d623a629dad0565c88eca1ecbe6c)

- LINE友だち追加されたときのLINE画面
[![Image from Gyazo](https://i.gyazo.com/ff6a33a47a9d3c9d3becdd5fc798528e.png)](https://gyazo.com/ff6a33a47a9d3c9d3becdd5fc798528e)

- マイページのLINE連携用tokenを表示(ユーザーにuidがない場合のみ)
[![Image from Gyazo](https://i.gyazo.com/8180bef0845fb525d56392a4ea73dcdd.gif)](https://gyazo.com/8180bef0845fb525d56392a4ea73dcdd)

- LINEアカウント連携用token送信時の応答メッセージ
  - 正常なtokenメッセージを送信した場合
  - 存在しないtokenを送信した場合
  - tokenではないメッセージが送信された場合
  - すでにアカウント連携されている場合 
[![Image from Gyazo](https://i.gyazo.com/4af10852046e24b905406d4fe6fdadc2.png)](https://gyazo.com/4af10852046e24b905406d4fe6fdadc2)

## 未実施内容
- LINEアカウント連携用tokenのクリップボードコピー機能(※別issueにて対応)
- LINEアカウント連携成功時にTabiClipのURLをメッセージに含めるか要検討

## 補足
- sidekiqの連携先Redisサーバーの設定を修正(#187 の修正)
- ログインが必要なアクションのコントローラーにbefore_actionを追加
  - 設定漏れに気づいたため対応
- 本番用DBのリセット
  - ユーザーにtokenを発行することに伴いDBリセット(現状重要なデータないため)

## 関連issue
#188, #187  