### PR TITLE
Update/スケジュール関連のレスポンシブ対応・CSS調整

### DIFF
--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -4,7 +4,7 @@ module TravelBooksHelper
   end
 
   def travel_book_duration(travel_book)
-    return t("helpers.undecided") unless travel_book.start_date || travel_book.end_date
+    return t("helpers.date_undecided") unless travel_book.start_date || travel_book.end_date
     "#{fmt_date(travel_book.start_date)} - #{fmt_date(travel_book.end_date)}"
   end
 

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,70 +1,71 @@
 <%= form_with model: @schedule_form, url: url, data: { turbo: false } do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
-  <div class="field mt-3">
-    <%= f.label :title, class: "w-full" do %>
-      <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
-    <% end %>
-    <%= f.text_field :title, autofocus: true, placeholder: t("schedules.form.placeholder.title"), class: "input input-bordered w-full", autocomplete: "off" %>
-  </div>
-
-  <div class="mt-3 flex flex-col sm:flex-row gap-2">
-    <div class="w-full">
-      <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
-      <%= f.datetime_field :start_date, class: "input input-bordered w-full", autocomplete: "off" %>
-    </div>
-    <div class="w-full">
-      <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
-      <%= f.datetime_field :end_date, class: "input input-bordered w-full", autocomplete: "off" %>
-    </div>
-  </div>
-
-  <div class="field">
-    <%= f.label :name, Spot.human_attribute_name(:name), class: "label" %>
-    <%= f.text_field :name, id: "spotName", class: "input input-bordered w-full", autocomplete: "off" %>
-  </div>
-  <div class="field">
-    <%= f.label :telephone, Spot.human_attribute_name(:telephone), class: "label" %>
-    <%= f.text_field :telephone, id: "phoneNumber", class: "input input-bordered w-full", autocomplete: "off" %>
-  </div>
-  <div class="field">
-    <%= f.label :address, Spot.human_attribute_name(:address), class: "label" %>
-    <%= f.text_field :address, id: "address", class: "input input-bordered w-full", autocomplete: "off" %>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>
-    <div class="flex items-center">
-      <%= f.number_field :budged, class: "input input-bordered w-full", autocomplete: "off" %>
-      <span class="ml-2"><%= t("helpers.currency_unit") %></span>
-    </div>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :memo, Schedule.human_attribute_name(:memo), class: "label" %>
-    <%= f.text_area :memo, placeholder: t("schedules.form.placeholder.memo"), rows: "3", class: "textarea textarea-bordered w-full", autocomplete: "off" %>
-  </div>
-
-  <div class="field mt-3">
-    <%= f.label :schedule_icon_id, ScheduleIcon.human_attribute_name(:name), class: "label" %>
-    <div class="flex flex-wrap gap-x-3 gap-y-2">
-      <% ScheduleIcon.all.each do |icon| %>
-        <div class="flex items-center gap-1">
-          <%= f.radio_button :schedule_icon_id, icon.id, id: "schedule_icon_#{icon.id}", class: "radio radio-primary" %>
-          <%= f.label "schedule_icon_#{icon.id}", for: "schedule_icon_#{icon.id}", class: "cursor-pointer" do %>
-            <% if icon.name == "none" %>
-              <span class="text-base"><%= t(".schedule_icon.none_icon") %></span>
-            <% else %>
-              <i class="fa-solid <%= icon.name %> text-xl"></i>
-            <% end %>
-          <% end %>
-        </div>
+  <div class="space-y-3">
+    <div>
+      <%= f.label :title, class: "w-full" do %>
+        <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
       <% end %>
+      <%= f.text_field :title, autofocus: true, placeholder: t("schedules.form.placeholder.title"), class: "input input-bordered w-full", autocomplete: "off" %>
     </div>
-  </div>
 
