### PR TITLE
Update/しおり関連のレスポンシブ対応・CSS修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -22,18 +22,6 @@
   display: block;
 }
 
-h2 {
-  font-size: 1.5rem;
-  text-align: center;
-  font-weight: bold;
-}
-
-h3 {
-  font-size: 1.25rem;
-  text-align: center;
-  font-weight: bold;
-}
-
 /* @applyでtailwindのクラスをまとめたクラスを作ることができる */
 .markdown-content a {
   @apply link link-primary;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,8 +43,15 @@ module ApplicationHelper
 
   # 日付をフォーマットする
   def fmt_date(date)
-    return "未定" if date.nil?
-    date.strftime("%Y/%-m/%-d(%a)")
+    return "日付未定" if date.nil?
+    format_date = date.strftime("%Y/%-m/%-d")
+    "#{format_date}(#{fmt_wday(date)})"
+  end
+
+  # 曜日をフォーマットする
+  def fmt_wday(date)
+    wdays = %w[日 月 火 水 木 金 土]
+    "#{wdays[date.wday]}"
   end
 
   def flash_message_color(type)

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -1,12 +1,15 @@
 module SchedulesHelper
   def fmt_schedule_date(date)
     return "" if date.nil?
-    date.strftime("%Y/%-m/%-d/(%a) %-H:%M")
+    format_date = date.strftime("%Y/%-m/%-d")
+    format_time = date.strftime("%-H:%M")
+    "#{format_date}(#{fmt_wday(date)}) #{format_time}"
   end
 
   def fmt_date_with_day(date)
     return date if date.is_a?(String)
-    date.strftime("%-m/%-d(%a)")
+    format_date = date.strftime("%-m/%-d")
+    "#{format_date}(#{fmt_wday(date)})"
   end
 
   def fmt_datetime(date)

--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -1,6 +1,6 @@
 module TravelBooksHelper
   def travel_book_description(travel_book)
-    travel_book.description || ""
+    travel_book.description.blank? ? "-" : travel_book.description
   end
 
   def travel_book_duration(travel_book)

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,6 +1,6 @@
-<div class="container">
-  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
-    <h2>しおりへ招待する</h2>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center">しおりに招待する</h2>
 
     <%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
 

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -1,68 +1,67 @@
 <%= form_with model: @travel_book do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
-  <div class="field mt-3">
-    <%= f.label :title, class: "w-full" do %>
-      <span class="text-red-400">*</span><%= TravelBook.human_attribute_name(:title) %>
-    <% end %>
-    <%= f.text_field :title, autofocus: true, placeholder: t(".placeholder.title"), class: "input input-bordered w-full" %>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :description, TravelBook.human_attribute_name(:description), class: "label" %>
-    <%= f.text_area :description, placeholder: t(".placeholder.description"), rows: "1", class: "textarea textarea-bordered w-full" %>
-  </div>
-
-  <div class="mt-3 flex flex-col sm:flex-row gap-2">
-    <div class="w-full">
-      <%= f.label :start_date, TravelBook.human_attribute_name(:start_date), class: "label" %>
-      <%= f.date_field :start_date, class: "input input-bordered w-full" %>
-    </div>
-    <div class="w-full">
-      <%= f.label :end_date, TravelBook.human_attribute_name(:end_date), class: "label" %>
-      <%= f.date_field :end_date, class: "input input-bordered w-full" %>
-    </div>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :area_id, TravelBook.human_attribute_name(:area), class: "label" %>
-    <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: t("helpers.prompt.select") }, { class: "select select-bordered w-full max-w-xs" } %>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :traveler_type_id, TravelBook.human_attribute_name(:traveler_type), class: "label" %>
-    <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: t("helpers.prompt.select") }, { class: "select select-bordered w-full max-w-xs" } %>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :travel_book_image, TravelBook.human_attribute_name(:travel_book_image), class: "label" %>
-    <%= f.file_field :travel_book_image, accept: "image/*", class: "file-input file-input-bordered w-full max-w-xs" %>
-    <%= f.hidden_field :travel_book_image_cache %>
-  </div>
-
-  <div class="mt-2 flex flex-row-reverse">
-    <% if @travel_book.persisted? && @travel_book.travel_book_image %>
-      <%= link_to delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-trash"></i>
+  <div class="space-y-3">
+    <div>
+      <%= f.label :title, class: "w-full" do %>
+        <span class="text-red-400">*</span><%= TravelBook.human_attribute_name(:title) %>
       <% end %>
