### PR TITLE
Fix/SchedulesController#indexの@spots生成のロジックを修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -7,9 +7,9 @@ class SchedulesController < ApplicationController
     # scheduleには0以上のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
     # スケジュール一覧では初日を初期表示するためindexでは初日のデータのみ取得する
     @schedules = @travel_book.sorted_schedules
-    first_date = @schedules.map { |s| s.start_date.to_date }.min
+    first_date = @schedules.map { |s| s.start_date&.to_date }.compact.min
     @spots = @schedules
-             .select { |s| s.start_date.to_date == first_date }
+             .select { |s| s.start_date&.to_date == first_date }
              .map(&:spot)
              .compact
              .select { |spot| spot.latitude.present? }


### PR DESCRIPTION
# 概要
SchedulesController#indexの@spots生成のロジック内でnilにto_dateを呼び出してNoMethodErrorが出てしまっていたためコードを修正しました。

## 実施内容
- [x] nilにto_dateを呼び出している箇所の修正

## 未実施内容
なし

## 補足
#264 の修正です

## 関連issue
なし