### PR TITLE
Feature/パスワードリセットメールの設定

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,4 @@
+<p><%= @resource.name %>様</p>
+<p>たびくりっぷをご利用いただきありがとうございます。</p>
+<p>パスワード再設定用のURLを送付いたします。<br>以下のURLより、変更をお願いいたします。</p>
+<p><%= link_to "再設定用URL", edit_password_url(@resource, reset_password_token: @token) %></p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,30 @@
-<h2>Change your password</h2>
+<div class="container">
+  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
+    <h2><%= t(".title") %></h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="field mt-3">
+        <div class="flex items-center gap-1">
+          <%= f.label :password, class: "label" %>
+          <i class="fa-solid fa-key"></i>
+        </div>
+        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder: t("users.form.placeholder.password"), class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="field">
+        <div class="flex items-center gap-1">
+          <%= f.label :password_confirmation, class: "label" %>
+          <i class="fa-solid fa-key"></i>
+        </div>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: t("users.form.placeholder.password"), class: "input input-bordered w-full" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit t(".change_password"), class: "btn btn-primary w-full mt-6 mx-auto" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -68,8 +68,12 @@ ja:
         title: プロフィール編集
     passwords:
       new:
+        title: パスワードの再設定
+        send: 確認メールを送信する
+        login_page: ログインページはこちら
+      edit:
         title: パスワード再設定
-        send: 送信
+        change_password: パスワードを再設定する
         login_page: ログインページはこちら
     show:
       profile_button: プロフィールを編集


### PR DESCRIPTION
# 概要
パスワードリセットメール送信画面とメール文章の修正を行いました。

## 実施内容
- [x] passwords#editアクションのビューのCSS調整
- [x] パスワードリセットメールのhtmlをフォルダ移動し文面の修正

## 未実施内容
- メール本文のi18n対応

## 補足
reset_password_instructions.html.erbをapp/views/users/mailer配下からapp/views/devise/mailer配下へ移動しました。

## 関連issue
#226 