-    <% end %>
-  </div>
+      <%= f.text_field :title, autofocus: true, placeholder: t(".placeholder.title"), class: "input input-bordered w-full" %>
+    </div>
 
-  <div class="field mt-3">
-    <%= f.label :is_public, TravelBook.human_attribute_name(:is_public), class: "label" %>
-    <div class="flex items-center gap-3">
-      <div class="flex items-center gap-1">
-        <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary", checked: f.object.is_public? %>
-        <%= f.label :is_public_true, t(".is_public.true"), for: "is_public_true" %>
+    <div>
+      <%= f.label :description, TravelBook.human_attribute_name(:description), class: "label" %>
+      <%= f.text_area :description, placeholder: t(".placeholder.description"), rows: "2", class: "textarea textarea-bordered w-full" %>
+    </div>
+
+    <div class="flex flex-col sm:flex-row sm:gap-2">
+      <div class="w-full">
+        <%= f.label :start_date, TravelBook.human_attribute_name(:start_date), class: "label" %>
+        <%= f.date_field :start_date, class: "input input-bordered w-full" %>
       </div>
-      <div class="flex items-center gap-1">
-        <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: !f.object.is_public? %>
-        <%= f.label :is_public_false, t(".is_public.false"), for: "is_public_false" %>
+      <div class="w-full">
+        <%= f.label :end_date, TravelBook.human_attribute_name(:end_date), class: "label" %>
+        <%= f.date_field :end_date, class: "input input-bordered w-full" %>
       </div>
     </div>
-  </div>
 
-  <div class="flex justify-end mt-5">
-    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
+    <div>
+      <%= f.label :area_id, TravelBook.human_attribute_name(:area), class: "label" %>
+      <%= f.collection_select :area_id, Area.all, :id, :name,{ prompt: t("helpers.prompt.select") }, { class: "select select-bordered w-full max-w-xs" } %>
+    </div>
+
+    <div>
+      <%= f.label :traveler_type_id, TravelBook.human_attribute_name(:traveler_type), class: "label" %>
+      <%= f.collection_select :traveler_type_id, TravelerType.all, :id, :name,{ prompt: t("helpers.prompt.select") }, { class: "select select-bordered w-full max-w-xs" } %>
+    </div>
+
+    <div>
+      <%= f.label :travel_book_image, TravelBook.human_attribute_name(:travel_book_image), class: "label" %>
+      <%= f.file_field :travel_book_image, accept: "image/*", class: "file-input file-input-bordered w-full max-w-xs" %>
+      <%= f.hidden_field :travel_book_image_cache %>
+    </div>
+
+    <div class="flex flex-row-reverse">
+      <% if @travel_book.persisted? && @travel_book.travel_book_image %>
+        <%= link_to delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:opacity-50" do %>
+          <i class="fa-solid fa-trash"></i>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div>
+      <%= f.label :is_public, TravelBook.human_attribute_name(:is_public), class: "label" %>
+      <div class="flex items-center gap-3">
+        <div class="flex items-center gap-1">
+          <%= f.radio_button :is_public, true, id: "is_public_true", class: "radio radio-primary", checked: f.object.is_public? %>
+          <%= f.label :is_public_true, t(".is_public.true"), for: "is_public_true" %>
+        </div>
+        <div class="flex items-center gap-1">
+          <%= f.radio_button :is_public, false, id: "is_public_false", class: "radio radio-primary", checked: !f.object.is_public? %>
+          <%= f.label :is_public_false, t(".is_public.false"), for: "is_public_false" %>
+        </div>
+      </div>
+    </div>
+    <%= f.submit nil, class: "btn btn-primary w-full" %>
   </div>
 <% end %>

--- a/app/views/travel_books/_my_travel_book.html.erb
+++ b/app/views/travel_books/_my_travel_book.html.erb
@@ -1,20 +1,18 @@
 <% travel_books.each do |travel_book| %>