-  <div class="flex justify-end mt-5">
-    <%= f.button nil, type: 'button', onclick: 'submit();', data: { turbo: false }, class: "btn btn-primary w-full mt-6 mx-auto" %>
+    <div class="flex flex-col sm:flex-row sm:gap-2">
+      <div class="w-full">
+        <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label" %>
+        <%= f.datetime_field :start_date, class: "input input-bordered w-full", autocomplete: "off" %>
+      </div>
+      <div class="w-full">
+        <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label" %>
+        <%= f.datetime_field :end_date, class: "input input-bordered w-full", autocomplete: "off" %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :name, Spot.human_attribute_name(:name), class: "label" %>
+      <%= f.text_field :name, id: "spotName", class: "input input-bordered w-full", autocomplete: "off" %>
+    </div>
+
+    <div>
+      <%= f.label :telephone, Spot.human_attribute_name(:telephone), class: "label" %>
+      <%= f.text_field :telephone, id: "phoneNumber", class: "input input-bordered w-full", autocomplete: "off" %>
+    </div>
+
+    <div>
+      <%= f.label :address, Spot.human_attribute_name(:address), class: "label" %>
+      <%= f.text_field :address, id: "address", class: "input input-bordered w-full", autocomplete: "off" %>
+    </div>
+
+    <div>
+      <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label" %>
+      <div class="flex items-center">
+        <%= f.number_field :budged, class: "input input-bordered w-full", autocomplete: "off" %>
+        <span class="ml-2"><%= t("helpers.currency_unit") %></span>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :memo, Schedule.human_attribute_name(:memo), class: "label" %>
+      <%= f.text_area :memo, placeholder: t("schedules.form.placeholder.memo"), rows: "3", class: "textarea textarea-bordered w-full", autocomplete: "off" %>
+    </div>
+
+    <div>
+      <%= f.label :schedule_icon_id, ScheduleIcon.human_attribute_name(:name), class: "label" %>
+      <div class="flex flex-wrap gap-x-3 gap-y-2">
+        <% ScheduleIcon.all.each do |icon| %>
+          <div class="flex items-center gap-1">
+            <%= f.radio_button :schedule_icon_id, icon.id, id: "schedule_icon_#{icon.id}", class: "radio radio-primary" %>
+            <%= f.label "schedule_icon_#{icon.id}", for: "schedule_icon_#{icon.id}", class: "cursor-pointer" do %>
+              <% if icon.name == "none" %>
+                <span class="text-base"><%= t(".schedule_icon.none_icon") %></span>
+              <% else %>
+                <i class="fa-solid <%= icon.name %> text-xl"></i>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <%= f.button nil, type: 'button', onclick: 'submit();', data: { turbo: false }, class: "btn btn-primary w-full" %>
   </div>
 <% end %>
 

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,12 +1,8 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to schedule_path(@schedule), data: { turbo: false }, class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
     <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,13 +1,9 @@
-<div class="flex">
-  <div class="form-container bg-base-100 shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to travel_book_path(@travel_book), class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <div class="flex flex-grow flex-col items-center">
-        <h3><%= @travel_book.title %></h3>
-        <p><%= travel_book_duration(@travel_book) %></p>
-      </div>
+<div class="max-w-screen-md mx-auto flex-none md:flex md:max-w-none">
+  <div class="bg-base-100 p-8 m-5 rounded-lg md:m-0 md:rounded-none md:shadow-md md:flex-1">
+
+    <div class="flex flex-grow flex-col items-center">
+      <h2 class="text-lg font-bold"><%= @travel_book.title %></h2>
+      <p><%= travel_book_duration(@travel_book) %></p>
     </div>
     <% if @schedules.present? %>
     <div data-controller="tabs">
@@ -25,8 +21,8 @@
 
         <!-- Tab for each date -->
         <% Schedule.group_by_date(@schedules).each do |date, schedules| %>
-          <input type="radio" data-action="change->tabs#changeTab"
-            data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
+            <input type="radio" data-action="change->tabs#changeTab"
+              data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
           <div role="tabpanel" class="tab-content p-3">
             <% schedules.each_with_index do |schedule, i| %>
               <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>
