### PR TITLE
Fix/しおり画像投稿時のエラー修正とCSS修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -56,7 +56,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # アカウント登録後のリダイレクト先
   def after_sign_up_path_for(resource)
-    travel_books_path
+    public_travel_books_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,7 +22,7 @@ class Users::SessionsController < Devise::SessionsController
 
   # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource)
-    travel_books_path
+    public_travel_books_path
   end
 
   # ログアウト後のリダイレクト先

--- a/app/uploaders/travel_book_uploader.rb
+++ b/app/uploaders/travel_book_uploader.rb
@@ -33,7 +33,7 @@ class TravelBookUploader < CarrierWave::Uploader::Base
 
   # Process files as they are uploaded:
   # process scale: [200, 300]
-  process resize_to_fit: [ 1000, 1000 ]
+  process resize_to_fill: [ 800, 600, "Center" ]
   #
   # def scale(width, height)
   #   # do something
@@ -63,16 +63,5 @@ class TravelBookUploader < CarrierWave::Uploader::Base
   # end
 
   # WebPに変換
-  process :convert_to_webp
-
-  def convert_to_webp
-    manipulate! do |img|
-      img.format "webp"
-      img
-    end
-  end
-
-  def filename
-    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
-  end
+  process convert: "webp"
 end

--- a/app/uploaders/travel_book_uploader.rb
+++ b/app/uploaders/travel_book_uploader.rb
@@ -33,7 +33,8 @@ class TravelBookUploader < CarrierWave::Uploader::Base
 
   # Process files as they are uploaded:
   # process scale: [200, 300]
-  process resize_to_fill: [ 800, 600, "Center" ]
+  process resize_to_fill: [ 1600, 1200, "Center" ]
+
   #
   # def scale(width, height)
   #   # do something

--- a/app/uploaders/user_uploader.rb
+++ b/app/uploaders/user_uploader.rb
@@ -27,8 +27,7 @@ class UserUploader < CarrierWave::Uploader::Base
 
   # Process files as they are uploaded:
   # process scale: [200, 300]
-  # process resize_to_fit: [ 80, 80 ]
-  process resize_to_fill: [ 80, 80, "Center" ]
+  process resize_to_fill: [ 160, 160, "Center" ]
 
   # def scale(width, height)
   #   # do something

--- a/app/uploaders/user_uploader.rb
+++ b/app/uploaders/user_uploader.rb
@@ -27,7 +27,8 @@ class UserUploader < CarrierWave::Uploader::Base
 
   # Process files as they are uploaded:
   # process scale: [200, 300]
-  process resize_to_fit: [ 80, 80 ]
+  # process resize_to_fit: [ 80, 80 ]
+  process resize_to_fill: [ 80, 80, "Center" ]
 
   # def scale(width, height)
   #   # do something
@@ -51,16 +52,5 @@ class UserUploader < CarrierWave::Uploader::Base
   # end
 
   # WebPに変換
-  process :convert_to_webp
-
-  def convert_to_webp
-    manipulate! do |img|
-      img.format "webp"
-      img
-    end
-  end
-
-  def filename
-    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
-  end
+  process convert: "webp"
 end

--- a/app/views/travel_books/_my_travel_book.html.erb
+++ b/app/views/travel_books/_my_travel_book.html.erb
@@ -1,8 +1,8 @@
 <% travel_books.each do |travel_book| %>
   <div class="card bg-base-100 w-full">
-    <figure class="h-48 w-full">
+    <figure>
       <%= link_to travel_book_path(travel_book), class: "hover:scale-[1.1] hover:duration-500" do %>
-        <%= image_tag travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
+        <%= image_tag travel_book.travel_book_image_url %>
       <% end %>
   </figure>
     <div class="card-body flex flex-col justify-between">

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,7 +1,7 @@
 <div class="card bg-base-100 w-full">
-  <figure class="h-48 w-full">
+  <figure>
     <%= link_to travel_book_path(travel_book), class: "hover:scale-[1.1] hover:duration-500" do %>
-      <%= image_tag travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
+      <%= image_tag travel_book.travel_book_image_url %>
     <% end %>
   </figure>
   <div class="card-body flex flex-col justify-between">

--- a/app/views/travel_books/bookmarks.html.erb
+++ b/app/views/travel_books/bookmarks.html.erb
@@ -1,5 +1,5 @@
-<div class="container">
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+<div class="max-w-screen-xl mx-auto">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m-5">
     <%= render partial: "travel_books/travel_book", collection: @bookmark_travel_books, as: :travel_book %>
   </div>
 </div>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-screen-md mx-auto">
   <div class="card bg-base-100 shadow-md m-3 md:m-5">
-    <figure class="h-64 w-full">
-      <%= image_tag @travel_book.travel_book_image_url, class: "object-cover h-full w-full" %>
+    <figure>
+      <%= image_tag @travel_book.travel_book_image_url %>
     </figure>
 
     <div class="card-body">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,4 +1,8 @@
 ja:
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      extension_whitelist_error: "は許可されている拡張子(jpg, jpeg, gif, png, heic, webp)のみアップロード可能です"
   activerecord:
     models:
       travel_book: しおり


### PR DESCRIPTION
# 概要
本番環境でしおりの画像に拡張子HEICをアップロードしようとするとエラーが発生する時としない時があったため
画像アップロード時にWebPに変換する処理を修正しました。
また、合わせて画像のリサイズやCSSの修正等も行いました。

[![Image from Gyazo](https://i.gyazo.com/5493081ee0797de42490a5f14554e93c.png)](https://gyazo.com/5493081ee0797de42490a5f14554e93c)

## 実施内容
- [x] 画像アップロード時にWebPに変換する処理を修正
- [x] 画像アップロード時に画像リサイズする処理を修正
- [x] 許可していない画像形式が送信された際のエラーメッセージを修正
- [x] しおりの画像を表示する画面（一覧、詳細画面）の高さの指定を削除
- [x] ブックマーク一覧のレスポンシブ対応

## 未実施内容
- しおりのデフォルト画像を4:3の画像に差し替え

## 補足
修正中に気になった以下の項目も修正しました。
- ブックマーク一覧のレスポンシブ対応にミスがあったため修正しました。
- 新規登録、ログイン後のリダイレクト先をマイしおりからしおり一覧へ変更しました。
- しおりの画像は`resize_to_fill`で4:3にリサイズしています

## 関連issue
#266 