### PR TITLE
Feature/ノート作成機能

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,5 +3,29 @@ class NotesController < ApplicationController
 
   def index
     @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @notes = @travel_book.notes
+  end
+
+  def new
+    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @note = Note.new
+  end
+
+  def create
+    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+
+    @note = @travel_book.notes.build(note_params)
+    if @note.save
+      redirect_to travel_book_notes_path(@travel_book), success: t("defaults.flash_message.created")
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created")
+      render :new
+    end
+  end
+
+  private
+
+  def note_params
+    params.require(:note).permit(:title, :body)
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,5 @@
 class Note < ApplicationRecord
-  belongs_to :travel_book, foreign_key: :travel_book_uuid
+  belongs_to :travel_book
 
   validates :title, presence: true, length: { maximum: 20 }
   validates :body, presence: true, length: { maximum: 65_535 }

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -9,7 +9,7 @@ class TravelBook < ApplicationRecord
   has_many :users, through: :user_travel_books
   has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :check_lists, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
-  has_many :notes, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
+  has_many :notes, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: note, url: travel_book_notes_path(travel_book) do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
+
+  <div class="space-y-4">
+    <div class="field">
+      <%= f.label :title, class: "w-full" do %>
+        <span class="text-red-400">*</span><%= Note.human_attribute_name(:title) %>
+      <% end %>
+      <%= f.text_field :title, autofocus: true, placeholder: t(".placeholder.title"), class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="field">
+      <%= f.text_area :body, placeholder: t(".placeholder.body"), rows: "5", class: "textarea textarea-bordered w-full" %>
+    </div>
+
+    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
+  </div>
+
+<% end %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,0 +1,6 @@
+<%= link_to note_path(note), data: { turbo: false }, class: "block" do %>
+  <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:opacity-50">
+    <i class="fa-solid fa-book-open"></i>
+    <div class="ml-3"><%= note.title %></div>
+  </div>
+<% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
+    <div class="flex items-center justify-between">
+      <%= link_to travel_book_notes_path(@travel_book), class:"hover:opacity-50" do %>
+        <i class="fa-solid fa-chevron-left"></i>
+      <% end %>
+      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
+    </div>
+    <%= render "form", note: @note, travel_book: @travel_book %>
+  </div>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       schedule: スケジュール
       spot: 場所
       area: エリア
+      note: ノート
       check_list: チェックリスト
       list_item: リストアイテム
       traveler_type: 旅行スタイル
@@ -35,6 +36,8 @@ ja:
         name: 場所名
         telephone: 電話番号
         address: 住所
+      note:
+        title: タイトル
       check_list:
         title: タイトル
       list_item:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -119,6 +119,7 @@ ja:
     index:
       note_link: ノート
       check_list_link: チェックリスト
+      new_button: ノート作成
       no_data: ノートは登録されていません
     new:
       title: ノート作成

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -115,6 +115,17 @@ ja:
         none_icon: なし
     helpers:
       no_memo: メモは登録されていません
+  notes:
+    index:
+      note_link: ノート
+      check_list_link: チェックリスト
+      no_data: ノートは登録されていません
+    new:
+      title: ノート作成
+    form:
+      placeholder:
+        title: ノートのタイトルを記入
+        body: サイトのURLも貼ることができます
   check_lists:
     index:
       note_link: ノート
@@ -130,11 +141,6 @@ ja:
     form:
       placeholder:
         title: チェックリストのタイトルを記入
-  notes:
-    index:
-      note_link: ノート
-      check_list_link: チェックリスト
-      no_data: ノートは登録されていません
   list_items:
     form:
       placeholder:


### PR DESCRIPTION
# 概要
ノートの作成機能を実装しました。

## 実施内容
- [x] notes#newアクションのビューとformのパーシャルを生成
- [x] notes#new,createアクションを定義
- [x] 外部キー設定のミスを修正
- [x] ノートのパーシャル(_note.html.erb)を生成
- [x] i18n対応

## 未実施内容
- ノートの詳細表示(別issueにて対応)

## 補足
- 外部キー設定のミスを修正
notesテーブル作成時にtravel_book_idをuuidとして参照するように設定していたが、他のテーブル(check_lists等)ではtravel_book_uuidをuuidとして参照するように設定している。不整合のリスク回避と可読性のためにtravel_book_uuidへ統一する修正を検討中。

## 関連issue
#207 