### PR TITLE
Update/ノート関連のレスポンシブ対応・CSS修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -27,9 +27,9 @@
   @apply link link-primary;
 }
 
-/* 連続で入力した空白や改行がブラウザでの表示に反映・要素のボックス端で自動で折り返し */
+/* 空白や改行がブラウザでの表示に反映・要素のボックス端で自動で折り返し(連続した空白は折りたたむ) */
 .markdown-content {
-  white-space: pre-wrap;
+  white-space: pre-line;
 }
 
 .bg-image {

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", check_list: @check_list, travel_book: @travel_book %>
   </div>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 
     <div class="flex items-center justify-between">
       <h2 class="md:text-lg font-bold md:ml-5"><%= @check_list.title %></h2>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="container">
-  <div class="form-container rounded-lg shadow-md bg-base-100 p-8">
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2>パスワードを入力してしおりへ参加する</h2>
 
     <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
@@ -33,7 +33,7 @@
       <% end %>
 
       <div class="actions">
-        <%= f.submit t("devise.invitations.edit.submit_button"), class: "btn btn-primary w-full mt-6 mx-auto" %>
+        <%= f.submit t("devise.invitations.edit.submit_button"), class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center">しおりに招待する</h2>
 
     <%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
@@ -19,7 +19,7 @@
       <% end -%>
 
       <div class="actions">
-        <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-primary w-full mt-6 mx-auto" %>
+        <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-primary w-full" %>
       </div>
     <% end %>
   </div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,20 +1,20 @@
 <%= form_with model: note, url: note.new_record?  ? travel_book_notes_path(travel_book) : note_path(note) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
-  <div class="space-y-4">
-    <div class="field">
+  <div class="space-y-3">
+    <div>
       <%= f.label :title, class: "w-full" do %>
         <span class="text-red-400">*</span><%= Note.human_attribute_name(:title) %>
       <% end %>
       <%= f.text_field :title, autofocus: true, placeholder: t(".placeholder.title"), class: "input input-bordered w-full" %>
     </div>
 
-    <div class="field">
+    <div>
       <%= f.label :title, Note.human_attribute_name(:body), class: "label" %>
       <%= f.text_area :body, placeholder: t(".placeholder.body"), rows: "10", class: "textarea textarea-bordered w-full" %>
     </div>
 
-    <%= f.submit nil, class: "btn btn-primary w-full mt-6 mx-auto" %>
+    <%= f.submit nil, class: "btn btn-primary w-full" %>
   </div>
 
 <% end %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,6 +1,6 @@
 <%= link_to note_path(note), data: { turbo: false }, class: "block" do %>
-  <div class="bg-base-100 flex items-center my-5 p-5 rounded-lg hover:opacity-50">
-    <i class="fa-solid fa-book-open"></i>
+  <div class="bg-base-100 flex items-center  my-2 md:my-5 p-2 md:p-5 rounded-full shadow-sm hover:scale-[1.03]">
+    <i class="fa-solid fa-book-open ml-3"></i>
     <div class="ml-3"><%= note.title %></div>
   </div>
 <% end %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,11 +1,6 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to travel_book_notes_path(@travel_book), class:"hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", note: @note, travel_book: @travel_book %>
   </div>
 </div>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,14 +1,16 @@
-<div class="container">
-  <div class="w-full flex gap-3">
-    <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-primary w-1/2" %>
-    <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-primary btn-outline w-1/2" %>
-  </div>
-  <% if @notes.present? %>
-    <%= render @notes %>
-  <% else %>
-    <%= t(".no_data")%>
-  <% end %>
+<div class="m-5">
+  <div class="max-w-screen-md mx-auto">
+    <div class="flex gap-3">
+      <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-sm md:btn-md btn-primary w-1/2" %>
+      <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-sm md:btn-md btn-outline btn-primary w-1/2" %>
+    </div>
+    <% if @notes.present? %>
+      <%= render @notes %>
+    <% else %>
+      <p class="text-center mt-10"><%= t(".no_data")%></p>
+    <% end %>
+    </div>
 </div>
-<%= link_to new_travel_book_note_path, class: "btn btn-primary fixed z-50 bottom-20 right-5 rounded-full cursor-pointer" do %>
-  <%= t(".new_button")%>
+<%= link_to new_travel_book_note_path, class: "btn btn-primary fixed z-50 bottom-20 right-5" do %>
+  <i class="fa-solid fa-plus"></i>
 <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,11 +1,6 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
-    <div class="flex items-center justify-between">
-      <%= link_to travel_book_notes_path(@travel_book), class:"hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= t(".title") %></h3>
-    </div>
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
+    <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", note: @note, travel_book: @travel_book %>
   </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,12 +1,9 @@
-<div class="container">
-  <div class="form-container bg-base-100 rounded-lg shadow-md p-8">
+<div class="max-w-screen-md mx-auto">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 
     <div class="flex items-center justify-between">
-      <%= link_to travel_book_notes_path(@travel_book), class: "hover:opacity-50" do %>
-        <i class="fa-solid fa-chevron-left"></i>
-      <% end %>
-      <h3 class="flex-grow text-center"><%= @note.title %></h3>
-        <div class="justify-end">
+    <h2 class="md:text-lg font-bold md:ml-5"><%= @note.title %></h2>
+      <div class="justify-end">
         <% if @travel_book.owned_by_user?(current_user) %>
           <%= link_to edit_note_path(@note), class:"hover:opacity-50" do %>
             <i class="fa-solid fa-pen"></i>
@@ -18,7 +15,7 @@
       </div>
     </div>
 
-    <div class="markdown-content mx-10">
+    <div class="markdown-content md:mx-5">
       <%= markdown(@note.body) %>
     </div>
   </div>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
     <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto flex-none md:flex md:max-w-none">
-  <div class="bg-base-100 p-8 m-5 rounded-lg md:m-0 md:rounded-none md:shadow-md md:flex-1">
+  <div class="bg-base-100 p-4 md:p-8 m-3 rounded-lg md:m-0 md:rounded-none md:shadow-md md:flex-1">
 
     <div class="flex flex-grow flex-col items-center">
       <h2 class="text-lg font-bold"><%= @travel_book.title %></h2>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
     <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 
     <div class="flex items-center justify-between">
       <h2 class="text-lg font-bold ml-5"><%= @schedule.title %></h2>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", travel_book: @travel_book %>
   </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
     <%= render "form", travel_book: @travel_book %>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-8 m-5">
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 
     <h2 class="text-lg font-bold text-center">メンバーリスト</h2>
 

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-screen-md mx-auto">
-  <div class="card bg-base-100 shadow-md m-5">
+  <div class="card bg-base-100 shadow-md m-3 md:m-5">
     <figure class="h-64 w-full">
       <%= image_tag @travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
     </figure>


### PR DESCRIPTION
# 概要
ノート関連のレスポンシブ対応・CSS修正を行いました。

## 実施内容
- [x] 以下のビューファイルのCSSクラスを修正
- notes/new
- notes/edit
- notes/index
- notes/show
- notes/_form
- notes/_note
- [x] ノート詳細画面のマークダウンでノートの余白が多すぎるためCSS修正
- [x] ノートで修正した共通するCSSクラスについてしおり、スケジュール、チェックリストにも反映

## 未実施内容
なし

## 補足
- ノート詳細画面のマークダウンでノートの余白が多すぎるためCSS修正
white-spaceを`pre-wrap`から`pre-line`へ修正しました。
それに伴い、連続する空白は折り込まれるようになりました。

- しおり、スケジュール、チェックリストにも共通するCSSクラスの修正を行なったため合わせて修正しました。

## 関連issue
#256