### PR TITLE
Fix/travel booksテーブルのidを追加

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -2,7 +2,7 @@ class BookmarksController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    travel_book = TravelBook.find(params[:travel_book_uuid])
+    travel_book = TravelBook.find(params[:travel_book_id])
     current_user.bookmark(travel_book)
     redirect_to public_travel_books_path, notice: "ブックマークしました"
   end

--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -14,7 +14,7 @@ class CheckListsController < ApplicationController
     @check_list = @travel_book.check_lists.build(check_list_param)
 
     if @check_list.save
-      redirect_to travel_book_check_lists_path(@travel_book), notice: t("defaults.flash_message.created", item: CheckList.model_name.human)
+      redirect_to travel_book_check_lists_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: CheckList.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: CheckList.model_name.human)
       render :new, status: :unprocessable_entity
@@ -43,13 +43,13 @@ class CheckListsController < ApplicationController
 
   def destroy
     @check_list.destroy!
-    redirect_to travel_book_check_lists_path(@travel_book), notice: t("defaults.flash_message.deleted", item: CheckList.model_name.human)
+    redirect_to travel_book_check_lists_path(@travel_book.uuid), notice: t("defaults.flash_message.deleted", item: CheckList.model_name.human)
   end
 
   private
 
   def set_travel_book
-    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @travel_book = current_user.travel_books.find_by(uuid: params[:travel_book_uuid])
   end
 
   def set_check_list

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -14,7 +14,7 @@ class NotesController < ApplicationController
   def create
     @note = @travel_book.notes.build(note_params)
     if @note.save
-      redirect_to travel_book_notes_path(@travel_book), notice: t("defaults.flash_message.created", item: Note.model_name.human)
+      redirect_to travel_book_notes_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Note.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created")
       render :new
@@ -36,13 +36,13 @@ class NotesController < ApplicationController
 
   def destroy
     @note.destroy
-    redirect_to travel_book_notes_path(@travel_book), notice: t("defaults.flash_message.deleted", item: Note.model_name.human)
+    redirect_to travel_book_notes_path(@travel_book.uuid), notice: t("defaults.flash_message.deleted", item: Note.model_name.human)
   end
 
   private
 
   def set_travel_book
-    @travel_book = current_user.travel_books.find(params[:travel_book_id])
+    @travel_book = current_user.travel_books.find_by(uuid: params[:travel_book_uuid])
   end
 
   def set_note

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -25,7 +25,7 @@ class SchedulesController < ApplicationController
     convert_to_jst(schedule_params[:start_date], schedule_params[:end_date])
 
     if @schedule_form.save
-      redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
+      redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: Schedule.model_name.human)
       render :new, status: :unprocessable_entity
@@ -46,7 +46,7 @@ class SchedulesController < ApplicationController
     convert_to_jst(schedule_params[:start_date], schedule_params[:end_date])
 
     if @schedule_form.update(schedule_params)
-      redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
+      redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: Schedule.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -55,7 +55,7 @@ class SchedulesController < ApplicationController
 
   def destroy
     @schedule.destroy!
-    redirect_to travel_book_schedules_path(@travel_book), notice: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
+    redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
   end
 
   def map
@@ -79,12 +79,12 @@ class SchedulesController < ApplicationController
       :address,
       :schedule_icon_id
     ).merge(
-      travel_book_uuid: @travel_book.id
+      travel_book_id: @travel_book.id
     )
   end
 
   def set_travel_book
-    @travel_book = TravelBook.find(params[:travel_book_id])
+    @travel_book = TravelBook.find_by(uuid: params[:travel_book_uuid])
   end
 
   def set_schedule

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -27,7 +27,7 @@ class TravelBooksController < ApplicationController
   end
 
   def show
-    @travel_book = TravelBook.find(params[:id])
+    @travel_book = TravelBook.find_by(uuid: params[:uuid])
     # メタタグを設定
     prepare_meta_tags(@travel_book)
   end
@@ -66,11 +66,13 @@ class TravelBooksController < ApplicationController
   def delete_owner
     user = User.find(params[:user_id])
     # しおりの作成者でない場合のみ削除
