### PR TITLE
Feature/ノート一覧

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,7 @@
+class NotesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,7 @@ module ApplicationHelper
     return false if controller_name == "home"
     (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(uuid: params[:id]))||
     (controller_name == "schedules")||
+    (controller_name == "notes") ||
     (controller_name == "check_lists") ||
     (controller_name == "list_items")
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,6 @@
+class Note < ApplicationRecord
+  belongs_to :travel_book, foreign_key: :travel_book_uuid
+
+  validates :title, presence: true, length: { maximum: 20 }
+  validates :body, presence: true, length: { maximum: 65_535 }
+end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -9,6 +9,7 @@ class TravelBook < ApplicationRecord
   has_many :users, through: :user_travel_books
   has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :check_lists, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
+  has_many :notes, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/views/check_lists/index.html.erb
+++ b/app/views/check_lists/index.html.erb
@@ -1,4 +1,8 @@
 <div class="container">
+  <div class="w-full flex gap-3">
+    <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-outline btn-primary w-1/2" %>
+    <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-primary w-1/2" %>
+  </div>
   <% if @check_lists.present? %>
     <%= render @check_lists %>
   <% else %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <div class="w-full flex gap-3">
+    <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-primary w-1/2" %>
+    <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-primary btn-outline w-1/2" %>
+  </div>
+  <% if @notes.present? %>
+    <%= render @notes %>
+  <% else %>
+    <%= t(".no_data")%>
+  <% end %>
+</div>
+<%= link_to new_travel_book_note_path, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
+  <%= t(".new_button")%>
+<% end %>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -12,7 +12,7 @@
     <span class="btm-nav-label"><%= t("btm_nav.map") %></span>
   <% end %>
   <% if @travel_book.owned_by_user?(current_user) %>
-    <%= link_to travel_book_check_lists_path(@travel_book), class: "#{add_active_class(travel_book_check_lists_path(@travel_book))}" do %>
+    <%= link_to travel_book_notes_path(@travel_book), class: "#{add_active_class(travel_book_check_lists_path(@travel_book))}" do %>
       <i class="fa-solid fa-file-pen"></i>
       <span class="btm-nav-label"><%= t("btm_nav.note") %></span>
     <% end %>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -7,4 +7,4 @@ bundle exec rails assets:clean
 bundle exec rails db:migrate
 # DBをリセットする際に実行
 # DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
-bundle exec rails db:seed
+# bundle exec rails db:seed

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -117,6 +117,8 @@ ja:
       no_memo: メモは登録されていません
   check_lists:
     index:
+      note_link: ノート
+      check_list_link: チェックリスト
       new_button: チェックリスト作成
       no_data: チェックリストは登録されていません
     show:
@@ -128,6 +130,11 @@ ja:
     form:
       placeholder:
         title: チェックリストのタイトルを記入
+  notes:
+    index:
+      note_link: ノート
+      check_list_link: チェックリスト
+      no_data: ノートは登録されていません
   list_items:
     form:
       placeholder:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
         end
       end
     end
+    resources :notes, shallow: true
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20250315005645_create_notes.rb
+++ b/db/migrate/20250315005645_create_notes.rb
@@ -1,0 +1,10 @@
+class CreateNotes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notes, id: :uuid do |t|
+      t.references :travel_book, null: false, type: :uuid, foreign_key: { to_table: :travel_books, primary_key: :uuid }
+      t.string :title, null: false
+      t.text :body
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_14_015132) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_15_005645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_015132) do
     t.datetime "updated_at", null: false
     t.uuid "check_list_uuid", null: false
     t.index ["check_list_uuid"], name: "index_list_items_on_check_list_uuid"
+  end
+
+  create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "travel_book_id", null: false
+    t.string "title", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["travel_book_id"], name: "index_notes_on_travel_book_id"
   end
 
   create_table "reminders", force: :cascade do |t|
@@ -146,6 +155,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_015132) do
 
   add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
+  add_foreign_key "notes", "travel_books", primary_key: "uuid"
   add_foreign_key "reminders", "list_items"
   add_foreign_key "schedules", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "spots", "schedules", column: "schedule_uuid", primary_key: "uuid"


### PR DESCRIPTION
# 概要
notesテーブルとNoteモデルの生成を行い、ノート一覧画面を作成しました。

## 実施内容
- [x] notesテーブルの生成
- [x] Noteモデルの生成
  - リレーション設定
  - バリデーション設定
- [x] ルーティング設定
- [x] notes#indexのビュー生成
- [x] check_lists#indexのビューにnotes#indexのビューのリンク設置
- [x] ボトムナビゲーションのノートボタンの遷移先をnotes#indexのビューに変更
- [x] renderビルドスクリプトのseed適用コマンドをコメントアウト

## 未実施内容
- ページネーションの設置

## 補足
notesテーブル生成時につまづいた箇所を記事にしました。
https://qiita.com/kurichii/items/ab17fe539fcb2c1157af

## 関連issue
#207 