### PR TITLE
Fix/スケジュールの日時がUTCで解釈される問題の修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -21,9 +21,9 @@ class SchedulesController < ApplicationController
 
   def create
     @schedule_form = ScheduleForm.new(schedule_params)
-    # config.time_zoneで設定されたタイムゾーンに変換
-    @schedule_form.start_date = Time.zone.parse(schedule_params[:start_date]) unless schedule_params[:start_date].nil?
-    @schedule_form.end_date = Time.zone.parse(schedule_params[:end_date]) unless schedule_params[:end_date].nil?
+
+    convert_to_jst(schedule_params[:start_date], schedule_params[:end_date])
+
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else
@@ -42,6 +42,9 @@ class SchedulesController < ApplicationController
   def update
     @spot = @schedule.spot
     @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
+
+    convert_to_jst(schedule_params[:start_date], schedule_params[:end_date])
+
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
     else
@@ -87,5 +90,11 @@ class SchedulesController < ApplicationController
   def set_schedule
     @schedule = Schedule.find(params[:id])
     @travel_book = @schedule.travel_book
+  end
+
+  # config.time_zoneで設定されたタイムゾーンに変換
+  def convert_to_jst(start_date, end_date)
+    @schedule_form.start_date = Time.zone.parse(start_date) unless start_date.nil?
+    @schedule_form.end_date = Time.zone.parse(end_date) unless end_date.nil?
   end
 end

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -37,13 +37,11 @@ class ScheduleForm
     # attributesがfalseもしくは未定義ならdefault_attributesを代入
     attributes ||= default_attributes(@travel_book)
     super(attributes)
-    # convert_to_jst
   end
 
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
-      # convert_to_jst
       @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
@@ -62,7 +60,6 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      # convert_to_jst
       @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
@@ -89,8 +86,8 @@ class ScheduleForm
       title: schedule.title,
       budged: schedule.budged,
       memo: schedule.memo,
-      start_date: schedule.start_date,
-      end_date: schedule.start_date,
+      start_date: schedule.start_date || travel_book&.start_date&.to_datetime,
+      end_date: schedule.start_date || travel_book&.start_date&.to_datetime,
       name: spot.name,
       telephone: spot.telephone,
       post_code: spot.post_code,
@@ -104,15 +101,5 @@ class ScheduleForm
       errors.add(:end_date, :after_start_date)
       false
     end
-  end
-
-  def convert_to_jst
-    Rails.logger.info "================"
-    Rails.logger.info "#{Time.zone}"
-    Rails.logger.info "Before : #{start_date} (#{start_date.class})"
-    self.start_date = Time.zone.parse(start_date) unless start_date.nil?
-    self.end_date = end_date.in_time_zone("Asia/Tokyo") unless end_date.nil?
-    Rails.logger.info "After : #{start_date} (#{start_date.class})"
-    Rails.logger.info "================"
   end
 end


### PR DESCRIPTION
# 概要
本番環境で登録したスケジュールの開始日時と終了日時がUTCで解釈される問題を修正しました。

## 実施内容
- [x] SchedulesControllersにconvert_to_jstメソッド定義
- [x] start_date,end_dateのデフォルト値設定

## 未実施内容
- 本番環境での確認

## 補足
- SchedulesControllers#create,updateでフォームからparamsを受け取った際に日時をJSTに変換するメソッドを追加しました。

## 関連issue
以下関連するPR
#269 #270, #271, #272, #273, #274, #278, #281, #282, #283, #284, #285, #286, #287, #288