### PR TITLE
Feature/メールサーバーの設定

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,14 +35,23 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:"smtp.gmail.com",
+    domain: "smtp.gmail.com",
+    port:587,
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,9 +44,9 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:"smtp.gmail.com",
+    address: "smtp.gmail.com",
     domain: "smtp.gmail.com",
-    port:587,
+    port: 587,
     user_name: ENV["MAILER_SENDER"],
     password: ENV["MAILER_PASSWORD"],
     authentication: :login,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,14 +81,13 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: "https://tabiclip.onrender.com"}
+  config.action_mailer.default_url_options = { host: "https://tabiclip.onrender.com" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.default :charset => "utf-8"
   config.action_mailer.smtp_settings = {
-    address:"smtp.gmail.com",
-    domain: 'smtp.gmail.com',
-    port:587,
+    address: "smtp.gmail.com",
+    domain: "smtp.gmail.com",
+    port: 587,
     user_name: ENV["MAILER_SENDER"],
     password: ENV["MAILER_PASSWORD"],
     authentication: :login,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,20 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: "https://tabiclip.onrender.com"}
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default :charset => "utf-8"
+  config.action_mailer.smtp_settings = {
+    address:"smtp.gmail.com",
+    domain: 'smtp.gmail.com',
+    port:587,
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "no-reply@exampel.com"
+  config.mailer_sender = ENV["MAILER_SENDER"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
# 概要
Gmailでアカウントを作成し、開発環境・本番環境でメールの設定を行いました。

## 実施内容
- [x] Gmailアドレス・アプリパスワード発行
- [x] 環境変数設定(Gmailアドレス・アプリパスワード)
- [x] 開発環境のメール送信用サーバーの設定
- [x] 本番環境のメール送信用サーバーの設定
- [x] deviseのsender_mailerの設定

## 未実施内容
- メール文章の調整
- gmailアカウントのアイコン設定

## 補足
なし

## 関連issue
#196, #195