### PR TITLE
WIP/スケジュールの日時がUTCで解釈される問題の調査

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -21,6 +21,9 @@ class SchedulesController < ApplicationController
 
   def create
     @schedule_form = ScheduleForm.new(schedule_params)
+    # config.time_zoneで設定されたタイムゾーンに変換
+    @schedule_form.start_date = Time.zone.parse(schedule_params[:start_date]) unless schedule_params[:start_date].nil?
+    @schedule_form.end_date = Time.zone.parse(schedule_params[:end_date]) unless schedule_params[:end_date].nil?
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -34,6 +34,7 @@ class ScheduleForm
     @spot = spot || @schedule.build_spot
     @travel_book = travel_book
 
+    # attributesがfalseもしくは未定義ならdefault_attributesを代入
     attributes ||= default_attributes(@travel_book)
     super(attributes)
     # convert_to_jst
@@ -42,7 +43,7 @@ class ScheduleForm
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
-      convert_to_jst
+      # convert_to_jst
       @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
@@ -61,7 +62,7 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      convert_to_jst
+      # convert_to_jst
       @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
@@ -109,7 +110,7 @@ class ScheduleForm
     Rails.logger.info "================"
     Rails.logger.info "#{Time.zone}"
     Rails.logger.info "Before : #{start_date} (#{start_date.class})"
-    self.start_date = start_date.in_time_zone("Asia/Tokyo") unless start_date.nil?
+    self.start_date = Time.zone.parse(start_date) unless start_date.nil?
     self.end_date = end_date.in_time_zone("Asia/Tokyo") unless end_date.nil?
     Rails.logger.info "After : #{start_date} (#{start_date.class})"
     Rails.logger.info "================"


### PR DESCRIPTION
# 概要
本番環境でスケジュールの開始時刻と終了時刻がUTCになる問題の調査中です。
デバッグ用ログを入れて確認します。

## 実施内容
- [x] formObject内ではなくSchedulesControllerでparamsを受け取った時にタイムゾーンの変換処理を入れる

## 未実施内容
- スケジュールの開始・終了時刻のデフォルト値の入力

## 補足

## 関連issue