### PR TITLE
Feature/しおりのブックマーク機能

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,15 @@
+class BookmarksController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    travel_book = TravelBook.find(params[:travel_book_uuid])
+    current_user.bookmark(travel_book)
+    redirect_to public_travel_books_path, notice: "ブックマークしました"
+  end
+
+  def destroy
+    travel_book = current_user.bookmarks.find(params[:id]).travel_book
+    current_user.unbookmark(travel_book)
+    redirect_to public_travel_books_path, notice: "ブックマークを解除しました", status: :see_other
+  end
+end

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -75,6 +75,10 @@ class TravelBooksController < ApplicationController
     @results = @q.result
   end
 
+  def bookmarks
+    @bookmark_travel_books = current_user.bookmark_travel_books.order(created_at: :desc)
+  end
+
   private
 
   def set_travel_book

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,4 @@
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :travel_book, foreign_key: :travel_book_uuid, primary_key: :uuid
+end

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -10,6 +10,7 @@ class TravelBook < ApplicationRecord
   has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :check_lists, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
   has_many :notes, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,16 @@ class User < ApplicationRecord
     self.raw_info = raw_info.to_json
     self.save!
   end
+
+  def bookmark(travel_book)
+    bookmark_travel_books << travel_book
+  end
+
+  def unbookmark(travel_book)
+    bookmark_travel_books.destroy(travel_book)
+  end
+
+  def bookmark?(travel_book)
+    bookmark_travel_books.include?(travel_book)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   has_many :user_travel_books, dependent: :destroy
   has_many :travel_books, primary_key: :uuid, foreign_key: :travel_book_uuid, through: :user_travel_books
   has_many :created_travel_books, class_name: "TravelBook", foreign_key: "creator_id", dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_travel_books, through: :bookmarks, source: :travel_book
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
   <div class="flex flex-1 justify-end px-2">
     <div class="flex items-stretch">
       <% if user_signed_in? %>
-            <div class="dropdown dropdown-end">
+        <div class="dropdown dropdown-end">
         <div class="flex-none">
           <button>
             <%= image_tag current_user.icon_image_url, class: "mx-auto rounded-full w-10 h-10 object-cover shadow-sm border border-gray-200 mr-2 hover:opacity-50" %>
@@ -20,6 +20,11 @@
             </li>
             <li>
               <%= link_to t("header.how_to_use"), "#" %>
+            </li>
+            <li>
+              <%= link_to bookmarks_travel_books_path do %>
+                <i class="fa-solid fa-bookmark"></i>ブックマーク
+              <% end %>
             </li>
             <li>
               <%= link_to t("header.logout"), destroy_user_session_path, data: { turbo_method: :delete } %>

--- a/app/views/travel_books/_bookmark_buttons.html.erb
+++ b/app/views/travel_books/_bookmark_buttons.html.erb
@@ -10,8 +10,20 @@
       <% end %>
     <% end %>
   <% else %>
-    <div class="tooltip" data-tip="ブックマーク機能を使用するにはログインする必要があります">
-      <button><i class="fa-regular fa-bookmark"></i></button>
-    </div>
+    <button onclick="document.getElementById('bookmark_button_on_login_modal_<%= travel_book.uuid %>').showModal()">
+      <i class="fa-regular fa-bookmark"></i>
+    </button>
+    <dialog id="bookmark_button_on_login_modal_<%= travel_book.uuid %>" class="modal">
+      <div class="modal-box">
+        <form method="dialog">
+          <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+        </form>
+        <h3 class="text-lg font-bold">しおりのブックマーク機能</h3>
+        <p class="py-4 text-center">ログインするとしおりのブックマークを利用できます</p>
+        <div class="flex justify-end">
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>
+        </div>
+      </div>
+    </dialog>
   <% end %>
 </div>

--- a/app/views/travel_books/_bookmark_buttons.html.erb
+++ b/app/views/travel_books/_bookmark_buttons.html.erb
@@ -1,11 +1,17 @@
 <div class="flex justify-end">
-  <% if current_user.bookmark?(travel_book) %>
-    <%= link_to bookmark_path(current_user.bookmarks.find_by(travel_book_uuid: travel_book.uuid)), data: { turbo_method: :delete } do %>
-      <i class="fa-solid fa-bookmark"></i>
+  <% if user_signed_in? %>
+    <% if current_user.bookmark?(travel_book) %>
+      <%= link_to bookmark_path(current_user.bookmarks.find_by(travel_book_uuid: travel_book.uuid)), data: { turbo_method: :delete } do %>
+        <i class="fa-solid fa-bookmark"></i>
+      <% end %>
+    <% else %>
+      <%= link_to bookmarks_path(travel_book_uuid: travel_book.uuid), data: { turbo_method: :post } do %>
+        <i class="fa-regular fa-bookmark"></i>
+      <% end %>
     <% end %>
   <% else %>
-    <%= link_to bookmarks_path(travel_book_uuid: travel_book.uuid), data: { turbo_method: :post } do %>
-      <i class="fa-regular fa-bookmark"></i>
-    <% end %>
+    <div class="tooltip" data-tip="ブックマーク機能を使用するにはログインする必要があります">
+      <button><i class="fa-regular fa-bookmark"></i></button>
+    </div>
   <% end %>
 </div>

