### PR TITLE
Fix/Blocked hostsエラーへの対処

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,7 +109,10 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
-  config.hosts << "tabiclip.jp"
+  config.hosts = [
+    "tabiclip.jp",
+    "tabiclip.onrender.com"
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
# 概要
デプロイ後にwebサーバーのログに以下のエラーが出ていたため、許可するホスト(ホワイトリスト)にRenderのデフォルトドメイン"tabiclip.onrender.com"を追加しました。
`Blocked hosts: [tabiclip.onrender.com]`

## 実施内容
- [x] 本番環境で許可したいホストをホワイトリストに追加

## 未実施内容
- 本番環境での確認

## 補足

## 関連issue
なし