-    if user != @travel_book.creator
-      @travel_book.users.destroy(user)
-      redirect_to share_travel_book_path(@travel_book), notice: "しおりのメンバーから削除しました"
+    return redirect_to share_travel_book_path(@travel_book.uuid), alert: "しおりの作成者は削除できません" if user == @travel_book.creator
+
+    @travel_book.users.destroy(user)
+    if user == current_user
+      redirect_to public_travel_books_path, notice: "しおりのメンバーから削除しました"
     else
-      redirect_to share_travel_book_path(@travel_book), alert: "しおりの作成者は削除できません"
+      redirect_to share_travel_book_path(@travel_book.uuid), notice: "しおりのメンバーから削除しました"
     end
   end
 
@@ -106,7 +108,7 @@ class TravelBooksController < ApplicationController
   end
 
   def set_travel_book
-    @travel_book = current_user.travel_books.find(params[:id])
+    @travel_book = current_user.travel_books.find_by(uuid: params[:uuid])
   end
 
   def travel_book_param

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -41,10 +41,13 @@ class Users::InvitationsController < Devise::InvitationsController
     resource = self.resource
 
     if resource.errors.empty? && resource.invited_by_travel_book_id.present?
+      # 招待されたしおりを特定
+      travel_book_id = TravelBook.find_by(uuid: resource.invited_by_travel_book_id).id
+
       # 中間テーブルに招待ユーザーと対象のしおりのidを保存
       user_travel_book = UserTravelBook.new(
         user_id: resource.id,
-        travel_book_uuid: resource.invited_by_travel_book_id
+        travel_book_id: travel_book_id
       )
       if user_travel_book.save
         flash[:notice] = "しおりのメンバーに追加されました"

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -2,7 +2,7 @@ class ScheduleForm
   include ActiveModel::Model # 通常のモデルのようにvalidationなどを使えるようにする
   include ActiveModel::Attributes # ActiveRecordのカラムのような属性を加えられるようにする
   # パラメータの読み書きを許可する
-  attribute :travel_book_uuid, :string
+  attribute :travel_book_id, :string
   attribute :title, :string
   attribute :start_date, :datetime
   attribute :end_date, :datetime
@@ -14,7 +14,7 @@ class ScheduleForm
   attribute :address, :string
   attribute :schedule_icon_id, :integer
 
-  validates :travel_book_uuid, presence: true
+  validates :travel_book_id, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validate  :end_date_after_start_date
   validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -42,7 +42,7 @@ class ScheduleForm
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
+      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
@@ -60,7 +60,7 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_uuid: travel_book_uuid, schedule_icon_id: schedule_icon_id)
+      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id, schedule_icon_id: schedule_icon_id)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,7 @@ module ApplicationHelper
   def display_bottom_nav_on_travel_book
     return false if current_user.nil?
     return false if controller_name == "home"
-    (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(uuid: params[:id]))||
+    (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(uuid: params[:uuid]))||
     (controller_name == "schedules")||
     (controller_name == "notes") ||
     (controller_name == "check_lists") ||

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,4 @@
 class Bookmark < ApplicationRecord
   belongs_to :user
-  belongs_to :travel_book, foreign_key: :travel_book_uuid, primary_key: :uuid
+  belongs_to :travel_book
 end

--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -1,5 +1,5 @@
 class CheckList < ApplicationRecord
-  belongs_to :travel_book, foreign_key: :travel_book_uuid
+  belongs_to :travel_book
   has_many :list_items, primary_key: :uuid, foreign_key: :check_list_uuid, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,5 @@
 class Note < ApplicationRecord
-  belongs_to :travel_book, foreign_key: :travel_book_uuid
+  belongs_to :travel_book
 
   validates :title, presence: true, length: { maximum: 20 }
   validates :body, presence: true, length: { maximum: 65_535 }

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,5 @@
 class Schedule < ApplicationRecord
-  belongs_to :travel_book, foreign_key: :travel_book_uuid
+  belongs_to :travel_book
   has_one :spot, primary_key: :uuid, foreign_key: :schedule_uuid, dependent: :destroy
   belongs_to :schedule_icon, optional: true
 

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -5,12 +5,12 @@ class TravelBook < ApplicationRecord
   belongs_to :traveler_type, optional: true
   belongs_to :creator, class_name: "User"
 
