### PR TITLE
Fix/スケジュール・マップ表示の修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -4,9 +4,15 @@ class SchedulesController < ApplicationController
   before_action :set_schedule, only: %i[ show edit update destroy ]
 
   def index
+    # scheduleには0以上のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
+    # スケジュール一覧では初日を初期表示するためindexでは初日のデータのみ取得する
     @schedules = @travel_book.sorted_schedules
-    # scheduleには0もしくは1のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
-    @spots = @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }
+    first_date = @schedules.map { |s| s.start_date.to_date }.min
+    @spots = @schedules
+             .select { |s| s.start_date.to_date == first_date }
+             .map(&:spot)
+             .compact
+             .select { |spot| spot.latitude.present? }
   end
 
   def new

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -6,10 +6,10 @@
       <div class="justify-end">
         <% if @travel_book.owned_by_user?(current_user) %>
           <%= link_to edit_note_path(@note), class:"hover:opacity-50" do %>
-            <i class="fa-solid fa-pen"></i>
+            <i class="fa-solid fa-pen text-sm md:text-base"></i>
           <% end %>
           <%= link_to note_path(@note), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
-            <i class="fa-solid fa-trash"></i>
+            <i class="fa-solid fa-trash text-sm md:text-base"></i>
           <% end %>
         <% end %>
       </div>

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -20,21 +20,21 @@ function initMap() {
 
   spots.forEach((spot,i) =>{
     // markerの設定
-    //  const marker = new google.maps.marker.AdvancedMarkerElement({
-      // position: {lat: parseFloat(spot.latitude), lng: parseFloat(spot.longitude)},
-      // map: map,
-      // title: spot.name
-    // });
-    // markerに登録された場所のindex番号を表示
-    const pinTextGlyph = new google.maps.marker.PinElement({
-      glyph: `${i+1}`,
-      glyphColor: "white",
+    const marker = new google.maps.marker.AdvancedMarkerElement({
+      position: {lat: parseFloat(spot.latitude), lng: parseFloat(spot.longitude)},
+      map: map,
+      title: spot.name
     });
+    // markerに登録された場所のindex番号を表示
+    // const pinTextGlyph = new google.maps.marker.PinElement({
+      // glyph: `${i+1}`,
+      // glyphColor: "white",
+    // });
     // markerを表示
     const markerViewGlyphText = new google.maps.marker.AdvancedMarkerElement({
       map,
       position: {lat: parseFloat(spot.latitude), lng: parseFloat(spot.longitude)},
-      content: pinTextGlyph.element,
+      // content: pinTextGlyph.element,
     });
 
     // markerがクリックされた時に地図の詳細情報を表示

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,4 +1,4 @@
-<div class="overflow-x-auto">
+<div class="max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg">
   <table class="table">
     <tbody>
       <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
@@ -18,11 +18,9 @@
           <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
         </td>
         <td class="w-1/6">
-          <% index = index +1 if defined?(index) && index %>
           <% if schedule.spot&.latitude %>
             <div class="relative inline-block">
               <i class="fa-solid fa-location-pin text-2xl text-red-500"></i>
-              <p class="absolute top-2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs text-white"><%= index %></p>
             </div>
           <% end %>
         </td>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -7,27 +7,18 @@
     </div>
     <% if @schedules.present? %>
     <div data-controller="tabs">
-      <div role="tablist" class="tabs tabs-bordered">
-        <!-- Tab for allday -->
+      <div role="tablist" class="tabs tabs-bordered overflow-x-scroll">
+        <% Schedule.group_by_date(@schedules).each_with_index do |(date, schedules),i| %>
           <input type="radio" data-action="change->tabs#changeTab"
-            data-tabs-spots-value="<%= @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
-            name="my_tabs_1" role="tab" class="tab" aria-label="ALL" checked="checked"/>
-          <div role="tabpanel" class="tab-content p-3">
-            <% @schedules.each_with_index do |schedule, i| %>
-              <%= render partial: "schedule", locals: { schedule: schedule, all_day: true, index: i } %>
-            <% end %>
-            <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(@schedules)) %><%= t("helpers.currency_unit") %></p>
-          </div>
-
-        <!-- Tab for each date -->
-        <% Schedule.group_by_date(@schedules).each do |date, schedules| %>
-            <input type="radio" data-action="change->tabs#changeTab"
-              data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>" name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" />
-          <div role="tabpanel" class="tab-content p-3">
+            data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
+            name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" <%= 'checked' if i == 0 %> />
+          <div role="tabpanel" class="tab-content md:p-3">
             <% schedules.each_with_index do |schedule, i| %>
               <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>
             <% end %>
-            <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(schedules)) %><%= t("helpers.currency_unit") %></p>
+            <div class="max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg">
+              <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(schedules)) %><%= t("helpers.currency_unit") %></p>
+            </div>
           </div>
         <% end %>
       </div>
@@ -82,15 +73,15 @@ function initMap() {
 
   spots.forEach((spot,i) =>{
     // markerに登録された場所のindex番号を表示
-    const pinTextGlyph = new google.maps.marker.PinElement({
-      glyph: `${i+1}`,
-      glyphColor: "white",
-    });
+    // const pinTextGlyph = new google.maps.marker.PinElement({
+    //   glyph: `${i+1}`,
+    //   glyphColor: "white",
+    // });
     // markerを表示
     const markerViewGlyphText = new google.maps.marker.AdvancedMarkerElement({
       map,
       position: {lat: parseFloat(spot.latitude), lng: parseFloat(spot.longitude)},
-      content: pinTextGlyph.element,
+      //content: pinTextGlyph.element,
     });
 
     // markerがクリックされた時に地図の詳細情報を表示

--- a/app/views/schedules/map.html.erb
+++ b/app/views/schedules/map.html.erb
@@ -1,4 +1,4 @@
-<div id="map-container" class="relative w-full h-[calc(100vh-64px)]">
+<div id="map-container" class="relative w-full h-[calc(100vh-64px-64px)]">
   <div id="map" class="w-full h-full"></div>
   <div id="popup" class="absolute bottom-[calc(64px+10px)] left-1/2 -translate-x-1/2"></div>
 </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -5,11 +5,11 @@
       <h2 class="text-lg font-bold ml-5"><%= @schedule.title %></h2>
       <div class="flex justify-end">
         <% if @travel_book.owned_by_user?(current_user) %>
-          <%= link_to edit_schedule_path(@schedule), data: { turbo: false }, class: "btn" do %>
-            <i class="fa-solid fa-pen"></i>
+          <%= link_to edit_schedule_path(@schedule), data: { turbo: false }, class: "hover:opacity-50" do %>
+            <i class="fa-solid fa-pen text-sm md:text-base"></i>
           <% end %>
-          <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-3 btn" do %>
-            <i class="fa-solid fa-trash"></i>
+          <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+            <i class="fa-solid fa-trash text-sm md:text-base"></i>
           <% end %>
         <% end %>
       </div>

--- a/app/views/travel_books/_my_travel_book.html.erb
+++ b/app/views/travel_books/_my_travel_book.html.erb
@@ -1,10 +1,10 @@
 <% travel_books.each do |travel_book| %>
   <div class="card bg-base-100 w-full">
-    <figure>
-      <%= link_to travel_book_path(travel_book), class: "hover:scale-125 hover:duration-500" do %>
-        <%= image_tag travel_book.travel_book_image_url %>
+    <figure class="h-48 w-full">
+      <%= link_to travel_book_path(travel_book), class: "hover:scale-[1.1] hover:duration-500" do %>
+        <%= image_tag travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
       <% end %>
-    </figure>
+  </figure>
     <div class="card-body flex flex-col justify-between">
       <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
         <h2 class="card-title"><%= truncate(travel_book.title) %></h2>

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,14 +1,13 @@
 <div class="card bg-base-100 w-full">
-  <figure>
-  <%= link_to travel_book_path(travel_book), class: "hover:scale-125 hover:duration-500" do %>
-    <%= image_tag travel_book.travel_book_image_url %>
-  <% end %>
+  <figure class="h-48 w-full">
+    <%= link_to travel_book_path(travel_book), class: "hover:scale-[1.1] hover:duration-500" do %>
+      <%= image_tag travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
+    <% end %>
   </figure>
   <div class="card-body flex flex-col justify-between">
     <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
       <h2 class="card-title"><%= truncate(travel_book.title) %></h2>
     <% end %>
-
     <div>
       <p><span class="badge mr-2">エリア</span><%= area_name(travel_book) %></p>
       <p><span class="badge mr-2">スタイル</span><%= traveler_type_name(travel_book) %></p>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -50,6 +50,11 @@
           <p><%= travel_book_is_public(@travel_book) %></p>
         </div>
 
+        <div>
+          <p class="font-bold text-sm"><%= t(".total_amount") %></p>
+          <p><%= total_budget(@travel_book.schedules) %><%= t("helpers.currency_unit") %></p>
+        </div>
+
         <% unless @travel_book.owned_by_user?(current_user) %>
           <%= link_to travel_book_schedules_path(@travel_book), class: "btn btn-primary w-full" do %>
             <i class="fa-regular fa-clock"></i> スケジュールを見る

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -12,11 +12,11 @@
         </div>
         <% if @travel_book.owned_by_user?(current_user) %>
           <div class="flex justify-end">
-            <%= link_to edit_travel_book_path(@travel_book), class: "btn hover:opacity-50" do %>
-              <i class="fa-solid fa-pen"></i>
+            <%= link_to edit_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
+              <i class="fa-solid fa-pen text-sm md:text-base"></i>
             <% end %>
-            <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "btn ml-3 hover:opacity-50" do %>
-              <i class="fa-solid fa-trash"></i>
+            <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+              <i class="fa-solid fa-trash text-sm md:text-base"></i>
             <% end %>
           </div>
         <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -91,6 +91,7 @@ ja:
       new_button: しおり作成
     show:
       duration: 期間
+      total_amount: 合計金額
     new:
       title: しおり作成
     edit:


### PR DESCRIPTION
# 概要
スケジュール一覧の表示とマップの表示について修正を加えました。
また、画像やアイコンサイズ等の修正を行いました。

## 実施内容
- [x] スケジュール一覧からALLタブの削除
- [x] 合計金額をしおり詳細に表示
- [x] スケジュールパーシャルとmapのピンから数字の表示を削除
- [x] マップに表示するpopup(場所情報)のレスポンシブ対応
- [x] アイコンサイズの修正(ノート、スケジュール、しおりの詳細画面)
- [x] しおり一覧画面のしおり画像の高さを指定

## 未実施内容
- タブのみのスクロール

## 補足
- スケジュール一覧のレスポンシブ対応を行う中で、ALLタブ(全日)の表示よりも日毎の表示範囲を広げた方が良いと判断しALLタブを削除(今後要検討)
- マップのピンにスケジュールの場所順に数値を表示していたが、場所情報がない場合、数字に反映されずわかりづらいと判断したため数字表記を削除しました

## 関連issue
なし