### PR TITLE
Fix/schedules#showのビュー表示エラーの対処とUTC

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,12 +50,6 @@ module ApplicationHelper
     controller_name == controller && action_name == action ? "text-white hover:scale-[1.1]" : "text-gray-500 hover:scale-[1.1]"
   end
 
-  # 日付をフォーマットする
-  def fmt_date(date)
-    return "日付未定" if date.nil?
-    format_date = date.strftime("%Y/%-m/%-d")
-    "#{format_date}(#{fmt_wday(date)})"
-  end
 
   # 曜日をフォーマットする
   def fmt_wday(date)

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -1,21 +1,13 @@
 module SchedulesHelper
-  def fmt_schedule_date(date)
-    return "" if date.nil?
-    format_date = date.strftime("%Y/%-m/%-d")
-    format_time = date.strftime("%-H:%M")
-    "#{format_date}(#{fmt_wday(date)}) #{format_time}"
-  end
-
-  def fmt_date_with_day(date)
+  def fmt_date_label(date)
     return date if date.is_a?(String)
-    format_date = date.strftime("%-m/%-d")
-    "#{format_date}(#{fmt_wday(date)})"
+    I18n.l(date.to_date, format: :short)
   end
 
-  def fmt_datetime_range(schedule)
+  def fmt_datetime_range(schedule, format)
     return t("helpers.undecided") if schedule.start_date.nil? && schedule.end_date.nil?
-    start_date = schedule.start_date&.strftime("%H:%M")
-    end_date = schedule.end_date&.strftime("%H:%M")
+    start_date = schedule.start_date.present? ? I18n.l(schedule.start_date, format: format) : ""
+    end_date = schedule.end_date.present? ? I18n.l(schedule.end_date, format: format) : ""
     "#{start_date} - #{end_date}"
   end
 

--- a/app/helpers/travel_books_helper.rb
+++ b/app/helpers/travel_books_helper.rb
@@ -4,8 +4,14 @@ module TravelBooksHelper
   end
 
   def travel_book_duration(travel_book)
-    return t("helpers.date_undecided") unless travel_book.start_date || travel_book.end_date
+    return t("helpers.date_undecided") if travel_book.start_date.nil? && travel_book.end_date.nil?
     "#{fmt_date(travel_book.start_date)} - #{fmt_date(travel_book.end_date)}"
+  end
+
+  # 日付をフォーマットする
+  def fmt_date(date)
+    return t("helpers.undecided") if date.nil?
+    format_date = I18n.l(date.to_date, format: :default)
   end
 
   def area_name(travel_book)

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -3,7 +3,7 @@
     <tbody>
       <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
         <td class="w-2/6">
-          <%= fmt_datetime_range(schedule) %>
+          <%= fmt_datetime_range(schedule, :short) %>
         </td>
         <td class="w-3/6">
           <% if schedule.schedule_icon.name == "none" %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -11,7 +11,7 @@
         <% Schedule.group_by_date(@schedules).each_with_index do |(date, schedules),i| %>
           <input type="radio" data-action="change->tabs#changeTab"
             data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
-            name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_with_day(date) %>" <%= 'checked' if i == 0 %> />
+            name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_label(date) %>" <%= 'checked' if i == 0 %> />
           <div role="tabpanel" class="tab-content md:p-3">
             <% schedules.each_with_index do |schedule, i| %>
               <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -17,7 +17,7 @@
 
     <div class="my-10">
       <ul class="fa-ul space-y-5">
-        <li><span class="fa-li"><i class="fa-regular fa-clock"></i></span><%= fmt_schedule_duration(@schedule) %></li>
+        <li><span class="fa-li"><i class="fa-regular fa-clock"></i></span><%= fmt_datetime_range(@schedule, :default) %></li>
         <li><span class="fa-li"><i class="fa-solid fa-location-dot"></i></span><%= schedule_spot_info(@schedule.spot) %></li>
         <li><span class="fa-li"><i class="fa-solid fa-wallet"></i></span><%= @schedule.budged %><%= t("helpers.currency_unit") %></li>
         <li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,12 @@
 ja:
+  date:
+    formats:
+      default: "%Y/%-m/%-d(%a)"
+      short: "%-m/%-d(%a)"
+  time:
+    formats:
+      default: "%Y/%-m/%-d(%a) %H:%M"
+      short: "%H:%M"
   views:
     pagination:
       previous: "前へ"


### PR DESCRIPTION
# 概要
#269 の修正にミスがあり、schedules#showのビューでNoMethodErrorを出力してしまったため修正しました。
またdatetimeがUTC表記されるため、`strftime`を使用しない形式に修正しました。

## 実施内容
- [x] ja.ymlに日付と時刻のデフォルト表記を追記
- [x] strftimeメソッドを使用しない形に修正

## 未実施内容
- 本番環境でUTC時刻で表示される原因について調査中

## 補足
- 本番環境でUTC時刻で表示される原因について調査中です。

## 関連issue
#269 