### PR TITLE
Fix/schedulesテーブルのidを追加

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -9,10 +9,8 @@ class SchedulesController < ApplicationController
     @schedules = @travel_book.sorted_schedules
     first_date = @schedules.map { |s| s.start_date&.to_date }.compact.min
     @spots = @schedules
-             .select { |s| s.start_date&.to_date == first_date }
-             .map(&:spot)
-             .compact
-             .select { |spot| spot.latitude.present? }
+    .select { |s| s.start_date&.to_date == first_date && s.spot&.latitude.present? }
+    .map { |s| { id: s.spot.id, latitude: s.spot.latitude, longitude: s.spot.longitude, name: s.spot.name, schedule_uuid: s.uuid } }
   end
 
   def new
@@ -61,7 +59,9 @@ class SchedulesController < ApplicationController
   def map
     @schedules = @travel_book.sorted_schedules
     # scheduleには0もしくは1のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
-    @spots = @schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }
+    @spots = @schedules
+    .select { |s| s.spot&.latitude.present? }
+    .map { |s| { id: s.spot.id, latitude: s.spot.latitude, longitude: s.spot.longitude, name: s.spot.name, schedule_uuid: s.uuid } }
   end
 
   private
@@ -88,7 +88,7 @@ class SchedulesController < ApplicationController
   end
 
   def set_schedule
-    @schedule = Schedule.find(params[:id])
+    @schedule = Schedule.find_by(uuid: params[:uuid])
     @travel_book = @schedule.travel_book
   end
 

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -2,7 +2,7 @@ class ScheduleForm
   include ActiveModel::Model # 通常のモデルのようにvalidationなどを使えるようにする
   include ActiveModel::Attributes # ActiveRecordのカラムのような属性を加えられるようにする
   # パラメータの読み書きを許可する
-  attribute :travel_book_id, :string
+  attribute :travel_book_id, :integer
   attribute :title, :string
   attribute :start_date, :datetime
   attribute :end_date, :datetime
@@ -46,7 +46,7 @@ class ScheduleForm
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
-        @spot = Spot.create!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_uuid: schedule.id)
+        @spot = Spot.create!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: schedule.id)
       end
       true
     end
@@ -64,7 +64,7 @@ class ScheduleForm
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
-        @spot.update!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_uuid: @schedule.id)
+        @spot.update!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: @schedule.id)
       else
         @schedule.spot.destroy
       end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,6 +1,6 @@
 class Schedule < ApplicationRecord
   belongs_to :travel_book
-  has_one :spot, primary_key: :uuid, foreign_key: :schedule_uuid, dependent: :destroy
+  has_one :spot, dependent: :destroy
   belongs_to :schedule_icon, optional: true
 
   def self.group_by_date(schedules)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,5 +1,5 @@
 class Spot < ApplicationRecord
-  belongs_to :schedule, optional: true, primary_key: :uuid, foreign_key: :schedule_uuid
+  belongs_to :schedule, optional: true
 
   geocoded_by :address
   after_validation :geocode

