### PR TITLE
Update/チェックリスト関連のレスポンシブ対応・CSS修正

### DIFF
--- a/app/views/check_lists/_check_list.html.erb
+++ b/app/views/check_lists/_check_list.html.erb
@@ -1,6 +1,6 @@
 <%= link_to check_list_path(check_list), data: { turbo: false }, class: "block" do %>
-  <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:opacity-50">
-    <i class="fa-solid fa-square-check"></i>
+  <div class="bg-base-100 flex items-center my-2 md:my-5 p-2 md:p-5 rounded-full shadow-sm hover:scale-[1.03]">
+    <i class="fa-solid fa-square-check ml-3"></i>
     <div class="ml-3"><%= check_list.title %></div>
   </div>
 <% end %>

--- a/app/views/check_lists/_form.html.erb
+++ b/app/views/check_lists/_form.html.erb
@@ -1,13 +1,11 @@
 <%= form_with model: check_list, url: check_list.new_record? ? travel_book_check_lists_path(travel_book) : check_list_path(check_list), data: { turbo: false } do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
-  <div class="field mt-3">
+  <div class="space-y-3">
     <%= f.label :title, class: "w-full" do %>
       <span class="text-red-400">*</span><%= Schedule.human_attribute_name(:title) %>
     <% end %>
     <%= f.text_field :title, autofocus: true, placeholder: t("check_lists.form.placeholder.title"), class: "input input-bordered w-full" %>
-  </div>
-  <div class="flex justify-end mt-5">
-    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
+    <%= f.submit nil, class: "btn btn-primary w-full" %>
   </div>
 <% end %>

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,11 +1,6 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to check_list_path(@check_list), data: { turbo: false }, class:"hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title") %></h1>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>
 </div>

--- a/app/views/check_lists/index.html.erb
+++ b/app/views/check_lists/index.html.erb
@@ -1,14 +1,16 @@
-<div class="container">
-  <div class="w-full flex gap-3">
-    <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-outline btn-primary w-1/2" %>
-    <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-primary w-1/2" %>
+<div class="m-5">
+  <div class="max-w-screen-md mx-auto">
+    <div class="flex gap-3">
+      <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-sm md:btn-md btn-outline btn-primary w-1/2" %>
+      <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-sm md:btn-md btn-primary w-1/2" %>
+    </div>
+    <% if @check_lists.present? %>
+      <%= render @check_lists %>
+    <% else %>
+      <p class="text-center mt-10"><%= t(".no_data")%></p>
+    <% end %>
   </div>
-  <% if @check_lists.present? %>
-    <%= render @check_lists %>
-  <% else %>
-    <%= t(".no_data")%>
-  <% end %>
 </div>
-<%= link_to new_travel_book_check_list_path, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-  <%= t(".new_button")%>
+<%= link_to new_travel_book_check_list_path, data: { turbo: false }, class: "btn btn-primary btn-circle fixed z-50 bottom-20 right-5 text-lg" do %>
+  <i class="fa-solid fa-plus"></i>
 <% end %>

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -1,11 +1,6 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to travel_book_check_lists_path(@travel_book), class:"hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>
 </div>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -1,22 +1,21 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
 
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_check_lists_path(@travel_book), class:"hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= @check_list.title %></h3>
-      <% if @travel_book.owned_by_user?(current_user) %>
-        <%= link_to edit_check_list_path(@check_list), class:"hover:opacity-50" do %>
-          <i class="fa-solid fa-pen"></i>
+      <h2 class="md:text-lg font-bold md:ml-5"><%= @check_list.title %></h2>
+      <div class="flex justify-end">
+        <% if @travel_book.owned_by_user?(current_user) %>
+          <%= link_to edit_check_list_path(@check_list), class:"hover:opacity-50" do %>
+            <i class="fa-solid fa-pen text-sm md:text-base"></i>
+          <% end %>
+          <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+            <i class="fa-solid fa-trash text-sm md:text-base"></i>
+          <% end %>
         <% end %>
-        <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
-          <i class="fa-solid fa-trash"></i>
-        <% end %>
-      <% end %>
+      </div>
     </div>
 
-    <div class="m-10">
+    <div class="md:m-10">
       <%= turbo_frame_tag "list_item" do %>
         <% if @list_items.present? %>
           <% @list_items.each do |list_item| %>
@@ -30,13 +29,12 @@
       <div id="add_list_item_button" class="my-5">
         <%= render "list_items/add_button", check_list: @check_list %>
       </div>
-      <div id="list_item_form"></div>
+      <div id="list_item_form" class="my-5"></div>
     </div>
 
     <div role="alert" class="alert alert-vertical sm:alert-horizontal">
       <i class="fa-solid fa-circle-info text-primary"></i>
-
-      <span>LINEの友だち追加すると<i class="fa-solid fa-bell"></i>で設定した時刻にLINEでリマインダーが届きます</span>
+      <span>LINEの友だち追加をすると指定した時間にLINEでリマインド通知を受け取れます</span>
       <div>
         <div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@450oywta" style="display: none;"></div>
         <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>

