### PR TITLE
Fix/フラッシュメッセージのタイプを修正

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -14,7 +14,7 @@ class CheckListsController < ApplicationController
     @check_list = @travel_book.check_lists.build(check_list_param)
 
     if @check_list.save
-      redirect_to travel_book_check_lists_path(@travel_book), success: t("defaults.flash_message.created", item: CheckList.model_name.human)
+      redirect_to travel_book_check_lists_path(@travel_book), notice: t("defaults.flash_message.created", item: CheckList.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: CheckList.model_name.human)
       render :new, status: :unprocessable_entity
@@ -34,7 +34,7 @@ class CheckListsController < ApplicationController
 
   def update
     if @check_list.update(check_list_param)
-      redirect_to check_list_path(@check_list), success: t("defaults.flash_message.updated", item: CheckList.model_name.human)
+      redirect_to check_list_path(@check_list), notice: t("defaults.flash_message.updated", item: CheckList.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: CheckList.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -43,7 +43,7 @@ class CheckListsController < ApplicationController
 
   def destroy
     @check_list.destroy!
-    redirect_to travel_book_check_lists_path(@travel_book), success: t("defaults.flash_message.deleted", item: CheckList.model_name.human)
+    redirect_to travel_book_check_lists_path(@travel_book), notice: t("defaults.flash_message.deleted", item: CheckList.model_name.human)
   end
 
   private

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -16,7 +16,7 @@ class SchedulesController < ApplicationController
   def create
     @schedule_form = ScheduleForm.new(schedule_params)
     if @schedule_form.save
-      redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.created", item: Schedule.model_name.human)
+      redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: Schedule.model_name.human)
       render :new, status: :unprocessable_entity
@@ -34,7 +34,7 @@ class SchedulesController < ApplicationController
     @spot = @schedule.spot
     @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
     if @schedule_form.update(schedule_params)
-      redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.updated", item: Schedule.model_name.human)
+      redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: Schedule.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -43,7 +43,7 @@ class SchedulesController < ApplicationController
 
   def destroy
     @schedule.destroy!
-    redirect_to travel_book_schedules_path(@travel_book), success: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
+    redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
   end
 
   def map

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -52,7 +52,7 @@ class TravelBooksController < ApplicationController
     @travel_book = TravelBook.find(params[:id])
     @travel_book.remove_travel_book_image! # CarrierWaveのメソッドを使って画像を削除
     @travel_book.save
-    redirect_to edit_travel_book_path(@travel_book), success: t("defaults.flash_message.deleted", item: TravelBook.model_name.human)
+    redirect_to edit_travel_book_path(@travel_book), notice: "しおりの画像を削除しました"
   end
 
   def public_travel_books

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -16,7 +16,7 @@ class TravelBooksController < ApplicationController
     if @travel_book.save
       # 中間テーブルに関連付けを追加
       current_user.user_travel_books.create(travel_book: @travel_book)
-      redirect_to travel_books_path, success: t("defaults.flash_message.created", item: TravelBook.model_name.human)
+      redirect_to travel_books_path, notice: t("defaults.flash_message.created", item: TravelBook.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: TravelBook.model_name.human)
       render :new, status: :unprocessable_entity
@@ -35,7 +35,7 @@ class TravelBooksController < ApplicationController
     @travel_book = current_user.travel_books.find(params[:id])
 
     if @travel_book.update(travel_book_param)
-      redirect_to travel_books_path(@travel_book), success: t("defaults.flash_message.updated", item: TravelBook.model_name.human)
+      redirect_to travel_books_path(@travel_book), notice: t("defaults.flash_message.updated", item: TravelBook.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: TravelBook.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -45,7 +45,7 @@ class TravelBooksController < ApplicationController
   def destroy
     travel_book = current_user.travel_books.find(params[:id])
     travel_book.destroy!
-    redirect_to travel_books_path, success: t("defaults.flash_message.deleted", item: TravelBook.model_name.human)
+    redirect_to travel_books_path, notice: t("defaults.flash_message.deleted", item: TravelBook.model_name.human)
   end
 
   def delete_image
@@ -70,7 +70,7 @@ class TravelBooksController < ApplicationController
     # しおりの作成者でない場合のみ削除
     if user != @travel_book.creator
       @travel_book.users.destroy(user)
-      redirect_to share_travel_book_path(@travel_book), success: "しおりのメンバーから削除しました"
+      redirect_to share_travel_book_path(@travel_book), notice: "しおりのメンバーから削除しました"
     else
       redirect_to share_travel_book_path(@travel_book), alert: "しおりの作成者は削除できません"
     end


### PR DESCRIPTION
# 概要
フラッシュメッセージのタイプが以前使用していた"success"のままでフラッシュメッセージが表示されていない箇所があったため、現在使用している"notice"へ修正しました。

## 実施内容
- [x] フラッシュメッセージのタイプをnoticeへ修正
- [x] def delete_imageアクションのメッセージ内容を修正
- [x] TravelBooksControllerのリファクタリングと軽微な修正

## 未実施内容
- TravelBooksControllerの一部アラートのi18n対応

## 補足
合わせて、TravelBooksControllerのリファクタリングを行いました。
また、しおりの所有者にのみ許可されるアクションでしおりのデータを取得する際は、ログイン中のユーザーが所有しているしおりのみを取得するようにコードを修正しました。

## 関連issue
#222 