--- a/app/views/schedules/_map.html.erb
+++ b/app/views/schedules/_map.html.erb
@@ -47,7 +47,7 @@ function initMap() {
         <div class="card-body">
           <div class="flex items-center justify-between">
             <a href="${scheduleUrl}" class="text-blue-500 underline">${spot.name}</a>
-            <button id="close-btn" class="btn btn-square btn-sm">
+            <button id="close-btn-${spot.schedule_uuid}" class="btn btn-square btn-sm">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -55,7 +55,7 @@ function initMap() {
       </div>`;
 
       // 削除ボタンクリック時にpopupを削除
-      document.querySelector("#close-btn").addEventListener("click", () => {
+      document.getElementById(`close-btn-${spot.schedule_uuid}`).addEventListener("click", () => {
         document.getElementById("popup").innerHTML = "";
       });
     });

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg">
   <table class="table">
     <tbody>
-      <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule) %>">
+      <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule.uuid) %>">
         <td class="w-2/6">
           <%= fmt_datetime_range(schedule, :short) %>
         </td>
@@ -11,7 +11,7 @@
           <% else %>
             <i class="fa-solid <%= schedule.schedule_icon.name %>"></i>
           <% end %>
-          <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule) %></span>
+          <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule.uuid) %></span>
         </td>
         <td class="w-1/6">
           <% if schedule.spot&.latitude %>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
 
-    <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule) %>
+    <%= render "form", schedule_form: @schedule_form, url: schedule_path(@schedule.uuid) %>
   </div>
   <div class="h-24"></div>
 </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -5,10 +5,10 @@
       <h2 class="text-lg font-bold ml-5"><%= @schedule.title %></h2>
       <div class="flex justify-end">
         <% if @travel_book.owned_by_user?(current_user) %>
-          <%= link_to edit_schedule_path(@schedule), data: { turbo: false }, class: "hover:opacity-50" do %>
+          <%= link_to edit_schedule_path(@schedule.uuid), data: { turbo: false }, class: "hover:opacity-50" do %>
             <i class="fa-solid fa-pen text-sm md:text-base"></i>
           <% end %>
-          <%= link_to schedule_path(@schedule), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+          <%= link_to schedule_path(@schedule.uuid), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
             <i class="fa-solid fa-trash text-sm md:text-base"></i>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       delete "delete_owner"
     end
     delete "delete_image", on: :member
-    resources :schedules, shallow: true do
+    resources :schedules, param: :uuid, shallow: true do
       collection do
         get :map
       end

--- a/db/migrate/20250405091507_add_id_to_schedules.rb
+++ b/db/migrate/20250405091507_add_id_to_schedules.rb
@@ -1,0 +1,38 @@
+class AddIdToSchedules < ActiveRecord::Migration[7.2]
+  def up
+    # 関連する外部キー制約を削除
+    remove_foreign_key :spots, column: :schedule_uuid
+
+    # 既存の主キーを削除
+    execute "ALTER TABLE schedules DROP CONSTRAINT schedules_pkey;"
+
+    # idカラムを追加
+    add_column :schedules, :id, :primary_key
+
+    # 関連付けを作成する（カラム、インデックス、外部キーを作成）
+    add_reference :spots, :schedule, null: false, foreign_key: true
+
+    # schedule_uuid カラムを削除
+    remove_column :spots, :schedule_uuid
+  end
+
+  def down
+    # 関連付けを削除する
+    remove_reference :spots, :schedule, foreign_key: true, index: false
+
+    # 既存の主キーを削除
+    execute "ALTER TABLE schedules DROP CONSTRAINT schedules_pkey;"
+
+    # 主キーをuuidに変更
+    execute "ALTER TABLE schedules ADD PRIMARY KEY (uuid);"
+
+    # uuidカラムを追加
+    add_column :spots, :schedule_uuid, :uuid
+
+    # 関連する外部キー制約を追加
+    add_foreign_key :spots, :schedules, column: :schedule_uuid, primary_key: :uuid
+
+    # idカラムを削除
+    remove_column :schedules, :id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_05_000453) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_05_091507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,7 +72,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_05_000453) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "schedules", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "schedules", force: :cascade do |t|
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "title", null: false
     t.integer "budged", default: 0
     t.text "memo"
@@ -95,8 +96,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_05_000453) do
     t.datetime "updated_at", null: false
     t.float "latitude"
     t.float "longitude"
-    t.uuid "schedule_uuid", null: false
-    t.index ["schedule_uuid"], name: "index_spots_on_schedule_uuid"
+    t.bigint "schedule_id", null: false
+    t.index ["schedule_id"], name: "index_spots_on_schedule_id"
   end
 
   create_table "travel_books", force: :cascade do |t|
@@ -170,7 +171,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_05_000453) do
   add_foreign_key "notes", "travel_books"
   add_foreign_key "reminders", "list_items"
   add_foreign_key "schedules", "travel_books"
-  add_foreign_key "spots", "schedules", column: "schedule_uuid", primary_key: "uuid"
+  add_foreign_key "spots", "schedules"
   add_foreign_key "travel_books", "areas"
   add_foreign_key "travel_books", "traveler_types"
   add_foreign_key "travel_books", "users", column: "creator_id"


### PR DESCRIPTION
# 概要
以前schedulesテーブルのidカラムを破壊的にuuidカラムに変更しましたが、
idカラムを追加しidカラムを主キーに設定する修正を行いました。(uuidカラムは残す)
ルーティングにはuuidを使用するように設定を実装しました。

## 実施内容
- [x] schedulesテーブルのマイグレーション
- idカラム追加
- idカラムを主キーに変更
- [x] schedulesのアソシエーションを修正
- [x] schedules関連のルーティングでuuidを使用するように設定
- [x] schedules関連のリンクでパラメータにuuidを渡すように修正

## 未実施内容
- brakemanのバージョンアップ
- ブラウザバックしたときにマップに表示されるポップアップのクローズボタンが動作しなくなります。(今後要検討)
もう一度マップのピンをクリックすると動作するようになります。

## 補足
- #154 でidカラムをuuidカラムに破壊的変更を加えていました。
- マップ上のポップアップにスケジュールへのリンクを表示する際、ルーティングがuuidで生成されるように修正しています。

## 関連issue
#154, #292