### PR TITLE
Fix/notesテーブルの外部キーのカラム名修正

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,5 @@
 class Note < ApplicationRecord
-  belongs_to :travel_book
+  belongs_to :travel_book, foreign_key: :travel_book_uuid
 
   validates :title, presence: true, length: { maximum: 20 }
   validates :body, presence: true, length: { maximum: 65_535 }

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -9,7 +9,7 @@ class TravelBook < ApplicationRecord
   has_many :users, through: :user_travel_books
   has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :check_lists, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
-  has_many :notes, dependent: :destroy
+  has_many :notes, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/db/migrate/20250318073008_rename_travel_book_id_to_notes.rb
+++ b/db/migrate/20250318073008_rename_travel_book_id_to_notes.rb
@@ -1,0 +1,9 @@
+class RenameTravelBookIdToNotes < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :notes, :travel_books
+
+    rename_column :notes, :travel_book_id, :travel_book_uuid
+
+    add_foreign_key :notes, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_15_005645) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_18_073008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,12 +39,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_15_005645) do
   end
 
   create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "travel_book_id", null: false
+    t.uuid "travel_book_uuid", null: false
     t.string "title", null: false
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["travel_book_id"], name: "index_notes_on_travel_book_id"
+    t.index ["travel_book_uuid"], name: "index_notes_on_travel_book_uuid"
   end
 
   create_table "reminders", force: :cascade do |t|
@@ -155,7 +155,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_15_005645) do
 
   add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
-  add_foreign_key "notes", "travel_books", primary_key: "uuid"
+  add_foreign_key "notes", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "reminders", "list_items"
   add_foreign_key "schedules", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "spots", "schedules", column: "schedule_uuid", primary_key: "uuid"


### PR DESCRIPTION
# 概要
notesテーブルを作成し、外部キーはtravel_bookのuuidを設定していましたが、
外部キーのカラム名をtravel_book_idとしており他のテーブルではtravel_book_uuidにしていることで
差異がありました。travel_book_uuidに統一する修正を行いました。

## 実施内容
- [x] マイグレーションファイルの適用
  - 外部キーの削除
  - 外部キーのカラム名変更(travel_book_id->travel_book_uuid)
  - 外部キーを設定
- [x] Noteモデル・TravelBookモデルのアソシエーション設定の修正

## 未実施内容
なし

## 補足
notesテーブルを作成した#208の修正です。

## 関連issue
#207, #217 