### PR TITLE
Update/LINEアカウント連携トークンのコピーボタン実装

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -43,24 +43,22 @@ class LinebotController < ApplicationController
     line_user_id = event["source"]["userId"]
 
     # 送信されたテキストがパターンマッチしない場合
-    return reply(event, "マイページのアカウント連携tokenをコピーして送信してください！") unless received_text.match?(/\A連携:[a-f0-9]{32}\z/)
+    return reply(event, "マイページにあるLINEアカウント連携用トークンをコピーして送信してください！") unless received_text.match?(/\A[a-f0-9]{32}\z/)
 
-    # received_textからtokenを取り出す(連携:の文字を削除)
-    token = received_text.sub("連携:", "")
     # tokenでUserを取得
-    user = User.find_by(token: token)
+    user = User.find_by(token: received_text)
 
     # tokenでuserが特定できない場合
-    return reply(event, "無効なtokenです。マイページのアカウント連携tokenを確認してください！") unless user
+    return reply(event, "無効なtokenです。マイページにあるLINEアカウント連携用トークンを確認してください！") unless user
 
     # すでにユーザーのuidが登録されている場合
-    return reply(event, "LINEアカウントとTabiClipアカウントの連携が完了しています！ぜひリマインダー設定してみてくださいね！※LINEログインを利用している場合はすでにアカウントが連携されています") if user.uid
+    return reply(event, "LINEアカウントとたびくりっぷアカウントの連携が完了しています！ぜひリマインダー設定してみてくださいね！※LINEログインを利用している場合はすでにアカウントが連携されています") if user.uid
 
     # ユーザーのuidを更新
     if user.update(uid: line_user_id)
-      reply(event, "LINEアカウントとTabiClipのアカウント連携が完了しました！")
+      reply(event, "LINEアカウントとたびくりっぷのアカウント連携が完了しました！")
     else
-      reply(event, "LINEアカウントとTabiClipのアカウント連携に失敗しました。もう一度tokenを送信してください！")
+      reply(event, "LINEアカウントとたびくりっぷのアカウント連携に失敗しました。もう一度tokenを送信してください！")
     end
   end
 

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="clipboard"
+export default class extends Controller {
+  static values = {
+    content: String
+  }
+
+  connect() {
+    this.originalContent = this.element.innerHTML
+  }
+
+  copy() {
+    navigator.clipboard.writeText(this.contentValue).then(
+      () => {
+        this.element.textContent = "コピーしました！"
+        setTimeout(()=>{
+          this.element.innerHTML = this.originalContent
+        }, 2000)
+      },
+      () => {[
+        alert("クリップボードにコピーできませんでした")
+      ]}
+    )
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,9 +20,12 @@
             <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
           </form>
           <h3 class="text-lg font-bold">LINEアカウント連携用トークン</h3>
-          <div class="m-5 text-center">
-            <p>以下のtokenをTabiClip公式LINEに送信してください</p>
-            <p>連携:<%= @user.token %></p>
+          <div class="space-y-2 m-5 text-center">
+            <p>以下の文字列をたびくりっぷの公式LINEに送信すると、LINEアカウントと連携されます</p>
+            <div class="flex flex-col md:flex-row items-center justify-center gap-2">
+              <input type="text" value="<%= @user.token %>" readonly class="input input-bordered w-full max-w-xs">
+              <%= button_tag "コピー", data: { controller: "clipboard", action: "clipboard#copy", clipboard_content_value: @user.token }, class: "btn btn-primary w-full md:w-auto max-w-xs" %>
+            </div>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
# 概要
マイページのLINEアカウント連携モーダル内のLINEアカウント連携トークンのコピーボタンを設置し、
クリップボードにコピーする機能を実装しました。

## 実施内容
- [x] stimulusコントローラー(clipboard_controller.js)を作成
- [x] マイページであるusers#showアクションのビューのモーダル内にコピーボタンを追加、トークンの表示をフォーム形式に修正
- [x] linebot_controller.rbの修正
- LINEメッセージの文言編集
- LINEで受け取るトークンから"連携:"を削除
- [x] LINE DeveloperでWebhook URLの修正(tabiclip.onrender.com -> tabiclip.jpへ修正)

### 実装イメージ
**実装前**
[![Image from Gyazo](https://i.gyazo.com/0040db58ffefdf2ebe534ab363ba4beb.gif)](https://gyazo.com/0040db58ffefdf2ebe534ab363ba4beb)

**実装後**
[![Image from Gyazo](https://i.gyazo.com/e77ec9fdadacca3f4f9f5b09d0575519.gif)](https://gyazo.com/e77ec9fdadacca3f4f9f5b09d0575519)

## 未実施内容
なし

## 補足
なし

## 関連issue
#246 