### PR TITLE
Fix/スケジュール編集時のラジオボタンの挙動を修正

### DIFF
--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -91,7 +91,7 @@ class ScheduleForm
       telephone: spot.telephone,
       post_code: spot.post_code,
       address: spot.address,
-      schedule_icon_id: 1
+      schedule_icon_id: schedule.schedule_icon_id || 1
     }
   end
 

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -50,7 +50,7 @@
     <div class="flex flex-wrap gap-x-3 gap-y-2">
       <% ScheduleIcon.all.each do |icon| %>
         <div class="flex items-center gap-1">
-          <%= f.radio_button :schedule_icon_id, icon.id, id: "schedule_icon_#{icon.id}", class: "radio radio-primary", checked: (icon.name == "none") %>
+          <%= f.radio_button :schedule_icon_id, icon.id, id: "schedule_icon_#{icon.id}", class: "radio radio-primary" %>
           <%= f.label "schedule_icon_#{icon.id}", for: "schedule_icon_#{icon.id}", class: "cursor-pointer" do %>
             <% if icon.name == "none" %>
               <span class="text-base"><%= t(".schedule_icon.none_icon") %></span>


### PR DESCRIPTION
# 概要
スケジュール編集時のラジオボタンにすでに登録済みのアイコンへのチェックが反映されていなかったため修正しました。

## 実施内容
- [x] formObjectのデフォルト値を修正
- schedule_icon_idがあればschedule_icon_id、なければid:1を設定(1はアイコンなし)
- [x] formからcheckedの指定を削除

## 未実施内容
なし

## 補足
schedule_iconsテーブルのid:1はアイコンなしを意味する"none"が保存されています

## 関連issue
#224 