@@ -38,20 +34,25 @@
     </div>
     <% else %>
       <% if @travel_book.owned_by_user?(current_user) %>
-        <p class="text-center my-10"><%= t(".no_data") %></p>
+        <p class="text-center mt-10"><%= t(".no_creator_no_data") %><br><%= t(".no_data") %></p>
+        <div class="flex justify-center">
+          <%= link_to new_travel_book_schedule_path(@travel_book), data: { turbo: false }, class: "btn my-5" do %>
+            <i class="fa-solid fa-plus"></i> <%= t(".new_button") %>
+          <% end %>
+        </div>
       <% else %>
         <p class="text-center my-10"><%= t(".no_creator_no_data") %></p>
       <% end %>
     <% end %>
 
     <% if @travel_book.owned_by_user?(current_user) %>
-      <%= link_to new_travel_book_schedule_path(@travel_book), data: { turbo: false }, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-        <%= t(".new_button") %>
+      <%= link_to new_travel_book_schedule_path(@travel_book), data: { turbo: false }, class: "btn btn-primary btn-circle fixed z-50 bottom-20 right-5 text-lg md:right-[calc(50%)] " do %>
+        <i class="fa-solid fa-plus"></i>
       <% end %>
     <% end %>
   </div>
 
-  <div id="map-container" class="relative w-full h-[calc(100vh-64px)]">
+  <div id="map-container" class="hidden md:block md:relative md:h-[calc(100vh-64px)] md:flex-1">
     <div id="map" class="w-full h-full"></div>
     <div id="popup" class="absolute bottom-[calc(64px+10px)] left-1/2 -translate-x-1/2"></div>
   </div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,13 +1,8 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-
-    <div class="relative flex items-center justify-center">
-      <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
     <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,22 +1,21 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
 
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= @schedule.title %></h3>
-      <% if @travel_book.owned_by_user?(current_user) %>
-        <%= link_to edit_schedule_path(@schedule), data: { turbo: false }, class: "hover:opacity-50" do %>
-          <i class="fa-solid fa-pen"></i>
+      <h2 class="text-lg font-bold ml-5"><%= @schedule.title %></h2>
+      <div class="flex justify-end">
+        <% if @travel_book.owned_by_user?(current_user) %>
+          <%= link_to edit_schedule_path(@schedule), data: { turbo: false }, class: "btn" do %>
+            <i class="fa-solid fa-pen"></i>
+          <% end %>
+          <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-3 btn" do %>
+            <i class="fa-solid fa-trash"></i>
+          <% end %>
         <% end %>
-        <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
-          <i class="fa-solid fa-trash"></i>
-        <% end %>
-      <% end %>
+      </div>
     </div>
 
-    <div class="m-10">
+    <div class="my-10">
       <ul class="fa-ul space-y-5">
         <li><span class="fa-li"><i class="fa-regular fa-clock"></i></span><%= fmt_schedule_duration(@schedule) %></li>
         <li><span class="fa-li"><i class="fa-solid fa-location-dot"></i></span><%= schedule_spot_info(@schedule.spot) %></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,7 @@ ja:
     total_amount: "合計金額：%{amount}"
     currency_unit: 円
     undecided: 未定
+    date_undecided: 日付未定
     public: 公開
     unpublic: 未公開
   defaults:


### PR DESCRIPTION
# 概要
スケジュール関連のレスポンシブ・CSSの修正を行いました。

## 実施内容
- [x] 以下のビューファイルのレスポンシブ対応・CSS修正
  - schedules/new
  - schedules/edit
  - schedules/index
  - schedules/show
  - schedules/_form
- [x] travel_book_durationヘルパーで返す文言を`"未定"`から`"日付未定"`へ変更

## 未実施内容
- スケジュール一覧の表示の修正
現状のdaisyuiのタブ機能ではレスポンシブ対応が難しいため、ビューの実装修正を検討

## 補足

## 関連issue
#250 