-  has_many :user_travel_books, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
+  has_many :user_travel_books, dependent: :destroy
   has_many :users, through: :user_travel_books
-  has_many :schedules, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
-  has_many :check_lists, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
-  has_many :notes, primary_key: :uuid, foreign_key: :travel_book_uuid, dependent: :destroy
-  has_many :bookmarks, foreign_key: :travel_book_uuid, dependent: :destroy
+  has_many :schedules, dependent: :destroy
+  has_many :check_lists, dependent: :destroy
+  has_many :notes, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,10 @@
 class User < ApplicationRecord
   mount_uploader :icon_image, UserUploader
   has_many :user_travel_books, dependent: :destroy
-  has_many :travel_books, primary_key: :uuid, foreign_key: :travel_book_uuid, through: :user_travel_books
+  has_many :travel_books, through: :user_travel_books
   has_many :created_travel_books, class_name: "TravelBook", foreign_key: "creator_id", dependent: :destroy
   has_many :bookmarks, dependent: :destroy
-  has_many :bookmark_travel_books, through: :bookmarks, source: :travel_book, foreign_key: :travel_book_uuid
+  has_many :bookmark_travel_books, through: :bookmarks, source: :travel_book
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user_travel_book.rb
+++ b/app/models/user_travel_book.rb
@@ -1,6 +1,6 @@
 class UserTravelBook < ApplicationRecord
   belongs_to :user
-  belongs_to :travel_book, foreign_key: :travel_book_uuid
+  belongs_to :travel_book
 
-  validates :user_id, uniqueness: { scope: :travel_book_uuid }
+  validates :user_id, uniqueness: { scope: :travel_book_id }
 end

--- a/app/views/check_lists/_form.html.erb
+++ b/app/views/check_lists/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: check_list, url: check_list.new_record? ? travel_book_check_lists_path(travel_book) : check_list_path(check_list), data: { turbo: false } do |f| %>
+<%= form_with model: check_list, url: url, data: { turbo: false } do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
   <div class="space-y-3">

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", check_list: @check_list, travel_book: @travel_book %>
+    <%= render "form", check_list: @check_list, travel_book: @travel_book, url: check_list_path(@check_list) %>
   </div>
 </div>

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", check_list: @check_list, travel_book: @travel_book %>
+    <%= render "form", check_list: @check_list, travel_book: @travel_book, url: travel_book_check_lists_path(@travel_book.uuid)  %>
   </div>
 </div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: note, url: note.new_record?  ? travel_book_notes_path(travel_book) : note_path(note) do |f| %>
+<%= form_with model: note, url: url do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
   <div class="space-y-3">
@@ -12,7 +12,11 @@
     </div>
 
     <div>
-      <%= f.label :title, Note.human_attribute_name(:body), class: "label-text" %>
+      <%= f.label :body, class: "label" do %>
+        <span class="label-text">
+          <%= Note.human_attribute_name(:body) %><span class="text-error">*</span>
+        </span>
+      <% end %>
       <%= f.text_area :body, placeholder: t(".placeholder.body"), rows: "10", class: "textarea textarea-bordered w-full" %>
     </div>
 

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", note: @note, travel_book: @travel_book %>
+    <%= render "form", note: @note, travel_book: @travel_book, url: note_path(@note) %>
   </div>
 </div>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,8 +1,8 @@
 <div class="m-5">
   <div class="max-w-screen-md mx-auto">
     <div class="flex gap-3">
-      <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-sm md:btn-md btn-primary w-1/2" %>
-      <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-sm md:btn-md btn-outline btn-primary w-1/2" %>
+      <%= link_to t(".note_link"), travel_book_notes_path(@travel_book.uuid), class: "btn btn-sm md:btn-md btn-primary w-1/2" %>
+      <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book.uuid), class: "btn btn-sm md:btn-md btn-outline btn-primary w-1/2" %>
     </div>
     <% if @notes.present? %>
       <%= render @notes %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", note: @note, travel_book: @travel_book %>
