### PR TITLE
Fix/スケジュールの日時がUTCで解釈される問題の修正

### DIFF
--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -106,10 +106,10 @@ class ScheduleForm
   end
 
   def convert_to_jst
-    self.start_date = start_date.in_time_zone("Tokyo") if start_date.present?
+    self.start_date = start_date.in_time_zone.utc if start_date.present?
     Rails.logger.info "================"
     Rails.logger.info "#{start_date}"
     Rails.logger.info "================"
-    self.end_date = end_date.in_time_zone("Tokyo") if end_date.present?
+    self.end_date = end_date.in_time_zone.utc if end_date.present?
   end
 end


### PR DESCRIPTION
# 概要
スケジュールの開始日時と終了日時がUTCで表示される問題の修正を行いました。

## 実施内容
- [x] データを保存する際にutcに変換

## 未実施内容
- 本番環境でのデバッグ

## 補足
datetime型にはタイムゾーン情報を含んでおらず、サーバーのタイムゾーンで解釈される。
しかし、RenderのwebサーバーのタイムゾーンがUTCのため、datetime型でデータを保存する際はUTCに変換されデータが保存される。
そのため、start_dateとend_dateを保存・更新する前に`.in_time_zone.utc`でconfig.time_zoneで設定しているJSTに変換してからutcで保存するように修正しました。

## 関連issue
#271, #272, #273