### PR TITLE
Fix/ノート詳細表示機能(#211)の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,9 +74,6 @@ gem "dotenv-rails"
 # Geocoding
 gem "geocoder"
 
-# テキスト内のURLをリンク化
-gem "rinku"
-
 # Markdownのパーサー
 gem "redcarpet"
 

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,9 @@ gem "geocoder"
 # テキスト内のURLをリンク化
 gem "rinku"
 
+# Markdownのパーサー
+gem "redcarpet"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,6 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.0)
-    rinku (2.0.6)
     rubocop (1.69.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -474,7 +473,6 @@ DEPENDENCIES
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
   redcarpet
-  rinku
   rubocop-rails-omakase
   selenium-webdriver
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,7 @@ GEM
     rake (13.2.1)
     rdoc (6.10.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.1)
     redis-client (0.23.2)
       connection_pool
     regexp_parser (2.10.0)
@@ -472,6 +473,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
+  redcarpet
   rinku
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -39,6 +39,11 @@ h3 {
   @apply link link-primary;
 }
 
+/* 連続で入力した空白や改行がブラウザでの表示に反映・要素のボックス端で自動で折り返し */
+.note-body {
+  white-space: pre-wrap;
+}
+
 .bg-image {
   background-image: url('map.webp');
   background-repeat: no-repeat;

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,21 @@
+module MarkdownHelper
+  require "redcarpet"
+  require "redcarpet/render_strip"
+
+  def markdown(text)
+    render_options = {
+      filter_html:     true, # htmlを出力しない
+      safe_links_only: true, # 安全であると見なされるプロトコルのリンクのみを生成
+      link_attributes: { rel: 'nofollow', target: "_blank" },
+    }
+
+    extensions = {
+      autolink:           true, # <>で囲まれてなくてもリンクを認識
+      no_intra_emphasis:  true, # 単語中の強調を認識しない
+    }
+
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+    markdown.render(text).html_safe
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -6,12 +6,12 @@ module MarkdownHelper
     render_options = {
       filter_html:     true, # htmlを出力しない
       safe_links_only: true, # 安全であると見なされるプロトコルのリンクのみを生成
-      link_attributes: { rel: 'nofollow', target: "_blank" },
+      link_attributes: { rel: "nofollow", target: "_blank" }
     }
 
     extensions = {
       autolink:           true, # <>で囲まれてなくてもリンクを認識
-      no_intra_emphasis:  true, # 単語中の強調を認識しない
+      no_intra_emphasis:  true # 単語中の強調を認識しない
     }
 
     renderer = Redcarpet::Render::HTML.new(render_options)

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -10,7 +10,8 @@
     </div>
 
     <div class="field">
-      <%= f.text_area :body, placeholder: t(".placeholder.body"), rows: "5", class: "textarea textarea-bordered w-full" %>
+      <%= f.label :title, Note.human_attribute_name(:body), class: "label" %>
+      <%= f.text_area :body, placeholder: t(".placeholder.body"), rows: "10", class: "textarea textarea-bordered w-full" %>
     </div>
 
     <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -18,8 +18,8 @@
       </div>
     </div>
 
-    <div class="note-body mx-10 my-5">
-      <%= safe_join(@note.body.split("\n").map { |line| raw Rinku.auto_link(line, :urls, "target='_blank' rel='noopener noreferrer'") }, tag.br) %>
+    <div class="note-body mx-10">
+      <%= markdown(@note.body) %>
     </div>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -38,6 +38,7 @@ ja:
         address: 住所
       note:
         title: タイトル
+        body: ノート本文
       check_list:
         title: タイトル
       list_item:


### PR DESCRIPTION
# 概要
ノート表示機能を修正しました。

## 実施内容
- [x] gem "redcarpet"のインストール
- [x]  Markdownヘルパーを生成
- [x] notes#showアクションのビューでノートの本文をmarkdown形式で表示
- [x] Markdownの改行やスペースを表示するためにCSS(`white-space: pre-wrap;`)を設定
- [x] ノートのフォームでノート本文のラベル追加
- [x] gem "rinku"を削除

## 未実施内容
なし

## 補足
#211 の実装ではテキスト内(note.body)のURLをrinkuでリンク化しビューで`raw`を使用して表示していていました。`raw`でユーザーの入力をそのまま表示することはXSSに脆弱であると判断し、修正を行いました。

## 関連issue
#210 