### PR TITLE
Fix/スケジュールの日時がUTCで解釈される問題の修正3

### DIFF
--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -106,10 +106,10 @@ class ScheduleForm
   end
 
   def convert_to_jst
-    self.start_date = start_date.in_time_zone("Tokyo").utc if start_date.present?
+    self.start_date = Time.zone.parse(start_date.to_s).in_time_zone("Tokyo") if start_date.present?
     Rails.logger.info "================"
     Rails.logger.info "#{start_date}"
     Rails.logger.info "================"
-    self.end_date = end_date.in_time_zone("Tokyo").utc if end_date.present?
+    self.end_date = Time.zone.parse(end_date.to_s).in_time_zone("Tokyo") if end_date.present?
   end
 end


### PR DESCRIPTION
# 概要
#282の修正で、スケジュールの開始日時と終了日時がUTCで表示される問題の修正を行いました。

## 実施内容
- [x] Time.zone.parseを使用するように変更

## 未実施内容
- 本番環境でのデバッグ

## 補足
#282 の修正です

## 関連issue
#282 