+    <%= render "form", note: @note, travel_book: @travel_book, url: travel_book_notes_path(@travel_book.uuid) %>
   </div>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -27,7 +27,7 @@
       <% if @travel_book.owned_by_user?(current_user) %>
         <p class="text-center mt-10"><%= t(".no_creator_no_data") %><br><%= t(".no_data") %></p>
         <div class="flex justify-center">
-          <%= link_to new_travel_book_schedule_path(@travel_book), data: { turbo: false }, class: "btn my-5" do %>
+          <%= link_to new_travel_book_schedule_path(@travel_book.uuid), data: { turbo: false }, class: "btn my-5" do %>
             <i class="fa-solid fa-plus"></i> <%= t(".new_button") %>
           <% end %>
         </div>
@@ -37,7 +37,7 @@
     <% end %>
 
     <% if @travel_book.owned_by_user?(current_user) %>
-      <%= link_to new_travel_book_schedule_path(@travel_book), data: { turbo: false }, class: "btn btn-primary btn-circle fixed z-20 bottom-20 right-5 text-lg md:right-[calc(50%)] " do %>
+      <%= link_to new_travel_book_schedule_path(@travel_book.uuid), data: { turbo: false }, class: "btn btn-primary btn-circle fixed z-20 bottom-20 right-5 text-lg md:right-[calc(50%)] " do %>
         <i class="fa-solid fa-plus"></i>
       <% end %>
     <% end %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -2,7 +2,7 @@
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
-    <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book) %>
+    <%= render "form", schedule: @schedule_form, travel_book: @travel_book, url: travel_book_schedules_path(@travel_book.uuid) %>
   </div>
   <div class="h-24"></div>
 </div>

--- a/app/views/shared/_bottom_navigation_on_travel_book.html.erb
+++ b/app/views/shared/_bottom_navigation_on_travel_book.html.erb
@@ -1,18 +1,18 @@
 <div class="btm-nav bg-primary shadow-sm">
-  <%= link_to travel_book_path(@travel_book.id), class: active_class_by_controller('travel_books') do %>
+  <%= link_to travel_book_path(@travel_book.uuid), class: active_class_by_controller('travel_books') do %>
     <i class="fa-regular fa-map"></i>
     <span class="btm-nav-label text-xs"><%= t("btm_nav.travel_book_info") %></span>
   <% end %>
-  <%= link_to travel_book_schedules_path(@travel_book), data: { turbo: false }, class: active_class_by_controller('schedules') do %>
+  <%= link_to travel_book_schedules_path(@travel_book.uuid), data: { turbo: false }, class: active_class_by_controller('schedules') do %>
     <i class="fa-regular fa-clock"></i>
     <span class="btm-nav-label text-xs"><%= t("btm_nav.schedule") %></span>
   <% end %>
-  <%= link_to map_travel_book_schedules_path(@travel_book), data: { turbo: false }, class: active_class_by_controller_and_action('schedules', 'map') do %>
+  <%= link_to map_travel_book_schedules_path(@travel_book.uuid), data: { turbo: false }, class: active_class_by_controller_and_action('schedules', 'map') do %>
   <i class="fa-solid fa-location-dot"></i>
     <span class="btm-nav-label text-xs"><%= t("btm_nav.map") %></span>
   <% end %>
   <% if @travel_book.owned_by_user?(current_user) %>
-    <%= link_to travel_book_notes_path(@travel_book), class: active_class_by_controller('notes','check_lists') do %>
+    <%= link_to travel_book_notes_path(@travel_book.uuid), class: active_class_by_controller('notes','check_lists') do %>
       <i class="fa-solid fa-file-pen"></i>
       <span class="btm-nav-label text-xs"><%= t("btm_nav.note") %></span>
     <% end %>

--- a/app/views/travel_books/_bookmark_buttons.html.erb
+++ b/app/views/travel_books/_bookmark_buttons.html.erb
@@ -1,19 +1,19 @@
 <div class="flex justify-end">
   <% if user_signed_in? %>
     <% if current_user.bookmark?(travel_book) %>
-      <%= link_to bookmark_path(current_user.bookmarks.find_by(travel_book_uuid: travel_book.uuid)), data: { turbo_method: :delete } do %>
+      <%= link_to bookmark_path(current_user.bookmarks.find_by(travel_book_id: travel_book.id)), data: { turbo_method: :delete } do %>
         <i class="fa-solid fa-bookmark"></i>
       <% end %>
     <% else %>
