### PR TITLE
Feature/しおりの招待機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 # ユーザー認証
 gem "devise"
+# 招待機能
+gem "devise_invitable"
 
 # LINEログイン
 gem "omniauth-line"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise_invitable (2.0.9)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     dotenv (3.1.7)
     dotenv-rails (3.1.7)
       dotenv (= 3.1.7)
@@ -451,6 +454,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  devise_invitable
   dotenv-rails
   draper
   fog-aws

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -6,7 +6,25 @@ class Users::InvitationsController < Devise::InvitationsController
   end
 
   def create
-    super
+    user_email = params[:user][:email]
+    travel_book_uuid = params[:user][:travel_book_uuid]
+    travel_book = TravelBook.find_by(uuid: travel_book_uuid)
+    user = User.find_by(email: user_email)
+
+    if user.present?
+      user.invite!(current_user)
+      user.update(invited_by_travel_book_id: travel_book_uuid)
+      redirect_to travel_book_path(travel_book), notice: "招待メールが #{user_email} に送信されました"
+    else
+      user = User.invite!({ email: user_email }, current_user)
+      user.update(invited_by_travel_book_id: travel_book_uuid)
+      if user.valid?
+        redirect_to travel_book_path(travel_book), notice: "招待メールが #{user_email} に送信されました"
+      else
+        flash[:alert] = "メールアドレスを正しく入力してください"
+        render "new", locals: { invited_by_travel_book_id: travel_book_uuid, resource: User.new, resource_name: :user }
+      end
+    end
   end
 
   def edit
@@ -14,17 +32,46 @@ class Users::InvitationsController < Devise::InvitationsController
   end
 
   def update
-    super
+    # リダイレクト先を招待されたしおりのビューにリダイレクトさせるために、元々の承認後の動作をオーバーライド
+    self.resource = accept_resource
+
+    # オーバーライドする場合、自分でサインインしないといけないみたい(オーバーライドする際は自動ログイン)
+    sign_in(resource_name, resource)
+
+    # createアクションでuserに保存しておいたしおりのidを取得
+    travel_book_uuid = resource.invited_by_travel_book_id
+
+    if travel_book_uuid.present?
+      # 中間テーブルに招待ユーザーと対象のしおりのidを保存
+      user_travel_book = UserTravelBook.new
+      user_travel_book.user_id = resource.id
+      user_travel_book.travel_book_uuid = travel_book_uuid
+      user_travel_book.save
+
+      travel_book = TravelBook.find_by(uuid: travel_book_uuid)
+      # 招待されたしおりにリダイレクト
+      redirect_to travel_book_path(travel_book), notice: "#{travel_book.title} に参加しました"
+    else
+      redirect_to root_path, notice: "しおりに参加できませんでした"
+    end
   end
 
   def destroy
     super
   end
 
+  private
+
+  # 招待を受け入れる処理をオーバーライド
+  def accept_resource
+    resource = resource_class.accept_invitation!(update_resource_params)
+    resource
+  end
+
   protected
 
-  # Permit the new params here.
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:invite, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: [ :name ])
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,30 @@
+class Users::InvitationsController < Devise::InvitationsController
+  before_action :configure_permitted_parameters
+
+  def new
+    super
+  end
+
+  def create
+    super
+  end
+
+  def edit
+    super
+  end
+
+  def update
+    super
+  end
+
+  def destroy
+    super
+  end
+
+  protected
+
+  # Permit the new params here.
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:invite, keys: [ :name ])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,9 +6,9 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[ line ]
+         :omniauthable, omniauth_providers: %i[ line ], invite_for: 24.hours
 
   before_create :generate_unique_token
 

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,27 @@
+<h2><%= t "devise.invitations.edit.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :invitation_token, readonly: true %>
+
+  <% if f.object.class.require_password_on_accepting %>
+    <div class="field">
+      <%= f.label :name %><br />
+      <%= f.text_field :name %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password %><br />
+      <%= f.password_field :password %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.edit.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,27 +1,40 @@
-<h2><%= t "devise.invitations.edit.header" %></h2>
+<div class="container">
+  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
+    <h2><%= t "devise.invitations.edit.header" %></h2>
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :invitation_token, readonly: true %>
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :invitation_token, readonly: true %>
 
-  <% if f.object.class.require_password_on_accepting %>
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name %>
-    </div>
+      <% if f.object.class.require_password_on_accepting %>
+        <div class="field mt-3">
+          <div class="flex items-center gap-1">
+            <%= f.label :name, class: "label" %>
+            <i class="fa-solid fa-user"></i>
+          </div>
+          <%= f.text_field :name, class: "input input-bordered w-full" %>
+        </div>
 
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password %>
-    </div>
+        <div class="field mt-3">
+          <div class="flex items-center gap-1">
+            <%= f.label :password, class: "label" %>
+            <i class="fa-solid fa-key"></i>
+          </div>
+          <%= f.password_field :password, class: "input input-bordered w-full" %>
+        </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation %>
-    </div>
-  <% end %>
+        <div class="field mt-3">
+          <div class="flex items-center gap-1">
+          <%= f.label :password_confirmation, class: "label" %>
+          <i class="fa-solid fa-key"></i>
+        </div>
+          <%= f.password_field :password_confirmation, class: "input input-bordered w-full" %>
+        </div>
+      <% end %>
 
-  <div class="actions">
-    <%= f.submit t("devise.invitations.edit.submit_button") %>
+      <div class="actions">
+        <%= f.submit t("devise.invitations.edit.submit_button"), class: "btn btn-primary w-full mt-6 mx-auto" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,16 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <% resource.class.invite_key_fields.each do |field| -%>
+    <div class="field">
+      <%= f.label field %><br />
+      <%= f.text_field field %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.new.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,16 +1,26 @@
-<h2><%= t "devise.invitations.new.header" %></h2>
+<div class="container">
+  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
+    <h2><%= t "devise.invitations.new.header" %></h2>
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
 
