### PR TITLE
Fix/timezoneの修正

### DIFF
--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -5,13 +5,9 @@ module SchedulesHelper
   end
 
   def fmt_datetime_range(schedule, format)
-    Rails.logger.info "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    Rails.logger.info "#{schedule.start_date}"
-    Rails.logger.info "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     return t("helpers.undecided") if schedule.start_date.nil? && schedule.end_date.nil?
-    start_date = schedule.start_date.present? ? I18n.l(schedule.start_date.in_time_zone("Tokyo"), format: format) : ""
-    end_date = schedule.end_date.present? ? I18n.l(schedule.end_date.in_time_zone("Tokyo"), format: format) : ""
-    Rails.logger.info "#{start_date} - #{end_date}"
+    start_date = schedule.start_date.present? ? I18n.l(schedule.start_date, format: format) : ""
+    end_date = schedule.end_date.present? ? I18n.l(schedule.end_date, format: format) : ""
     "#{start_date} - #{end_date}"
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,5 @@ module Myapp
 
     config.i18n.default_locale = :ja
     config.time_zone = "Tokyo"
-    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
# 概要
Render.comのコンソールで値の確認をするために設定をもとに戻します。

## 実施内容
- [x] in_time_zoneメソッドの削除
- [x] active_record.default_timezone = :localの削除

## 未実施内容
- 本番環境での確認

## 補足
datetimeカラムがUTC表記になる原因調査中です。

## 関連issue
#269 