### PR TITLE
Fix/スケジュールの表示がUTCになる原因調査

### DIFF
--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -5,9 +5,13 @@ module SchedulesHelper
   end
 
   def fmt_datetime_range(schedule, format)
+    Rails.logger.info "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    Rails.logger.info "#{schedule.start_date}"
+    Rails.logger.info "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     return t("helpers.undecided") if schedule.start_date.nil? && schedule.end_date.nil?
-    start_date = schedule.start_date.present? ? I18n.l(schedule.start_date, format: format) : ""
-    end_date = schedule.end_date.present? ? I18n.l(schedule.end_date, format: format) : ""
+    start_date = schedule.start_date.present? ? I18n.l(schedule.start_date.in_time_zone("Tokyo"), format: format) : ""
+    end_date = schedule.end_date.present? ? I18n.l(schedule.end_date.in_time_zone("Tokyo"), format: format) : ""
+    Rails.logger.info "#{start_date} - #{end_date}"
     "#{start_date} - #{end_date}"
   end
 


### PR DESCRIPTION
# 概要
本番環境でdatetime型のスケジュールを表示する際にUTCで表示される問題への対処として、
タイムゾーンの指定とデバッグを仕込みました。

## 実施内容
- [x] `in_time_zone("Tokyo")`の指定
- [x] fmt_datetime_rangeメソッドにデバッグ追加

## 未実施内容
- 本番環境での確認

## 補足
config/application.rbでは以下のタイムゾーン設定済みです。
```ruby
config.time_zone = "Tokyo"
config.active_record.default_timezone = :local
```
## 関連issue
#269 