### PR TITLE
Feature/お問い合わせページの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,3 @@
+class StaticPagesController < ApplicationController
+  def form; end
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,8 +1,8 @@
 <footer class="footer footer-center bg-primary text-white p-10">
   <nav class="grid grid-flow-col gap-4">
-    <%= link_to "利用規約", "#", class: "link link-hover" %>
-    <%= link_to "お問い合わせ", "#", class: "link link-hover" %>
-    <%= link_to "プライバシーポリシー", "#", class: "link link-hover" %>
-    <p>Copyright © 2025 TabiClip</p>
+    <%= link_to t("defaults.policy"), "#", class: "link link-hover" %>
+    <%= link_to t("defaults.terms"), "#", class: "link link-hover" %>
+    <%= link_to t("defaults.form"), form_path, class: "link link-hover" %>
   </nav>
+  <p>Copyright © 2025 TabiClip</p>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -82,13 +82,13 @@
             <% end %>
             <div class="divider"></div>
             <li>
-              <%= link_to t("header.terms_of_service"), "#" %>
+              <%= link_to t("defaults.policy"), "#" %>
             </li>
             <li>
-              <%= link_to t("header.privacy_policy"), "#" %>
+              <%= link_to t("defaults.terms"), "#" %>
             </li>
             <li>
-              <%= link_to t("header.contact"), "#" %>
+              <%= link_to t("defaults.form"), form_path %>
             </li>
             <p class="text-center mt-auto">Copyright © 2025 TabiClip</p>
           </ul>

--- a/app/views/static_pages/form.html.erb
+++ b/app/views/static_pages/form.html.erb
@@ -1,0 +1,4 @@
+<% content_for(:title, t(".title")) %>
+<div class="flex justify-center mt-3 md:mt-5 mb-12">
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfMrU8rIjqeR_tWecnPA552KoE5BcYONgI1CQXW1TiNJ11TEA/viewform?embedded=true" width="640" height="1147" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -26,6 +26,9 @@ ja:
     public: 公開
     unpublic: 未公開
   defaults:
+    policy: プライバシーポリシー
+    terms: 利用規約
+    form: お問い合わせ
     delete_confirm: 削除しますか？
     flash_message:
       created: "%{item}を作成しました"
@@ -49,9 +52,6 @@ ja:
     travel_book_create: しおり作成
     my_travel_book: マイしおり
     bookmark: ブックマーク
-    terms_of_service: 利用規約
-    contact: お問い合わせ
-    privacy_policy: プライバシーポリシー
   btm_nav:
     travel_books_search: しおり検索
     travel_book_create: しおり作成
@@ -171,3 +171,10 @@ ja:
         title: 項目名を記入
     add_button:
       new_button: 項目を追加
+  static_pages:
+    form:
+      title: お問い合わせフォーム
+    policy:
+      title: プライバシーポリシー
+    terms:
+      title: 利用規約

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   post "/callback" => "linebot#callback"
   get "users/profile" => "users#show"
   get "home/index"
+  get "form", to: "static_pages#form"
   get "images/ogp.png", to: "images#ogp", as: "images_ogp"
   resources :travel_books do
     collection do


### PR DESCRIPTION
# 概要
Googleフォームでお問い合わせページを作成し、アプリへ埋め込みました。

## 実施内容
- [x] Googleフォームの作成
- [x] ルーティング設定
- [x] StaticPagesControllerの作成
- [x] お問い合わせページ(StaticPagesController#formのビュー)作成
- [x] ヘッダーのナビゲーションメニュー・フッターへのリンク設置
- [x] i18n化対応

## 未実施内容
- お問い合わせした方への自動返信は設定していません。
- StaticPagesControllerの`skip_before_action :authenticator!`の設定は別PRにて対応します。

## 補足
なし

## 関連issue
#279 