### PR TITLE
Fix/icon.pngに関するエラー解消とPWA導入

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "たびくりっぷ",
+  "short_name": "たびくりっぷ",
+  "start_url": "https://tabiclip.jp/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/icon_192x192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "/icon_512x512.png",
+      "type": "image/png",
+      "sizes": "512x512",
+      "purpose": "maskable"
+    }
+  ]
+}


### PR DESCRIPTION
# 概要
app/views/pwa/manifest.json.erbの設定により存在しないファイル("/icon.png")に関するエラーが出力されていました。
`ActionController::RoutingError (No route matches [GET] "/icon.png")`

エラーの解消と合わせて、補足の記事を参考にPWAを導入しました。

## 実施内容
- [x] public/manifest.jsonの追加

## 未実施内容
- public/service_worker.jsの追加

## 補足
マニフェストを動的に変更する必要がなかったため、app/views/pwa/manifest.json.erb を使用せず、
public/manifest.jsonを新規で追加しました。

参考記事
https://qiita.com/kumaryoya/items/a1c6562a8d00df93c265

## 関連issue
なし