-      <%= link_to bookmarks_path(travel_book_uuid: travel_book.uuid), data: { turbo_method: :post } do %>
+      <%= link_to bookmarks_path(travel_book_id: travel_book.id), data: { turbo_method: :post } do %>
         <i class="fa-regular fa-bookmark"></i>
       <% end %>
     <% end %>
   <% else %>
-    <button onclick="document.getElementById('bookmark_button_on_login_modal_<%= travel_book.uuid %>').showModal()">
+    <button onclick="document.getElementById('bookmark_button_on_login_modal_<%= travel_book.id %>').showModal()">
       <i class="fa-regular fa-bookmark"></i>
     </button>
-    <dialog id="bookmark_button_on_login_modal_<%= travel_book.uuid %>" class="modal">
+    <dialog id="bookmark_button_on_login_modal_<%= travel_book.id %>" class="modal">
       <div class="modal-box">
         <form method="dialog">
           <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @travel_book do |f| %>
+<%= form_with model: @travel_book, url: url do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
   <div class="space-y-3">

--- a/app/views/travel_books/_my_travel_book.html.erb
+++ b/app/views/travel_books/_my_travel_book.html.erb
@@ -1,12 +1,12 @@
 <% travel_books.each do |travel_book| %>
   <div class="card bg-base-100 w-full">
     <figure>
-      <%= link_to travel_book_path(travel_book), class: "hover:scale-[1.1] hover:duration-500" do %>
+      <%= link_to travel_book_path(travel_book.uuid), class: "hover:scale-[1.1] hover:duration-500" do %>
         <%= image_tag travel_book.travel_book_image_url %>
       <% end %>
   </figure>
     <div class="card-body flex flex-col justify-between">
-      <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
+      <%= link_to travel_book_path(travel_book.uuid), class: "hover:opacity-50" do %>
         <h2 class="card-title"><%= truncate(travel_book.title) %></h2>
       <% end %>
       <div>

--- a/app/views/travel_books/_travel_book.html.erb
+++ b/app/views/travel_books/_travel_book.html.erb
@@ -1,11 +1,11 @@
 <div class="card bg-base-100 w-full">
   <figure>
-    <%= link_to travel_book_path(travel_book), class: "hover:scale-[1.1] hover:duration-500" do %>
+    <%= link_to travel_book_path(travel_book.uuid), class: "hover:scale-[1.1] hover:duration-500" do %>
       <%= image_tag travel_book.travel_book_image_url %>
     <% end %>
   </figure>
   <div class="card-body flex flex-col justify-between">
-    <%= link_to travel_book_path(travel_book), class: "hover:opacity-50" do %>
+    <%= link_to travel_book_path(travel_book.uuid), class: "hover:opacity-50" do %>
       <h2 class="card-title"><%= truncate(travel_book.title) %></h2>
     <% end %>
     <div>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", travel_book: @travel_book %>
+    <%= render "form", travel_book: @travel_book, url: travel_book_path(@travel_book.uuid) %>
   </div>
   <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,8 +1,7 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-
-    <%= render "form", travel_book: @travel_book %>
+    <%= render "form", travel_book: @travel_book, url: travel_books_path %>
   </div>
   <div class="h-24"></div>
 </div>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -14,7 +14,7 @@
                   <%= user.name %>
                 </div>
                 <% unless user == @travel_book.creator %>
-                  <%= link_to delete_owner_travel_book_path(@travel_book, user_id: user.id), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "btn" do %>
+                  <%= link_to delete_owner_travel_book_path(@travel_book.uuid, user_id: user.id), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "btn" do %>
                     <i class="fa-solid fa-minus"></i>
                   <% end %>
                 <% end %>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -12,10 +12,10 @@
         </div>
         <% if @travel_book.owned_by_user?(current_user) %>
           <div class="flex justify-end">
-            <%= link_to edit_travel_book_path(@travel_book), class: "hover:opacity-50" do %>
+            <%= link_to edit_travel_book_path(@travel_book.uuid), class: "hover:opacity-50" do %>
               <i class="fa-solid fa-pen text-sm md:text-base"></i>
             <% end %>
