### PR TITLE
Fix/しおりの招待メールの本文修正

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -7,5 +7,3 @@
 <% if @resource.invitation_due_at %>
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
 <% end %>
-
-<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -32,6 +32,13 @@ ja:
         subject: "メールアドレスを変更しました"
       password_change:
         subject: "パスワードを変更しました"
+      invitation_instructions:
+        subject: "しおりへのご招待"
+        hello: "%{email} 様"
+        someone_invited_you: "たびくりっぷのしおりに招待されました。"
+        accept: "こちらのリンクからしおりに参加できます。"
+        accept_until: "この招待は %{due_date} まで有効です。"
+        accept_until_format: "%Y年%m月%d日 %H:%M"
     omniauth_callbacks:
       failure: '%{kind} アカウントでログインできませんでした: \"%{reason}\"'
       success: "%{kind} アカウントでログインしました"


### PR DESCRIPTION
# 概要
しおりの招待メールの本文を修正しました。

## 実施内容
 - [x] 招待メールのビュー修正
 - [x] devise.ja.ymlへ追記

## 未実施内容
なし

## 補足
なし

## 関連issue
#232 