### PR TITLE
Feature/スケジュールアイコンのCRUD機能

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -65,6 +65,7 @@ class SchedulesController < ApplicationController
       :telephone,
       :post_code,
       :address,
+      :schedule_icon_id
     ).merge(
       travel_book_uuid: @travel_book.id
     )

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -12,6 +12,7 @@ class ScheduleForm
   attribute :telephone, :string
   attribute :post_code, :string
   attribute :address, :string
+  attribute :schedule_icon_id, :integer
 
   validates :travel_book_uuid, presence: true
   validates :title, presence: true, length: { maximum: 255 }
@@ -22,6 +23,7 @@ class ScheduleForm
   validates :telephone, length: { maximum: 15 }
   validates :post_code, length: { maximum: 10 }
   validates :address, length: { maximum: 255 }
+  validates :schedule_icon_id, inclusion: { in: ScheduleIcon.pluck(:id) }
 
   # フォームのアクションをPOST/PUTCHに切り替える
   # ScheduleFormオブジェクトがpersisted?メソッドを呼ぶと、Scheduleオブジェクトのpersisted?メソッドが呼び出される
@@ -39,7 +41,7 @@ class ScheduleForm
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid)
+      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
@@ -57,7 +59,7 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid)
+      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
@@ -88,7 +90,8 @@ class ScheduleForm
       name: spot.name,
       telephone: spot.telephone,
       post_code: spot.post_code,
-      address: spot.address
+      address: spot.address,
+      schedule_icon_id: 1
     }
   end
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,6 +1,7 @@
 class Schedule < ApplicationRecord
   belongs_to :travel_book, foreign_key: :travel_book_uuid
   has_one :spot, primary_key: :uuid, foreign_key: :schedule_uuid, dependent: :destroy
+  belongs_to :schedule_icon, optional: true
 
   def self.group_by_date(schedules)
     schedules.group_by { |schedule| (schedule.start_date&.to_date || schedule.end_date&.to_date) || "日付未定" }

--- a/app/models/schedule_icon.rb
+++ b/app/models/schedule_icon.rb
@@ -1,0 +1,3 @@
+class ScheduleIcon < ApplicationRecord
+  has_many :schedule
+end

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -45,6 +45,24 @@
     <%= f.text_area :memo, placeholder: t("schedules.form.placeholder.memo"), rows: "3", class: "textarea textarea-bordered w-full", autocomplete: "off" %>
   </div>
 
+  <div class="field mt-3">
+    <%= f.label :schedule_icon_id, ScheduleIcon.human_attribute_name(:name), class: "label" %>
+    <div class="flex flex-wrap gap-x-3 gap-y-2">
+      <% ScheduleIcon.all.each do |icon| %>
+        <div class="flex items-center gap-1">
+          <%= f.radio_button :schedule_icon_id, icon.id, id: "schedule_icon_#{icon.id}", class: "radio radio-primary", checked: (icon.name == "none") %>
+          <%= f.label "schedule_icon_#{icon.id}", for: "schedule_icon_#{icon.id}", class: "cursor-pointer" do %>
+            <% if icon.name == "none" %>
+              <span class="text-base"><%= t(".schedule_icon.none_icon") %></span>
+            <% else %>
+              <i class="fa-solid <%= icon.name %> text-xl"></i>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
   <div class="flex justify-end mt-5">
     <%= f.button nil, type: 'button', onclick: 'submit();', data: { turbo: false }, class: "btn btn-primary w-full mt-6 mx-auto" %>
   </div>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -2,18 +2,22 @@
   <table class="table">
     <tbody>
       <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
-        <td class="w-1/3 p-4">
+        <td class="w-2/6">
           <% if defined?(all_day) && all_day %>
             <%= fmt_all_day_schedule_datetime_duration(schedule) %>
           <% else %>
             <%= fmt_schedule_datetime_duration(schedule) %>
           <% end %>
         </td>
-        <td class="w-2/3 p-4">
-          <i class="fa-solid fa-circle"></i>
+        <td class="w-3/6">
+          <% if schedule.schedule_icon.name == "none" %>
+            <i class="fa-solid fa-circle" style="visibility: hidden;"></i>
+          <% else %>
+            <i class="fa-solid <%= schedule.schedule_icon.name %>"></i>
+          <% end %>
           <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
         </td>
-        <td class="p-4">
+        <td class="w-1/6">
           <% index = index +1 if defined?(index) && index %>
           <% if schedule.spot&.latitude %>
             <div class="relative inline-block">

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -16,7 +16,7 @@
           <input type="radio" data-action="change->tabs#changeTab"
             data-tabs-spots-value="<%= @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
             name="my_tabs_1" role="tab" class="tab" aria-label="ALL" checked="checked"/>
-          <div role="tabpanel" class="tab-content p-10">
+          <div role="tabpanel" class="tab-content p-3">
             <% @schedules.each_with_index do |schedule, i| %>
               <%= render partial: "schedule", locals: { schedule: schedule, all_day: true, index: i } %>
             <% end %>
@@ -27,7 +27,7 @@
         <% Schedule.group_by_date(@schedules).each do |date, schedules| %>
           <input type="radio" data-action="change->tabs#changeTab"
             data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
