### PR TITLE
Fix/スケジュールの時間表記のズレを修正

### DIFF
--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -12,36 +12,12 @@ module SchedulesHelper
     "#{format_date}(#{fmt_wday(date)})"
   end
 
-  def fmt_datetime(date)
-    return "" if date.nil?
-    date.strftime("%-H:%M")
+  def fmt_datetime_range(schedule)
+    return t("helpers.undecided") if schedule.start_date.nil? && schedule.end_date.nil?
+    start_date = schedule.start_date&.strftime("%H:%M")
+    end_date = schedule.end_date&.strftime("%H:%M")
+    "#{start_date} - #{end_date}"
   end
-
-  def fmt_date_with_datetime(date)
-    return "" if date.nil?
-    date.strftime("%-m/%-d %-H:%M")
-  end
-
-  def fmt_schedule_duration(schedule)
-    if schedule.start_date && schedule.end_date
-      "#{fmt_schedule_date(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
-    elsif schedule.start_date || schedule.end_date
-      "#{fmt_schedule_date(schedule.start_date)} - #{fmt_schedule_date(schedule.end_date)}".strip
-    else
-      t("helpers.undecided")
-    end
-  end
-
-  def fmt_schedule_datetime_duration(schedule)
-    return t("helpers.undecided") unless schedule.start_date || schedule.end_date
-    "#{fmt_datetime(schedule.start_date)} - #{fmt_datetime(schedule.end_date)}"
-  end
-
-  def fmt_all_day_schedule_datetime_duration(schedule)
-    return t("helpers.undecided") unless schedule.start_date || schedule.end_date
-    "#{fmt_date_with_datetime(schedule.start_date)} - #{fmt_date_with_datetime(schedule.end_date)}"
-  end
-
 
   def schedule_spot_info(data)
     return content_tag(:li, t(".no_data")) if data.nil?

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -3,11 +3,7 @@
     <tbody>
       <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
         <td class="w-2/6">
-          <% if defined?(all_day) && all_day %>
-            <%= fmt_all_day_schedule_datetime_duration(schedule) %>
-          <% else %>
-            <%= fmt_schedule_datetime_duration(schedule) %>
-          <% end %>
+          <%= fmt_datetime_range(schedule) %>
         </td>
         <td class="w-3/6">
           <% if schedule.schedule_icon.name == "none" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,6 @@ module Myapp
 
     config.i18n.default_locale = :ja
     config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
# 概要
スケジュールの時間表記がUTCになっていたため、JSTになるように設定を追加しました。

## 実施内容
- [x] active_record.default_timezoneの設定追加
- [x] スケジュールの時間表示用ヘルパーメソッドの修正と不要なメソッドの削除

## 未実施内容
なし

## 補足
- ALLタブの表示をなくした(#264)ため日付を含むヘルパーメソッドを削除

- スケジュールの時間表記修正の参考記事
https://qiita.com/joker1007/items/2c277cca5bd50e4cce5e
> config.active_record.default_timezoneの設定はDBを読み書きする際に、DBに記録されている時間をTime.utcで読むかTime.localで読むかを設定する。

## 関連issue
#268