--- a/app/views/travel_books/_bookmark_buttons.html.erb
+++ b/app/views/travel_books/_bookmark_buttons.html.erb
@@ -1,0 +1,11 @@
+<div class="flex justify-end">
+  <% if current_user.bookmark?(travel_book) %>
+    <%= link_to bookmark_path(current_user.bookmarks.find_by(travel_book_uuid: travel_book.uuid)), data: { turbo_method: :delete } do %>
+      <i class="fa-solid fa-bookmark"></i>
+    <% end %>
+  <% else %>
+    <%= link_to bookmarks_path(travel_book_uuid: travel_book.uuid), data: { turbo_method: :post } do %>
+      <i class="fa-regular fa-bookmark"></i>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,20 +1,30 @@
-<%= link_to travel_book_path(travel_book), class: "block" do %>
-  <div class="card bg-base-100 w-full">
-    <figure>
+<div class="card bg-base-100 w-full">
+  <figure>
+  <%= link_to travel_book_path(travel_book) do %>
     <%= image_tag travel_book.travel_book_image_url %>
-    </figure>
-    <div class="card-body flex flex-col items-center justify-center text-center">
+  <% end %>
+  </figure>
+  <div class="card-body flex flex-col">
+    <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
       <h2 class="card-title"><%= travel_book.title %></h2>
-      <p><%= area_name(travel_book) %></p>
-      <p><%= traveler_type_name(travel_book) %></p>
+    <% end %>
+
+    <p class="text-sm"><span class="badge">エリア</span><%= area_name(travel_book) %></p>
+    <p class="text-sm"><span class="badge">旅行スタイル</span><%= traveler_type_name(travel_book) %></p>
+
+    <div class="flex justify-between">
       <div class="flex items-center justify-center gap-2">
         <div class="avatar">
-          <div class="w-8 rounded-full shadow-lg border border-gray-200">
+          <div class="w-8 rounded-full border border-gray-200">
             <%= image_tag travel_book.creator.icon_image_url %>
           </div>
         </div>
-        <p><%= travel_book.creator.name %></p>
+        <p class="text-sm"><%= travel_book.creator.name %></p>
       </div>
+
+      <% unless travel_book.owned_by_user?(current_user) %>
+        <%= render "bookmark_buttons", { travel_book: travel_book } %>
+      <% end %>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/travel_books/bookmarks.html.erb
+++ b/app/views/travel_books/bookmarks.html.erb
@@ -1,0 +1,5 @@
+<div class="container">
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <%= render partial: "travel_books/travel_book", collection: @bookmark_travel_books, as: :travel_book %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     collection do
       get "public", action: :public_travel_books
       get "search"
+      get :bookmarks
     end
     member do
       get :share
@@ -49,6 +50,7 @@ Rails.application.routes.draw do
     end
     resources :notes, shallow: true
   end
+  resources :bookmarks, only: %i[ create destroy ]
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250320005047_create_bookmarks.rb
+++ b/db/migrate/20250320005047_create_bookmarks.rb
@@ -1,0 +1,12 @@
+class CreateBookmarks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, foreign_key: true, null: false
+      t.uuid :travel_book_uuid, null: false
+      t.timestamps
+    end
+
+    add_foreign_key :bookmarks, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_index :bookmarks, [:user_id, :travel_book_uuid], unique: true
+  end
+end

--- a/db/migrate/20250320005047_create_bookmarks.rb
+++ b/db/migrate/20250320005047_create_bookmarks.rb
@@ -7,6 +7,6 @@ class CreateBookmarks < ActiveRecord::Migration[7.2]
     end
 
     add_foreign_key :bookmarks, :travel_books, column: :travel_book_uuid, primary_key: :uuid
-    add_index :bookmarks, [:user_id, :travel_book_uuid], unique: true
+    add_index :bookmarks, [ :user_id, :travel_book_uuid ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_18_073008) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_18_073008) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.uuid "travel_book_uuid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "travel_book_uuid"], name: "index_bookmarks_on_user_id_and_travel_book_uuid", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "check_lists", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -153,6 +162,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_18_073008) do
     t.index ["token"], name: "index_users_on_token", unique: true
   end
 
+  add_foreign_key "bookmarks", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
   add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
   add_foreign_key "notes", "travel_books", column: "travel_book_uuid", primary_key: "uuid"


### PR DESCRIPTION
# 概要
しおりのブックマーク機能を実装しました。
しおりのブックマークはログインユーザーのみ使用できます。

## 実施内容
- [x] bookmarksテーブル追加
- [x] Bookmark,User,TravelBookモデルにアソシエーション設定
- [x] ブックマーク追加、削除、一覧表示用のルーティング追加
- [x] Userモデルにブックマーク追加、削除、確認用のインスタンスメソッド追加
- [x] しおりのパーシャルにブックマークボタン追加
- [x] bookmarks#create,destroyアクション追加
- [x] ヘッダーのハンバーガーメニューにブックマーク一覧画面へのリンク追加
- [x] ブックマーク一覧画面のビュー作成

## 未実施内容
- i18n化

## 補足
ログインしていない場合は、モーダルでログインユーザーのみ使用可能であることを伝えるメッセージを表示しています。

## 関連issue
#230 