### PR TITLE
Feature/しおりの検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,9 @@ gem "geocoder"
 # Markdownのパーサー
 gem "redcarpet"
 
+# 検索機能
+gem "ransack"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.10.0)
       psych (>= 4.0.0)
     redcarpet (3.6.1)
@@ -472,6 +476,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
+  ransack
   redcarpet
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -3,7 +3,7 @@ class TravelBooksController < ApplicationController
   before_action :set_travel_book, only: %i[ edit update destroy delete_image share delete_owner ]
 
   def index
-    @travel_books = current_user.travel_books.order(:created_at).page(params[:page])
+    @travel_books = current_user.travel_books.order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -51,7 +51,8 @@ class TravelBooksController < ApplicationController
   end
 
   def public_travel_books
-    @travel_books = TravelBook.where(is_public: true).includes(:users).order(:created_at).page(params[:page])
+    @q = TravelBook.ransack(params[:q])
+    @travel_books = @q.result.where(is_public: true).includes(:users).order(created_at: :desc).page(params[:page])
   end
 
   def share
@@ -67,6 +68,11 @@ class TravelBooksController < ApplicationController
     else
       redirect_to share_travel_book_path(@travel_book), alert: "しおりの作成者は削除できません"
     end
+  end
+
+  def search
+    @q = TravelBook.ransack(params[:q])
+    @results = @q.result
   end
 
   private

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -26,6 +26,11 @@ class TravelBook < ApplicationRecord
     schedules.sort_by { |schedule| schedule.start_date || DateTime.new(0) }
   end
 
+  # ransackで検索に使用するカラムを記述
+  def self.ransackable_attributes(auth_object = nil)
+    [ "area_id", "traveler_type_id" ]
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/views/travel_books/public_travel_books.html.erb
+++ b/app/views/travel_books/public_travel_books.html.erb
@@ -1,12 +1,13 @@
 <div class="container">
-
-  <%= search_form_for @q, url: public_travel_books_path, method: :get do |f| %>
-    <%= f.label :area_name_eq, "エリア" %>
-    <%= f.select :area_id_eq, options_from_collection_for_select(Area.all, :id, :name, @q.area_id_eq), { include_blank: "選択してください" } %>
-    <%= f.label :traveler_type_name_eq, "旅行スタイル" %>
-    <%= f.select :traveler_type_id_eq, options_from_collection_for_select(TravelerType.all, :id, :name, @q.traveler_type_id_eq), { include_blank: "選択してください" } %>
-    <%= f.submit %>
-  <% end %>
+  <div class="my-5 flex items-center">
+    <%= search_form_for @q, url: public_travel_books_path, method: :get do |f| %>
+      <%= f.select :area_id_eq, options_from_collection_for_select(Area.all, :id, :name, @q.area_id_eq), { include_blank: "エリア" }, { class: "select select-bordered select-sm md:select-md" } %>
+      <%= f.select :traveler_type_id_eq, options_from_collection_for_select(TravelerType.all, :id, :name, @q.traveler_type_id_eq), { include_blank: "旅行スタイル" }, { class: "select select-bordered select-sm md:select-md" } %>
+      <%= button_tag type: "submit", class: "btn btn-primary btn-sm md:btn-md" do %>
+        <span class="text-xs"><i class="text-xs fa-solid fa-magnifying-glass"></i></span>
+      <% end %>
+    <% end %>
+  </div>
 
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <%= render partial: "travel_books/travel_book", collection: @travel_books, as: :travel_book %>

--- a/app/views/travel_books/public_travel_books.html.erb
+++ b/app/views/travel_books/public_travel_books.html.erb
@@ -1,4 +1,13 @@
 <div class="container">
+
+  <%= search_form_for @q, url: public_travel_books_path, method: :get do |f| %>
+    <%= f.label :area_name_eq, "エリア" %>
+    <%= f.select :area_id_eq, options_from_collection_for_select(Area.all, :id, :name, @q.area_id_eq), { include_blank: "選択してください" } %>
+    <%= f.label :traveler_type_name_eq, "旅行スタイル" %>
+    <%= f.select :traveler_type_id_eq, options_from_collection_for_select(TravelerType.all, :id, :name, @q.traveler_type_id_eq), { include_blank: "選択してください" } %>
+    <%= f.submit %>
+  <% end %>
+
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <%= render partial: "travel_books/travel_book", collection: @travel_books, as: :travel_book %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   resources :travel_books do
     collection do
       get "public", action: :public_travel_books
+      get "search"
     end
     member do
       get :share


### PR DESCRIPTION
# 概要
公開しおり一覧のしおり検索機能。

## 実施内容
- [x] gem 'ransack'インストール
- [x] ルーティング設定
- [x] 検索に使用するカラムを検索対象のモデル(TravelBook)に設定
- [x] TravelBoooks#searchアクションの定義とpublic_travel_booksアクションの編集
- [x] 公開しおり一覧画面に検索フォーム追加、CSS調整

## 未実施内容
なし

## 補足
しおりの検索機能は公開されたしおり一覧のみ実装しています。

## 関連issue
#228