### PR TITLE
Feature/しおりのメンバー表示機能

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -59,6 +59,11 @@ class TravelBooksController < ApplicationController
     @travel_books = TravelBook.where(is_public: true).includes(:users).order(:created_at).page(params[:page])
   end
 
+  def share
+    @travel_book = TravelBook.find(params[:id])
+    @users = @travel_book.users
+  end
+
   private
 
   def travel_book_param

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -1,0 +1,36 @@
+<div class="container">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
+
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_path(@travel_book), data: { turbo: false }, class: "hover:opacity-50" do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center">メンバーリスト</h3>
+    </div>
+
+      <table class="table">
+        <tbody>
+          <% @users.each do |user| %>
+            <tr class="border-b last:border-none">
+              <td>
+                <div class="flex justify-between items-center">
+                  <div class="flex items-center gap-3">
+                    <%= image_tag user.icon_image_url, class: "rounded-full w-10 h-10 object-cover border border-gray-200" %>
+                    <%= user.name %>
+                  </div>
+                    <div class="dropdown dropdown-end">
+                      <div tabindex="0" role="button" class="btn btn-circle">
+                        <i class="fa-solid fa-ellipsis-vertical"></i>
+                      </div>
+                      <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+                        <li>削除</li>
+                      </ul>
+                    </div>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+  </div>
+</div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -13,10 +13,13 @@
           <h3 class="flex-grow text-center"><%= @travel_book.title %></h3>
           <% if @travel_book.owned_by_user?(current_user) %>
             <div class="justify-end">
-              <%= link_to edit_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
+              <%= link_to share_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
+                <i class="fa-solid fa-share-from-square"></i>
+              <% end %>
+              <%= link_to edit_travel_book_path(@travel_book), class: "ml-3 hover:opacity-50" do %>
                 <i class="fa-solid fa-pen"></i>
               <% end %>
-              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-3 hover:opacity-50" do %>
                 <i class="fa-solid fa-trash"></i>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
     collection do
       get "public", action: :public_travel_books
     end
+    member do
+      get :share
+    end
     delete "delete_image", on: :member
     resources :schedules, shallow: true do
       collection do


### PR DESCRIPTION
# 概要
しおりを所有するメンバーを表示する機能を実装しました。

## 実施内容
- [x] メンバーリスト画面へのルーティング設定
- [x] TravelBookControllers#shareアクションを定義
- [x] メンバーリスト画面へ遷移するリンクを設置
- [x] しおりのメンバー表示ビューの作成

## 未実施内容
- しおり所有メンバーの削除機能（別issueで対応）

## 補足
現在しおり作者以外のユーザーを紐づける機能は未実装です。

## 関連issue
#190 