### PR TITLE
Fix/リマインダー設定モーダルのNoMethodErrorの修正

### DIFF
--- a/app/views/reminders/_modal.html.erb
+++ b/app/views/reminders/_modal.html.erb
@@ -11,7 +11,7 @@
       <p>「<%= list_item.title %>」</p>
 
       <% if reminder&.reminder_date %>
-        <p><%= fmt_schedule_date(list_item.reminder.reminder_date) %>にリマインダーの設定があります</p>
+        <p><%= l(list_item.reminder.reminder_date, format: :default) %>にリマインダーの設定があります</p>
       <% else %>
         <p>リマインダーの設定はされていません</p>
       <% end %>


### PR DESCRIPTION
# 概要
リマインダー設定モーダル内でNoMothodErrorが発生していたため修正しました。

## 実施内容
- [x] 現在使用していないfmt_schedule_dateメソッドを削除し、修正

## 未実施内容
- リマインダーモーダル内のi18n化対応

## 補足
#270 にてfmt_schedule_dateメソッド削除しました。

## 関連issue
#277 