--- a/app/views/list_items/_add_button.html.erb
+++ b/app/views/list_items/_add_button.html.erb
@@ -1,5 +1,5 @@
 <div id="add_list_item_button">
   <%= link_to new_check_list_list_item_path(@check_list), class: "btn btn-primary", data: { turbo_stream: true } do %>
-    <i class="fa-solid fa-circle-plus"></i><%= t(".new_button") %>
+    <i class="fa-solid fa-plus"></i><%= t(".new_button") %>
   <% end %>
 </div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag "list_item_#{list_item.id}" do %>
   <%= form_with model: @list_item, url: @list_item.new_record? ? check_list_list_items_path(@check_list): list_item_path(@list_item) do |f| %>
-  <%= render "shared/error_messages", object: f.object %>
-  <div class="flex gap-2">
+    <%= render "shared/error_messages", object: f.object %>
+    <div class="flex gap-2 items-center">
       <%= f.text_field :title, autofocus: true, placeholder: t("list_items.form.placeholder.title"), class: "input input-bordered w-full" %>
-    <div class="flex gap-2">
-      <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn btn-ghoast", data: { turbo_method: :post } do %>
-        <i class="fa-solid fa-xmark"></i>
-      <% end %>
-      <%= f.submit nil, class: "btn btn-primary" %>
+      <div class="flex gap-2 items-center">
+        <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn btn-ghoast", data: { turbo_method: :post } do %>
+          <i class="fa-solid fa-xmark"></i>
+        <% end %>
+        <%= f.submit nil, class: "btn btn-primary" %>
+      </div>
     </div>
-  </div>
   <% end %>
 <% end %>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -5,23 +5,40 @@
         <%= f.check_box :completed, onchange: "this.form.requestSubmit()", class: "checkbox" %>
         <%= list_item.title %>
       </div>
-      <div class="flex gap-5">
-        <% if list_item.persisted? %>
-          <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:opacity-50" do %>
-            <i class="fa-solid fa-pen"></i>
-          <% end %>
-          <button class="hover:opacity-50" type="button" onclick="modal_<%= list_item.id %>.showModal()">
-            <% if list_item.reminder.reminder_date %>
-              <i class="fa-solid fa-bell"></i>
-            <% else %>
-              <i class="fa-solid fa-bell-slash"></i>
-            <% end %>
-          </button>
-          <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "hover:opacity-50" do %>
-            <i class="fa-solid fa-trash"></i>
-          <% end %>
+      <div class="flex items-center">
+        <% if list_item.reminder.reminder_date %>
+          <div class="tooltip" data-tip="リマインダー設定済み">
+            <i class="fa-solid fa-bell text-sm md:text-base mr-2"></i>
+          </div>
         <% end %>
+        <div class="dropdown dropdown-end">
+          <div tabindex="0" role="button" class="m-1"><i class="fa-solid fa-ellipsis-vertical"></i></div>
+          <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+            <% if list_item.persisted? %>
+              <li>
+              <%= link_to edit_list_item_path(list_item), data: { turbo_stream: true }, class: "hover:opacity-50" do %>
+                <i class="fa-solid fa-pen fa-fw text-sm md:text-base"></i> 編集
+              <% end %>
+              </li>
+              <li>
+                <button class="hover:opacity-50" type="button" onclick="modal_<%= list_item.id %>.showModal()">
+                  <% if list_item.reminder.reminder_date %>
+                    <i class="fa-solid fa-bell fa-fw text-sm md:text-base"></i> リマインダー解除
+                  <% else %>
+                    <i class="fa-solid fa-bell-slash fa-fw text-sm md:text-base"></i> リマインダー設定
+                  <% end %>
+                </button>
+              </li>
+              <li>
+                <%= link_to list_item_path(list_item), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "hover:opacity-50" do %>
+                  <i class="fa-solid fa-trash fa-fw text-sm md:text-base"></i> 削除
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
       </div>
+
     </div>
   <% end %>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -139,7 +139,7 @@ ja:
       note_link: ノート
       check_list_link: チェックリスト
       new_button: チェックリスト作成
-      no_data: チェックリストは登録されていません
+      no_data: チェックリストが登録されていません
     show:
       no_data: チェックリストに項目を追加しましょう
     new:


### PR DESCRIPTION
# 概要
チェックリスト関連のレスポンシブ対応とCSSの修正を行いました。

## 実施内容
- [x] 以下ビューファイルのCSSの修正
- check_lists/new
- check_lists/edit
- check_lists/index
- check_lists/show
- check_lists/_check_list
- check_lists/_form
- list_items/_list_item
- list_items/_form
- list_items/_add_button

## 未実施内容
なし

## 補足
### 修正イメージ
- スマホサイズのときにチェックリストの編集・リマインダー・削除ボタンが幅をとっていたため、ドロップダウンメニューに変更しました。
【修正前】
[![Image from Gyazo](https://i.gyazo.com/fe3c5b71f7af6bd392cb0528833424c5.png)](https://gyazo.com/fe3c5b71f7af6bd392cb0528833424c5)

【修正後】
[![Image from Gyazo](https://i.gyazo.com/6de126f6ca0277a8621c87651166b66e.png)](https://gyazo.com/6de126f6ca0277a8621c87651166b66e)

## 関連issue
#254 