### PR TITLE
Fix/スケジュール詳細画面のメモをmarkdownで表示

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -35,12 +35,12 @@ h3 {
 }
 
 /* @applyでtailwindのクラスをまとめたクラスを作ることができる */
-.note-body a {
+.markdown-content a {
   @apply link link-primary;
 }
 
 /* 連続で入力した空白や改行がブラウザでの表示に反映・要素のボックス端で自動で折り返し */
-.note-body {
+.markdown-content {
   white-space: pre-wrap;
 }
 

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -49,11 +49,6 @@ module SchedulesHelper
     safe_join(content)
   end
 
-
-  def schedule_memo(data)
-    data.blank? ? t("schedules.helpers.no_memo") : data
-  end
-
   def total_budget(schedules)
     schedules.sum { |schedule| schedule.budged.to_i }
   end

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-    <div class="note-body mx-10">
+    <div class="markdown-content mx-10">
       <%= markdown(@note.body) %>
     </div>
   </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -26,7 +26,7 @@
           <% if @schedule.memo.blank? %>
             <%= t("schedules.helpers.no_memo") %>
           <% else %>
-            <div class="note-body"><%= markdown(@schedule.memo) %></div>
+            <div class="markdown-content"><%= markdown(@schedule.memo) %></div>
           <% end %>
         </li>
       </ul>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -36,7 +36,11 @@
 
       <div class="mt-5 flex items-start">
         <i class="fa-solid fa-file-pen mt-1"></i>
-        <p class="ml-2"><%= schedule_memo(@schedule.memo) %></p>
+        <% if @schedule.memo.blank? %>
+          <div class="ml-2"><%= t("schedules.helpers.no_memo") %></div>
+        <% else %>
+          <div class="ml-2 note-body"><%= markdown(@schedule.memo) %></div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -16,32 +16,20 @@
       <% end %>
     </div>
 
-    <div class="mx-10 mb-5">
-      <div class="mt-5 flex items-center">
-        <i class="fa-regular fa-clock"></i>
-        <p class="ml-2"><%= fmt_schedule_duration(@schedule) %></p>
-      </div>
-
-      <div class="mt-5 flex">
-        <i class="fa-solid fa-location-dot mt-1"></i>
-        <div class="ml-2">
-          <ul><%= schedule_spot_info(@schedule.spot) %></ul>
-        </div>
-      </div>
-
-      <div class="mt-5 flex items-center">
-        <i class="fa-solid fa-wallet"></i>
-        <p class="ml-2"><%= @schedule.budged %><%= t("helpers.currency_unit") %></p>
-      </div>
-
-      <div class="mt-5 flex items-start">
-        <i class="fa-solid fa-file-pen mt-1"></i>
-        <% if @schedule.memo.blank? %>
-          <div class="ml-2"><%= t("schedules.helpers.no_memo") %></div>
-        <% else %>
-          <div class="ml-2 note-body"><%= markdown(@schedule.memo) %></div>
-        <% end %>
-      </div>
+    <div class="m-10">
+      <ul class="fa-ul space-y-5">
+        <li><span class="fa-li"><i class="fa-regular fa-clock"></i></span><%= fmt_schedule_duration(@schedule) %></li>
+        <li><span class="fa-li"><i class="fa-solid fa-location-dot"></i></span><%= schedule_spot_info(@schedule.spot) %></li>
+        <li><span class="fa-li"><i class="fa-solid fa-wallet"></i></span><%= @schedule.budged %><%= t("helpers.currency_unit") %></li>
+        <li>
+          <span class="fa-li"><i class="fa-solid fa-file-pen"></i></span>
+          <% if @schedule.memo.blank? %>
+            <%= t("schedules.helpers.no_memo") %>
+          <% else %>
+            <div class="note-body"><%= markdown(@schedule.memo) %></div>
+          <% end %>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -107,7 +107,7 @@ ja:
     form:
       placeholder:
         title: スケジュールのタイトルを記入
-        memo: 移動手段や観光地の情報などのメモを記入
+        memo: 移動手段や観光地の情報などのメモやURLを記入
       is_public:
         true: 公開
         false: 非公開


### PR DESCRIPTION
# 概要
スケジュール詳細画面で表示するスケジュールのメモを Markdown形式で表示します。
Markdownで表示することで、改行とURLのハイパーリンクを表示可能にしました。

## 実施内容
- [x] scheduleのmemoが空白でない場合markdown形式で表示するように修正
- [x] 不要なヘルパー(schedule_memo)削除
- [x] アイコン整列のため、fontawesomeのクラス適用
- [x] markdownに適用するCSSクラス名を共通化

## 未実施内容
なし

## 補足
fontawesomeのクラスは以下を適用しました。
https://docs.fontawesome.com/web/style/lists

## 関連issue
#220 