### PR TITLE
WIP/スケジュールの日時がUTCで保存表示される問題の調査

### DIFF
--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -36,11 +36,13 @@ class ScheduleForm
 
     attributes ||= default_attributes(@travel_book)
     super(attributes)
+    # convert_to_jst
   end
 
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
+      convert_to_jst
       @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
@@ -59,6 +61,7 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
+      convert_to_jst
       @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
@@ -100,5 +103,13 @@ class ScheduleForm
       errors.add(:end_date, :after_start_date)
       false
     end
+  end
+
+  def convert_to_jst
+    self.start_date = start_date.in_time_zone("Tokyo") if start_date.present?
+    Rails.logger.info "================"
+    Rails.logger.info "#{start_date}"
+    Rails.logger.info "================"
+    self.end_date = end_date.in_time_zone("Tokyo") if end_date.present?
   end
 end


### PR DESCRIPTION
# 概要
スケジュールの日時がUTCで保存、表示される問題について調査中です。
スケジュールの日時をdatetime型で保存する際にJSTに変換します。

## 実施内容
- [x] save、updateアクションでスケジュール(start_date,end_date)を保存する前に時間をJSTに変換

## 補足
- 本番環境でのデバッグログ、コンソールの確認を行います。
- 参考資料
https://community.render.com/t/date-time-server/5598
https://qiita.com/aosho235/items/a31b895ce46ee5d3b444
https://qiita.com/joker1007/items/2c277cca5bd50e4cce5e

## 関連issue
