### PR TITLE
Fix/しおりの招待機能のバグ修正

### DIFF
--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
-    <h2><%= t "devise.invitations.edit.header" %></h2>
+    <h2>パスワードを入力してしおりへ参加する</h2>
 
     <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= render "shared/error_messages", object: resource %>
       <%= f.hidden_field :invitation_token, readonly: true %>
 
       <% if f.object.class.require_password_on_accepting %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -2,7 +2,7 @@
   <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
     <h2><%= t "devise.invitations.new.header" %></h2>
 
-    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+    <%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
 
       <%= render "devise/shared/error_messages", resource: resource %>
 
@@ -14,7 +14,7 @@
           </div>
           <%= f.email_field field, autocomplete: "email", placeholder: "xxx@example.com", class: "input input-bordered w-full" %>
 
-          <%= f.hidden_field :travel_book_uuid, value: params[:travel_book_uuid] %>
+          <%= f.hidden_field :travel_book_uuid, value: params[:travel_book_uuid] || travel_book_uuid %>
         </div>
       <% end -%>
 

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
   <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
-    <h2><%= t "devise.invitations.new.header" %></h2>
+    <h2>しおりへ招待する</h2>
 
     <%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
 
-      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= render "shared/error_messages", object: resource %>
 
       <% resource.class.invite_key_fields.each do |field| -%>
         <div class="field mt-3">


### PR DESCRIPTION
# 概要
#195 にて実装したしおりの招待機能にバグがあったため修正しました。
- 招待の送信画面でバリデーションエラーが表示されない(メールアドレスが空欄の際にエラーが表示されない)
- 招待の承認画面でバリデーションエラーがある場合でも招待されたしおりに画面遷移してしまう

## 実施内容
- [x] 招待の送信画面でバリデーションエラーが表示されるように修正
- [x] 招待の承認画面でバリデーションエラーがあっても招待されたしおりが表示される状態だったためupdateアクションを修正
- [x] バリデーションエラーのパーシャルをdevise用ではなく共通のパーシャル(app/views/shared/_error_messages.html.erb)に修正
- [x] 招待の送信・承認画面のタイトルを変更

### 実装イメージ
■招待の送信画面
修正前
[![Image from Gyazo](https://i.gyazo.com/5cf01d4fd5031124a0213cca595f9c0d.gif)](https://gyazo.com/5cf01d4fd5031124a0213cca595f9c0d)

修正後
[![Image from Gyazo](https://i.gyazo.com/6cfa53053ab2c89212dd3085f3ab28c2.gif)](https://gyazo.com/6cfa53053ab2c89212dd3085f3ab28c2)

■招待の承認画面
修正前
[![Image from Gyazo](https://i.gyazo.com/f7f854e7490c85581ffae6564d594c85.gif)](https://gyazo.com/f7f854e7490c85581ffae6564d594c85)

修正後
[![Image from Gyazo](https://i.gyazo.com/86a20ea409806ac3c869e928ceffe3fc.gif)](https://gyazo.com/86a20ea409806ac3c869e928ceffe3fc)

[![Image from Gyazo](https://i.gyazo.com/9ff1189f136084cb77f8183b4effe307.gif)](https://gyazo.com/9ff1189f136084cb77f8183b4effe307)

## 未実施内容
- エラーやビュー等のi18n化

## 補足
なし

## 関連issue
#201 , #194