-  <%= link_to travel_book_path(travel_book), class: "block" do %>
-    <div class="card bg-base-100 w-full">
-      <figure>
-      <%= image_tag travel_book.travel_book_image_url %>
-      </figure>
-      <div class="card-body flex flex-col items-center justify-center text-center">
-        <h2 class="card-title"><%= travel_book.title %></h2>
-        <div class="flex items-center justify-center gap-2">
-          <div class="badge"><%= t(".departure") %></div>
-          <p><%= fmt_date(travel_book.start_date) %></p>
-        </div>
-        <div class="flex items-center justify-center gap-2">
-          <div class="badge"><%= t(".arrival") %></div>
-          <p><%= fmt_date(travel_book.end_date) %></p>
-        </div>
+  <div class="card bg-base-100 w-full">
+    <figure>
+      <%= link_to travel_book_path(travel_book), class: "hover:scale-125 hover:duration-500" do %>
+        <%= image_tag travel_book.travel_book_image_url %>
+      <% end %>
+    </figure>
+    <div class="card-body flex flex-col justify-between">
+      <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
+        <h2 class="card-title"><%= truncate(travel_book.title) %></h2>
+      <% end %>
+      <div>
+        <p><span class="badge mr-2"><%= t(".departure") %></span><%= fmt_date(travel_book.start_date) %></p>
+        <p><span class="badge mr-2"><%= t(".arrival") %></span><%= fmt_date(travel_book.end_date) %></p>
       </div>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,30 +1,32 @@
 <div class="card bg-base-100 w-full">
   <figure>
-  <%= link_to travel_book_path(travel_book) do %>
+  <%= link_to travel_book_path(travel_book), class: "hover:scale-125 hover:duration-500" do %>
     <%= image_tag travel_book.travel_book_image_url %>
   <% end %>
   </figure>
-  <div class="card-body flex flex-col">
+  <div class="card-body flex flex-col justify-between">
     <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
-      <h2 class="card-title"><%= travel_book.title %></h2>
+      <h2 class="card-title"><%= truncate(travel_book.title) %></h2>
     <% end %>
 
-    <p class="text-sm"><span class="badge">エリア</span><%= area_name(travel_book) %></p>
-    <p class="text-sm"><span class="badge">旅行スタイル</span><%= traveler_type_name(travel_book) %></p>
+    <div>
+      <p><span class="badge mr-2">エリア</span><%= area_name(travel_book) %></p>
+      <p><span class="badge mr-2">スタイル</span><%= traveler_type_name(travel_book) %></p>
 
-    <div class="flex justify-between">
-      <div class="flex items-center justify-center gap-2">
-        <div class="avatar">
-          <div class="w-8 rounded-full border border-gray-200">
-            <%= image_tag travel_book.creator.icon_image_url %>
+      <div class="flex justify-between">
+        <div class="flex items-center gap-2">
+          <div class="avatar">
+            <div class="w-8 rounded-full border border-gray-200">
+              <%= image_tag travel_book.creator.icon_image_url %>
+            </div>
           </div>
+          <p><%= travel_book.creator.name %></p>
         </div>
-        <p class="text-sm"><%= travel_book.creator.name %></p>
-      </div>
 
-      <% unless travel_book.owned_by_user?(current_user) %>
-        <%= render "bookmark_buttons", { travel_book: travel_book } %>
-      <% end %>
+        <% unless travel_book.owned_by_user?(current_user) %>
+          <%= render "bookmark_buttons", { travel_book: travel_book } %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,12 +1,7 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to travel_book_path(@travel_book), class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title")%></h3>
-    </div>
-
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", travel_book: @travel_book %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,10 +1,11 @@
-<div class="container">
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-    <%if @travel_books.present? %>
+<div class="max-w-screen-xl mx-auto">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m-5">
+    <% if @travel_books.present? %>
       <%= render "my_travel_book", travel_books: @travel_books %>
     <% else %>
       <%= t(".no_data") %>
     <% end %>
   </div>
   <%= paginate @travel_books %>
+  <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,12 +1,8 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to travel_books_path, class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title")%></h3>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
     <%= render "form", travel_book: @travel_book %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/public_travel_books.html.erb
+++ b/app/views/travel_books/public_travel_books.html.erb
@@ -1,16 +1,17 @@
-<div class="container">
-  <div class="my-5 flex items-center">
+<div class="max-w-screen-xl mx-auto">
+  <div class="m-5 flex items-center">
     <%= search_form_for @q, url: public_travel_books_path, method: :get do |f| %>