-            <%= link_to travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+            <%= link_to travel_book_path(@travel_book.uuid), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
               <i class="fa-solid fa-trash text-sm md:text-base"></i>
             <% end %>
           </div>
@@ -56,11 +56,11 @@
         </div>
 
         <% unless @travel_book.owned_by_user?(current_user) %>
-          <%= link_to travel_book_schedules_path(@travel_book), class: "btn btn-primary w-full" do %>
+          <%= link_to travel_book_schedules_path(@travel_book.uuid), class: "btn btn-primary w-full" do %>
             <i class="fa-regular fa-clock"></i> スケジュールを見る
           <% end %>
         <% else %>
-          <%= link_to share_travel_book_path(@travel_book), class: "btn btn-primary w-full" do %>
+          <%= link_to share_travel_book_path(@travel_book.uuid), class: "btn btn-primary w-full" do %>
             <i class="fa-solid fa-users"></i> しおりのメンバーリスト・しおりに招待
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get "home/index"
   get "form", to: "static_pages#form"
   get "images/ogp.png", to: "images#ogp", as: "images_ogp"
-  resources :travel_books do
+  resources :travel_books, param: :uuid do
     collection do
       get "public", action: :public_travel_books
       get "search"

--- a/db/migrate/20250405000453_add_id_to_travel_books.rb
+++ b/db/migrate/20250405000453_add_id_to_travel_books.rb
@@ -1,0 +1,62 @@
+class AddIdToTravelBooks < ActiveRecord::Migration[7.2]
+  def up
+    # 関連する外部キー制約を削除
+    remove_foreign_key :bookmarks, column: :travel_book_uuid
+    remove_foreign_key :check_lists, column: :travel_book_uuid
+    remove_foreign_key :notes, column: :travel_book_uuid
+    remove_foreign_key :schedules, column: :travel_book_uuid
+    remove_foreign_key :user_travel_books, column: :travel_book_uuid
+
+    # 既存の主キーを削除
+    execute "ALTER TABLE travel_books DROP CONSTRAINT travel_books_pkey;"
+
+    # idカラムを追加
+    add_column :travel_books, :id, :primary_key
+
+    # 関連付けを作成する（カラム、インデックス、外部キーを作成）
+    add_reference :bookmarks, :travel_book, null: false, foreign_key: true
+    add_reference :check_lists, :travel_book, null: false, foreign_key: true
+    add_reference :notes, :travel_book, null: false, foreign_key: true
+    add_reference :schedules, :travel_book, null: false, foreign_key: true
+    add_reference :user_travel_books, :travel_book, null: false, foreign_key: true
+
+    # travel_book_uuid カラムを削除
+    remove_column :bookmarks, :travel_book_uuid
+    remove_column :check_lists, :travel_book_uuid
+    remove_column :notes, :travel_book_uuid
+    remove_column :schedules, :travel_book_uuid
+    remove_column :user_travel_books, :travel_book_uuid
+  end
+
+  def down
+    # 関連付けを削除する
+    remove_reference :bookmarks, :travel_book, foreign_key: true, index: false
+    remove_reference :check_lists, :travel_book, foreign_key: true, index: false
+    remove_reference :notes, :travel_book, foreign_key: true, index: false
+    remove_reference :schedules, :travel_book, foreign_key: true, index: false
+    remove_reference :user_travel_books, :travel_book, foreign_key: true, index: false
+
+    # 既存の主キーを削除
+    execute "ALTER TABLE travel_books DROP CONSTRAINT travel_books_pkey;"
+
+    # 主キーをuuidに変更
+    execute "ALTER TABLE travel_books ADD PRIMARY KEY (uuid);"
+
+    # uuidカラムを追加
+    add_column :bookmarks, :travel_book_uuid, :uuid
+    add_column :check_lists, :travel_book_uuid, :uuid
+    add_column :notes, :travel_book_uuid, :uuid
+    add_column :schedules, :travel_book_uuid, :uuid
+    add_column :user_travel_books, :travel_book_uuid, :uuid
+
+    # 関連する外部キー制約を追加
+    add_foreign_key :bookmarks, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_foreign_key :check_lists, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_foreign_key :notes, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_foreign_key :schedules, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+    add_foreign_key :user_travel_books, :travel_books, column: :travel_book_uuid, primary_key: :uuid
+
+    # idカラムを削除
+    remove_column :travel_books, :id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_05_000453) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,10 +22,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.uuid "travel_book_uuid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id", "travel_book_uuid"], name: "index_bookmarks_on_user_id_and_travel_book_uuid", unique: true
+    t.bigint "travel_book_id", null: false
+    t.index ["travel_book_id"], name: "index_bookmarks_on_travel_book_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
@@ -33,8 +33,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "travel_book_uuid", null: false
-    t.index ["travel_book_uuid"], name: "index_check_lists_on_travel_book_uuid"
+    t.bigint "travel_book_id", null: false
+    t.index ["travel_book_id"], name: "index_check_lists_on_travel_book_id"
     t.index ["uuid"], name: "index_check_lists_on_uuid", unique: true
   end
 