-          <div role="tabpanel" class="tab-content p-10">
+          <div role="tabpanel" class="tab-content p-3">
             <% schedules.each_with_index do |schedule, i| %>
               <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>
             <% end %>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -7,4 +7,4 @@ bundle exec rails assets:clean
 bundle exec rails db:migrate
 # DBをリセットする際に実行
 # DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
-# bundle exec rails db:seed
+bundle exec rails db:seed

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -29,6 +29,8 @@ ja:
         memo: メモ
         start_date: 開始時刻
         end_date: 終了時刻
+      schedule_icon:
+        name: アイコン
       spot:
         name: 場所名
         telephone: 電話番号

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -111,6 +111,8 @@ ja:
       is_public:
         true: 公開
         false: 非公開
+      schedule_icon:
+        none_icon: なし
     helpers:
       no_memo: メモは登録されていません
   check_lists:

--- a/db/migrate/20250313095002_create_schedule_icons.rb
+++ b/db/migrate/20250313095002_create_schedule_icons.rb
@@ -1,0 +1,8 @@
+class CreateScheduleIcons < ActiveRecord::Migration[7.2]
+  def change
+    create_table :schedule_icons do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250314015132_add_schedule_icon_id_to_schedules.rb
+++ b/db/migrate/20250314015132_add_schedule_icon_id_to_schedules.rb
@@ -1,0 +1,5 @@
+class AddScheduleIconIdToSchedules < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schedules, :schedule_icon_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_11_051027) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_14_015132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_051027) do
     t.index ["list_item_id"], name: "index_reminders_on_list_item_id"
   end
 
+  create_table "schedule_icons", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "schedules", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "budged", default: 0
@@ -57,6 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_051027) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "travel_book_uuid", null: false
+    t.integer "schedule_icon_id"
     t.index ["travel_book_uuid"], name: "index_schedules_on_travel_book_uuid"
     t.index ["uuid"], name: "index_schedules_on_uuid", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,7 +63,7 @@ areas = [
     { id: 13, name: "fa-torii-gate" },
     { id: 14, name: "fa-guitar" },
     { id: 15, name: "fa-heart" },
-    { id: 16, name: "fa-baby-carriage" },
+    { id: 16, name: "fa-baby-carriage" }
   ]
 
   schedule_icons.each do |schedule_icon|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,4 +46,29 @@ areas = [
       t.name = traveler_type[:name]
     end
   end
+
+  schedule_icons = [
+    { id: 1, name: "none" },
+    { id: 2, name: "fa-person-walking" },
+    { id: 3, name: "fa-bicycle" },
+    { id: 4, name: "fa-car" },
+    { id: 5, name: "fa-train-subway" },
+    { id: 6, name: "fa-plane-up" },
+    { id: 7, name: "fa-ship" },
+    { id: 8, name: "fa-hotel" },
+    { id: 9, name: "fa-utensils" },
+    { id: 10, name: "fa-mug-saucer" },
+    { id: 11, name: "fa-cart-shopping" },
+    { id: 12, name: "fa-star" },
+    { id: 13, name: "fa-torii-gate" },
+    { id: 14, name: "fa-guitar" },
+    { id: 15, name: "fa-heart" },
+    { id: 16, name: "fa-baby-carriage" },
+  ]
+
+  schedule_icons.each do |schedule_icon|
+    ScheduleIcon.find_or_create_by(id: schedule_icon[:id]) do |t|
+      t.name = schedule_icon[:name]
+    end
+  end
 end


### PR DESCRIPTION
# 概要
スケジュールのCRUDでスケジュール用のアイコンを含めてCRUDできるように実装しました。

## 実施内容
- [x] shchedule_iconsテーブルの作成
- [x] ScheduleとScheduleIconモデルの関連付け
- [x] SchedulesControllerでストロングパラメータにschedule_iconを追加
- [x] seed.rbでアイコンを追加
- [x] スケジュール登録で使用しているformObject(ScheduleForm)にschedule_icon_idの追加
  - attribute
  - validation
  - デフォルト値
  - save/updateメソッドの引数追加
- [x] スケジュール登録フォームにラジオボタン追加
  - i18n対応
  - CSS調整
- [x] スケジュール表示画面のtabのCSS調整
- [x] renderビルドスクリプトでseedファイルの適用設定

### 実装イメージ
スケジュール登録・編集フォーム
[![Image from Gyazo](https://i.gyazo.com/5a186d3f0862c3573277750773f12a74.png)](https://gyazo.com/5a186d3f0862c3573277750773f12a74)

スケジュール表示画面
[![Image from Gyazo](https://i.gyazo.com/776df085216a03dd1b4c4474d7121b50.png)](https://gyazo.com/776df085216a03dd1b4c4474d7121b50)

## 未実施内容
特になし

## 補足
- スケジュールでアイコンをなしで登録する場合、schedule_iconsテーブルのid:1,name:なしが選択されます。
radioボタンで値を送信する場合、nilでは遅れずparamsが"on"に変換されてしまいました。
そのため、アイコンをなしにする場合もテーブルから選択するようにしています。
アイコンの初期値はなしに設定しています。

- 次のmergeでrenderビルドスクリプトでseedファイルの適用設定をコメントアウトします。

## 関連issue
#204