-      <%= f.select :area_id_eq, options_from_collection_for_select(Area.all, :id, :name, @q.area_id_eq), { include_blank: "エリア" }, { class: "select select-bordered select-sm md:select-md" } %>
-      <%= f.select :traveler_type_id_eq, options_from_collection_for_select(TravelerType.all, :id, :name, @q.traveler_type_id_eq), { include_blank: "旅行スタイル" }, { class: "select select-bordered select-sm md:select-md" } %>
-      <%= button_tag type: "submit", class: "btn btn-primary btn-sm md:btn-md" do %>
+      <%= f.select :area_id_eq, options_from_collection_for_select(Area.all, :id, :name, @q.area_id_eq), { include_blank: "エリア" }, { class: "select select-bordered select-sm sm:select-md" } %>
+      <%= f.select :traveler_type_id_eq, options_from_collection_for_select(TravelerType.all, :id, :name, @q.traveler_type_id_eq), { include_blank: "旅行スタイル" }, { class: "select select-bordered select-sm sm:select-md" } %>
+      <%= button_tag type: "submit", class: "btn btn-primary btn-sm sm:btn-md" do %>
         <span class="text-xs"><i class="text-xs fa-solid fa-magnifying-glass"></i></span>
       <% end %>
     <% end %>
   </div>
 
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m-5">
     <%= render partial: "travel_books/travel_book", collection: @travel_books, as: :travel_book %>
   </div>
   <%= paginate @travel_books %>
+  <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -1,12 +1,7 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
 
-    <div class="flex items-center justify-between">
-      <%= link_to travel_book_path(@travel_book), data: { turbo: false }, class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center">メンバーリスト</h3>
-    </div>
+    <h2 class="text-lg font-bold text-center">メンバーリスト</h2>
 
     <table class="table">
       <tbody>
@@ -30,9 +25,10 @@
       </tbody>
     </table>
     <div class="text-right mt-5">
-      <%= link_to new_user_invitation_path(travel_book_uuid: @travel_book.uuid), class: "btn btn-primary hover:opacity-50" do %>
-        <i class="fa-solid fa-envelope"></i>メンバーを招待
+      <%= link_to new_user_invitation_path(travel_book_uuid: @travel_book.uuid), class: "btn btn-primary" do %>
+        <i class="fa-solid fa-envelope"></i> しおりに招待
       <% end %>
     </div>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,77 +1,74 @@
-<div class="container">
-  <div class="form-container">
-    <div class="card bg-base-100 shadow-md m-6">
-      <figure class="h-64 w-full">
-        <%= image_tag @travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
-      </figure>
+<div class="max-w-screen-md mx-auto">
+  <div class="card bg-base-100 shadow-md m-5">
+    <figure class="h-64 w-full">
+      <%= image_tag @travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
+    </figure>
 
-      <div class="card-body">
-        <div class="card-actions items-center justify-between">
-          <%= link_to (user_signed_in? ? travel_books_path : public_travel_books_path), class: "hover:opacity-50" do %>
-            <i class="fa-solid fa-chevron-left"></i>
-          <% end %>
-          <h3 class="flex-grow text-center"><%= @travel_book.title %></h3>
-          <% if @travel_book.owned_by_user?(current_user) %>
-            <div class="justify-end">
-              <%= link_to share_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
-                <i class="fa-solid fa-share-from-square"></i>
-              <% end %>
-              <%= link_to edit_travel_book_path(@travel_book), class: "ml-3 hover:opacity-50" do %>
-                <i class="fa-solid fa-pen"></i>
-              <% end %>
-              <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-3 hover:opacity-50" do %>
-                <i class="fa-solid fa-trash"></i>
-              <% end %>
-            </div>
-          <% end %>
+    <div class="card-body">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <p class="font-bold text-sm"><%= TravelBook.human_attribute_name(:title) %></p>
+          <h2 class="text-lg font-bold"><%= @travel_book.title %></h2>
         </div>
-
-        <div class="space-y-3">
-          <div>
-            <p class="font-bold"><%= TravelBook.human_attribute_name(:description) %></p>
-            <p><%= travel_book_description(@travel_book) %></p>
-          </div>
-
-          <% if @travel_book.owned_by_user?(current_user) %>
-          <div>
-            <p class="font-bold"><%= t(".duration") %></p>
-            <p><%= travel_book_duration(@travel_book)%></p>
-          </div>
-          <% end %>
-
-          <div>
-            <p class="font-bold"><%= TravelBook.human_attribute_name(:area) %></p>
-            <p><%= area_name(@travel_book) %></p>
-          </div>
-
-          <div>
-            <p class="font-bold"><%= TravelBook.human_attribute_name(:traveler_type) %></p>
-            <p><%= traveler_type_name(@travel_book) %></p>
-          </div>
-
-          <div>
-            <p class="font-bold"><%= TravelBook.human_attribute_name(:is_public) %></p>
-            <p><%= travel_book_is_public(@travel_book) %></p>
-          </div>
-
-          <% if @travel_book.is_public %>
-            <div class="text-gray-600">
-              <% prepare_meta_tags @travel_book %>
-              <% twitter_share_url = "https://twitter.com/intent/tweet?url= #{CGI.escape(travel_book_url(@travel_book))}" %>
-              <%= link_to twitter_share_url, target: "_blank", data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" do %>
-                <i class="fa-brands fa-square-x-twitter fa-2xl"></i> Xでシェア
-              <% end %>
-            </div>
-          <% end %>
-
-          <div>
-            <% unless @travel_book.owned_by_user?(current_user) %>
-              <%= link_to travel_book_schedules_path(@travel_book), class: "btn btn-primary w-full hover:opacity-50" do %>
-                スケジュールを見る
-              <% end %>
+        <% if @travel_book.owned_by_user?(current_user) %>
+          <div class="flex justify-end">
+            <%= link_to edit_travel_book_path(@travel_book), class: "btn hover:opacity-50" do %>
+              <i class="fa-solid fa-pen"></i>
+            <% end %>
+            <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "btn ml-3 hover:opacity-50" do %>
+              <i class="fa-solid fa-trash"></i>
             <% end %>
           </div>