-  <% resource.class.invite_key_fields.each do |field| -%>
-    <div class="field">
-      <%= f.label field %><br />
-      <%= f.text_field field %>
-    </div>
-  <% end -%>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions">
-    <%= f.submit t("devise.invitations.new.submit_button") %>
+      <% resource.class.invite_key_fields.each do |field| -%>
+        <div class="field mt-3">
+          <div class="flex items-center gap-1">
+            <%= f.label :email, class: "label" %>
+            <i class="fa-solid fa-envelope"></i>
+          </div>
+          <%= f.email_field field, autocomplete: "email", placeholder: "xxx@example.com", class: "input input-bordered w-full" %>
+
+          <%= f.hidden_field :travel_book_uuid, value: params[:travel_book_uuid] %>
+        </div>
+      <% end -%>
+
+      <div class="actions">
+        <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-primary w-full mt-6 mx-auto" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -8,29 +8,34 @@
       <h3 class="flex-grow text-center">メンバーリスト</h3>
     </div>
 
-      <table class="table">
-        <tbody>
-          <% @users.each do |user| %>
-            <tr class="border-b last:border-none">
-              <td>
-                <div class="flex justify-between items-center">
-                  <div class="flex items-center gap-3">
-                    <%= image_tag user.icon_image_url, class: "rounded-full w-10 h-10 object-cover border border-gray-200" %>
-                    <%= user.name %>
-                  </div>
-                    <div class="dropdown dropdown-end">
-                      <div tabindex="0" role="button" class="btn btn-circle">
-                        <i class="fa-solid fa-ellipsis-vertical"></i>
-                      </div>
-                      <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-                        <li>削除</li>
-                      </ul>
-                    </div>
+    <table class="table">
+      <tbody>
+        <% @users.each do |user| %>
+          <tr class="border-b last:border-none">
+            <td>
+              <div class="flex justify-between items-center">
+                <div class="flex items-center gap-3">
+                  <%= image_tag user.icon_image_url, class: "rounded-full w-10 h-10 object-cover border border-gray-200" %>
+                  <%= user.name %>
                 </div>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+                  <div class="dropdown dropdown-end">
+                    <div tabindex="0" role="button" class="btn btn-circle">
+                      <i class="fa-solid fa-ellipsis-vertical"></i>
+                    </div>
+                    <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+                      <li>削除</li>
+                    </ul>
+                  </div>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <div class="text-right mt-5">
+      <%= link_to new_user_invitation_path(travel_book_uuid: @travel_book.uuid), class: "btn btn-primary hover:opacity-50" do %>
+        <i class="fa-solid fa-share-from-square"></i>メンバーを招待
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -34,7 +34,7 @@
     </table>
     <div class="text-right mt-5">
       <%= link_to new_user_invitation_path(travel_book_uuid: @travel_book.uuid), class: "btn btn-primary hover:opacity-50" do %>
-        <i class="fa-solid fa-share-from-square"></i>メンバーを招待
+        <i class="fa-solid fa-envelope"></i>メンバーを招待
       <% end %>
     </div>
   </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "no-reply@exampel.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     sessions: "users/sessions",
     passwords: "users/passwords",
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
+    invitations: "users/invitations"
   }
   post "/callback" => "linebot#callback"
   get "users/profile" => "users#show"

--- a/db/migrate/20250310075105_devise_invitable_add_to_users.rb
+++ b/db/migrate/20250310075105_devise_invitable_add_to_users.rb
@@ -1,0 +1,22 @@
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[7.2]
+  def up
+    change_table :users do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitation_token, unique: true # for invitable
+      t.index      :invited_by_id
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+    end
+  end
+end

--- a/db/migrate/20250311051027_add_invited_by_travel_book_id_to_users.rb
+++ b/db/migrate/20250311051027_add_invited_by_travel_book_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddInvitedByTravelBookIdToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :invited_by_travel_book_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_10_075105) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_11_051027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -128,6 +128,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_10_075105) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.string "invited_by_travel_book_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_07_073014) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_10_075105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -120,7 +120,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_07_073014) do
     t.string "provider"
     t.string "uid"
     t.string "token"
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.integer "invitations_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["token"], name: "index_users_on_token", unique: true
   end


### PR DESCRIPTION
# 概要
gem devise_invitableを導入し、しおりへの招待機能(招待メール送信機能)を実装しました。

## 実施内容
- [x] gem devise_invitableを導入
- [x] devise_invitable用カラム追加
- [x] Userモデルにdevise_invitableのオプション追加
- [x] devise_invitable用ビューを追加
- [x] devise_invitable用ルーティング設定
- [x] usersテーブルに招待されているtravel_book_uuidを一時保存する(invited_by_travel_book_id)を追加
- [x] deviseに仮のメールアドレスを設定
- [x] メンバー招待メール送信画面のリンクを設置
- [x] invitations/newにhidden_fieldでtravel_book_uuidパラメーターを設置
- [x] InvitationsControllerをオーバーライド
  - ストロングパラメーターの拡張
  - createアクションでurlから受け取ったtravel_book_uuidをinvited_by_travel_book_idへ保存
  - updateアクションで招待userとinvited_by_travel_book_idをもとにuser_travel_books(中間)テーブルに保存
  - updateアクションのリダイレクト先をtravel_book_pathもしくはroot_pathへ変更
- [x] devise_invitable用ビューのCSS調整

## 未実施内容
- アプリのメールアドレスの設定

## 補足
deviseで送信元のアドレスを仮(存在しないメールアドレス)にしているため、この後アドレスを発行して設定します。

## 関連issue
#194 