### PR TITLE
Fix/ボトムナビゲーションの修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,15 @@ module ApplicationHelper
     (controller_name == "list_items")
   end
 
-  # 指定したパスが現在のページであれば"active"を返す
-  def add_active_class(path)
-    current_page?(path) ? "hover:bg-base-200" : "hover:bg-base-200 opacity-50"
+  # 指定したパスが現在のコントローラーと一致する場合クラスを返す
+  def active_class_by_controller(*controllers)
+    return "text-gray-500 hover:scale-[1.1]" if action_name == "map"
+    controllers.include?(controller_name) ? "text-white hover:scale-[1.1]" : "text-gray-500 hover:scale-[1.1]"
+  end
+
+  # 指定したパスが現在のアクションと一致する場合クラスを返す
+  def active_class_by_controller_and_action(controller, action)
+    controller_name == controller && action_name == action ? "text-white hover:scale-[1.1]" : "text-gray-500 hover:scale-[1.1]"
   end
 
   # 日付をフォーマットする

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,16 +1,16 @@
 <div class="btm-nav bg-primary">
-  <%= link_to public_travel_books_path, class: "#{add_active_class(public_travel_books_path)}" do %>
+  <%= link_to public_travel_books_path, class: active_class_by_controller_and_action('travel_books', 'public_travel_books') do %>
     <i class="fa-solid fa-magnifying-glass"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.travel_books_search") %></span>
+    <span class="btm-nav-label text-xs"><%= t("btm_nav.travel_books_search") %></span>
   <% end %>
 
-  <%= link_to new_travel_book_path, class: "#{add_active_class(new_travel_book_path)}" do %>
+  <%= link_to new_travel_book_path, class: active_class_by_controller_and_action('travel_books', 'new') do %>
     <i class="fa-solid fa-plus"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.travel_book_create") %></span>
+    <span class="btm-nav-label text-xs"><%= t("btm_nav.travel_book_create") %></span>
   <% end %>
 
-  <%= link_to travel_books_path, class: "#{add_active_class(travel_books_path)}" do %>
+  <%= link_to travel_books_path, class: active_class_by_controller_and_action('travel_books', 'index') do %>
     <i class="fa-solid fa-map-location-dot"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.my_travel_book") %></span>
+    <span class="btm-nav-label text-xs"><%= t("btm_nav.my_travel_book") %></span>
   <% end %>
 </div>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -1,24 +1,26 @@
 <div class="btm-nav bg-primary shadow-sm">
-  <%= link_to travel_book_path(@travel_book.id), class: "#{add_active_class(travel_book_path(@travel_book))}" do %>
+  <%= link_to travel_book_path(@travel_book.id), class: active_class_by_controller('travel_books') do %>
     <i class="fa-regular fa-map"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.travel_book_info") %></span>
+    <span class="btm-nav-label text-xs"><%= t("btm_nav.travel_book_info") %></span>
   <% end %>
-  <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "#{add_active_class(travel_book_schedules_path(@travel_book))}" do %>
+  <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: active_class_by_controller('schedules') do %>
     <i class="fa-regular fa-clock"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.schedule") %></span>
+    <span class="btm-nav-label text-xs"><%= t("btm_nav.schedule") %></span>
   <% end %>
-  <%= link_to map_travel_book_schedules_path(@travel_book), data: { turbo: false }, class: "#{add_active_class(map_travel_book_schedules_path(@travel_book))}" do %>
+  <%= link_to map_travel_book_schedules_path(@travel_book), data: { turbo: false }, class: active_class_by_controller_and_action('schedules', 'map') do %>
   <i class="fa-solid fa-location-dot"></i>
-    <span class="btm-nav-label"><%= t("btm_nav.map") %></span>
+    <span class="btm-nav-label text-xs"><%= t("btm_nav.map") %></span>
   <% end %>
   <% if @travel_book.owned_by_user?(current_user) %>
-    <%= link_to travel_book_notes_path(@travel_book), class: "#{add_active_class(travel_book_check_lists_path(@travel_book))}" do %>
+    <%= link_to travel_book_notes_path(@travel_book), class: active_class_by_controller('notes','check_lists') do %>
       <i class="fa-solid fa-file-pen"></i>
-      <span class="btm-nav-label"><%= t("btm_nav.note") %></span>
+      <span class="btm-nav-label text-xs"><%= t("btm_nav.note") %></span>
     <% end %>
-    <%= link_to "#", class: "opacity-50" do %>
+    <%= link_to "#", class: "text-gray-500" do %>
+    <span class="tooltip flex flex-col items-center gap-1" data-tip="今後実装予定です">
       <i class="fa-solid fa-image"></i>
-      <span class="btm-nav-label"><%= t("btm_nav.album") %></span>
+      <span class="btm-nav-label text-xs"><%= t("btm_nav.album") %></span>
+    </span>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
# 概要
ボトムナビゲーションのCSSクラス付与ロジックとCSSの修正を行いました。

## 実施内容
- [x] ボトムナビゲーションでactiveなメニューのCSSを表示する際のメソッド修正
- [x] ボトムナビゲーションのCSSを修正

## 未実施内容
- 文字色の調整（文字色は仮で反映）

## 補足
- ボトムナビゲーションでactiveなメニューのCSSを表示する際のメソッド修正
current_pageで現在のページで判断していたが、controller_nameとaction_nameで現在のactiveメニューを判断するようにメソッドを修正しました。

- プロフィール画面、しおりの招待画面を表示する際はボトムナビゲーションはactiveになるメニューはありません。

## 関連issue
#161