### PR TITLE
Feature/しおりの所有者からメンバーを削除

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -67,9 +67,13 @@ class TravelBooksController < ApplicationController
   def delete_owner
     @travel_book = TravelBook.find(params[:id])
     user = User.find(params[:user_id])
-    @travel_book.users.destroy(user)
-
-    redirect_to share_travel_book_path(@travel_book), success: "しおりのメンバーから削除しました"
+    # しおりの作成者でない場合のみ削除
+    if user != @travel_book.creator
+      @travel_book.users.destroy(user)
+      redirect_to share_travel_book_path(@travel_book), success: "しおりのメンバーから削除しました"
+    else
+      redirect_to share_travel_book_path(@travel_book), alert: "しおりの作成者は削除できません"
+    end
   end
 
   private

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -64,6 +64,14 @@ class TravelBooksController < ApplicationController
     @users = @travel_book.users
   end
 
+  def delete_owner
+    @travel_book = TravelBook.find(params[:id])
+    user = User.find(params[:user_id])
+    @travel_book.users.destroy(user)
+
+    redirect_to share_travel_book_path(@travel_book), success: "しおりのメンバーから削除しました"
+  end
+
   private
 
   def travel_book_param

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -18,14 +18,11 @@
                   <%= image_tag user.icon_image_url, class: "rounded-full w-10 h-10 object-cover border border-gray-200" %>
                   <%= user.name %>
                 </div>
-                  <div class="dropdown dropdown-end">
-                    <div tabindex="0" role="button" class="btn btn-circle">
-                      <i class="fa-solid fa-ellipsis-vertical"></i>
-                    </div>
-                    <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-                      <li>削除</li>
-                    </ul>
-                  </div>
+                <% unless user == @travel_book.creator %>
+                  <%= link_to delete_owner_travel_book_path(@travel_book, user_id: user.id), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "btn" do %>
+                    <i class="fa-solid fa-minus"></i>
+                  <% end %>
+                <% end %>
               </div>
             </td>
           </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     end
     member do
       get :share
+      delete "delete_owner"
     end
     delete "delete_image", on: :member
     resources :schedules, shallow: true do


### PR DESCRIPTION
# 概要
しおりのメンバーリストからメンバーを削除する機能を実装しました。
しおりの作成者の場合はメンバーリストから削除できない仕様にしています。

## 実施内容
- [x] メンバー削除用ルーティングの設定
- [x] メンバーリストに削除リンクを設置
- [x] TravelBooksControllerに削除アクションを定義

## 未実施内容
なし

## 補足
本実装中に招待機能の不備を見つけたため、issue化して対応

## 関連issue
#198 