### PR TITLE
Feature/リマインダーレコード定期削除

### DIFF
--- a/app/jobs/delete_reminder_record_job.rb
+++ b/app/jobs/delete_reminder_record_job.rb
@@ -1,0 +1,8 @@
+class DeleteReminderRecordJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Reminder.where("reminder_date < ?", Time.zone.now).delete_all
+    Rails.logger.info "現在時刻：#{Time.zone.now}"
+  end
+end

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,7 +4,7 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 # 通常
-# bundle exec rails db:migrate
+bundle exec rails db:migrate
 # DBをリセットする際に実行
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
-bundle exec rails db:seed
+# DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
+# bundle exec rails db:seed

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,8 @@
 :concurrency: 3
 :queues:
   - default
+:scheduler:
+  :schedule:
+    delete_reminder_record:
+      cron: "0 * * * * *"
+      class: DeleteReminderRecordJob


### PR DESCRIPTION
# 概要
リマインダーに設定している時刻(Remindersテーブルのreminder_date)を経過したら、リマインダーを削除するために
ジョブを作成し、Sidekiqで毎分の定期実行を設定しました。

## 実施内容
- [x] リマインダー削除ジョブを作成
- [x] リマインダー削除ジョブを毎分実行するようにスケジュール設定
- [x] ビルドスクリプトのDBリセット処理のコメントアウト

## 未実施内容
なし

## 補足
- デプロイ時(render-build.sh)のDBのリセット処理をコメントアウト(#189)

## 関連issue
#191 