+        <% end %>
+      </div>
+
+      <div class="space-y-3">
+        <div>
+          <p class="font-bold text-sm"><%= TravelBook.human_attribute_name(:description) %></p>
+          <p><%= travel_book_description(@travel_book) %></p>
         </div>
+
+        <% if @travel_book.owned_by_user?(current_user) %>
+        <div>
+          <p class="font-bold text-sm"><%= t(".duration") %></p>
+          <p><%= travel_book_duration(@travel_book)%></p>
+        </div>
+        <% end %>
+
+        <div>
+          <p class="font-bold text-sm"><%= TravelBook.human_attribute_name(:area) %></p>
+          <p><%= area_name(@travel_book) %></p>
+        </div>
+
+        <div>
+          <p class="font-bold text-sm"><%= TravelBook.human_attribute_name(:traveler_type) %></p>
+          <p><%= traveler_type_name(@travel_book) %></p>
+        </div>
+
+        <div>
+          <p class="font-bold text-sm"><%= TravelBook.human_attribute_name(:is_public) %></p>
+          <p><%= travel_book_is_public(@travel_book) %></p>
+        </div>
+
+        <% unless @travel_book.owned_by_user?(current_user) %>
+          <%= link_to travel_book_schedules_path(@travel_book), class: "btn btn-primary w-full" do %>
+            <i class="fa-regular fa-clock"></i> スケジュールを見る
+          <% end %>
+        <% else %>
+          <%= link_to share_travel_book_path(@travel_book), class: "btn btn-primary w-full" do %>
+            <i class="fa-solid fa-users"></i> しおりのメンバーリスト・しおりに招待
+          <% end %>
+        <% end %>
+
+        <% if @travel_book.is_public %>
+          <% prepare_meta_tags @travel_book %>
+          <% twitter_share_url = "https://twitter.com/intent/tweet?url= #{CGI.escape(travel_book_url(@travel_book))}" %>
+          <%= link_to twitter_share_url, target: "_blank", data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア", class: "btn w-full" do %>
+            <i class="fa-brands fa-square-x-twitter text-lg"></i> Xに投稿
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>
+  <div class="h-24"></div>
+</div>


### PR DESCRIPTION
# 概要
しおり関連の画面のレスポンシブ対応・CSSの修正を行いました。

## 実施内容
- [x] 曜日を漢字表記にするため日付に関するヘルパーメソッド修正
- [x] ravel_book_descriptionヘルパーメソッドの修正
- [x] application.tailwind.cssの不要なCSSを削除
- [x] 以下のビューファイルのレスポンシブ対応・CSS修正
- travelbooks/new
- travelbooks/edit
- travelbooks/index
- travelbooks/show
- travelbooks/public_travel_books
- travelbooks/_form
- travelbooks/_my_travel_book
- travelbooks/_travel_book
- devise/invitations

## 未実施内容
- ボトムスメニューの下の余白作成
- 配色の調整
- CSSクラスのリファクタリング

## 補足
- 曜日を漢字表記にするように修正しました(-> `(Sun)` `(日)`)
- travel_book_descriptionヘルパーメソッドの修正
  - 説明が空白の場合`""`から`"-"`へ修正しました
-  application.tailwind.cssの不要なCSSを削除
  - 一旦カスタムクラスを作らずにerbファイルに記載するようにしました
- ボトムスメニューの下の余白がうまく調整できず一旦以下を挿入
`<div class="h-24"></div>`

## 関連issue
#248 