@@ -48,12 +48,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
   end
 
   create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "travel_book_uuid", null: false
     t.string "title", null: false
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["travel_book_uuid"], name: "index_notes_on_travel_book_uuid"
+    t.bigint "travel_book_id", null: false
+    t.index ["travel_book_id"], name: "index_notes_on_travel_book_id"
   end
 
   create_table "reminders", force: :cascade do |t|
@@ -80,9 +80,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
     t.datetime "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "travel_book_uuid", null: false
     t.integer "schedule_icon_id"
-    t.index ["travel_book_uuid"], name: "index_schedules_on_travel_book_uuid"
+    t.bigint "travel_book_id", null: false
+    t.index ["travel_book_id"], name: "index_schedules_on_travel_book_id"
     t.index ["uuid"], name: "index_schedules_on_uuid", unique: true
   end
 
@@ -99,7 +99,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
     t.index ["schedule_uuid"], name: "index_spots_on_schedule_uuid"
   end
 
-  create_table "travel_books", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "travel_books", force: :cascade do |t|
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "title", null: false
     t.text "description"
     t.boolean "is_public", default: false, null: false
@@ -127,8 +128,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "travel_book_uuid", null: false
-    t.index ["travel_book_uuid"], name: "index_user_travel_books_on_travel_book_uuid"
+    t.bigint "travel_book_id", null: false
+    t.index ["travel_book_id"], name: "index_user_travel_books_on_travel_book_id"
     t.index ["user_id"], name: "index_user_travel_books_on_user_id"
   end
 
@@ -162,17 +163,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_005047) do
     t.index ["token"], name: "index_users_on_token", unique: true
   end
 
-  add_foreign_key "bookmarks", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
+  add_foreign_key "bookmarks", "travel_books"
   add_foreign_key "bookmarks", "users"
-  add_foreign_key "check_lists", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
+  add_foreign_key "check_lists", "travel_books"
   add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
-  add_foreign_key "notes", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
+  add_foreign_key "notes", "travel_books"
   add_foreign_key "reminders", "list_items"
-  add_foreign_key "schedules", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
+  add_foreign_key "schedules", "travel_books"
   add_foreign_key "spots", "schedules", column: "schedule_uuid", primary_key: "uuid"
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "travel_books", "users", column: "creator_id"
-  add_foreign_key "user_travel_books", "travel_books", column: "travel_book_uuid", primary_key: "uuid"
+  add_foreign_key "user_travel_books", "travel_books"
   add_foreign_key "user_travel_books", "users"
 end


### PR DESCRIPTION
# 概要
以前travel_booksテーブルのidカラムを破壊的にuuidカラムに変更しましたが、
idカラムを追加しidカラムを主キーに設定する修正を行いました。(uuidカラムは残す)
ルーティングにはuuidを使用するように設定を実装しました。

## 実施内容
- [x] travel_booksテーブルのマイグレーション
- idカラム追加
- idカラムを主キーに変更
- [x] travel_booksのアソシエーションを修正
- [x] travel_books関連のルーティングでuuidを使用するように設定
- [x] travel_books関連のリンクでパラメータにuuidを渡すように修正

## 未実施内容
なし

## 補足
#133 でidカラムをuuidカラムに破壊的変更を加えていました。

## 関連issue
#133 