### PR TITLE
Fix/check_listテーブルのidを追加

### DIFF
--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -34,7 +34,7 @@ class CheckListsController < ApplicationController
 
   def update
     if @check_list.update(check_list_param)
-      redirect_to check_list_path(@check_list), notice: t("defaults.flash_message.updated", item: CheckList.model_name.human)
+      redirect_to check_list_path(@check_list.uuid), notice: t("defaults.flash_message.updated", item: CheckList.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: CheckList.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -53,7 +53,7 @@ class CheckListsController < ApplicationController
   end
 
   def set_check_list
-    @check_list = CheckList.find(params[:id])
+    @check_list = CheckList.find_by(uuid: params[:uuid])
     @travel_book = @check_list.travel_book
   end
 

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -42,7 +42,7 @@ class ListItemsController < ApplicationController
       @reminder = @list_item.reminder || @list_item.build_reminder
     else
       # 新規作成時（new）のキャンセル
-      @check_list = CheckList.find(params[:check_list_id])
+      @check_list = CheckList.find_by(uuid: params[:check_list_uuid])
       render "cancel_new"
     end
   end
@@ -56,7 +56,7 @@ class ListItemsController < ApplicationController
   private
 
   def set_check_list
-    @check_list = CheckList.find(params[:check_list_id])
+    @check_list = CheckList.find_by(uuid: params[:check_list_uuid])
   end
 
   def set_list_item

--- a/app/models/check_list.rb
+++ b/app/models/check_list.rb
@@ -1,6 +1,6 @@
 class CheckList < ApplicationRecord
   belongs_to :travel_book
-  has_many :list_items, primary_key: :uuid, foreign_key: :check_list_uuid, dependent: :destroy
+  has_many :list_items, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,5 +1,5 @@
 class ListItem < ApplicationRecord
-  belongs_to :check_list, foreign_key: :check_list_uuid
+  belongs_to :check_list
   has_one :reminder, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/views/check_lists/_check_list.html.erb
+++ b/app/views/check_lists/_check_list.html.erb
@@ -1,4 +1,4 @@
-<%= link_to check_list_path(check_list), data: { turbo: false }, class: "block" do %>
+<%= link_to check_list_path(check_list.uuid), data: { turbo: false }, class: "block" do %>
   <div class="bg-base-100 flex items-center my-2 md:my-5 p-2 md:p-5 rounded-full shadow-sm hover:scale-[1.03]">
     <i class="fa-solid fa-square-check ml-3"></i>
     <div class="ml-3"><%= check_list.title %></div>

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", check_list: @check_list, travel_book: @travel_book, url: check_list_path(@check_list) %>
+    <%= render "form", check_list: @check_list, travel_book: @travel_book, url: check_list_path(@check_list.uuid) %>
   </div>
 </div>

--- a/app/views/check_lists/index.html.erb
+++ b/app/views/check_lists/index.html.erb
@@ -1,8 +1,8 @@
 <div class="m-5">
   <div class="max-w-screen-md mx-auto">
     <div class="flex gap-3">
-      <%= link_to t(".note_link"), travel_book_notes_path(@travel_book), class: "btn btn-sm md:btn-md btn-outline btn-primary w-1/2" %>
-      <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book), class: "btn btn-sm md:btn-md btn-primary w-1/2" %>
+      <%= link_to t(".note_link"), travel_book_notes_path(@travel_book.uuid), class: "btn btn-sm md:btn-md btn-outline btn-primary w-1/2" %>
+      <%= link_to t(".check_list_link"), travel_book_check_lists_path(@travel_book.uuid), class: "btn btn-sm md:btn-md btn-primary w-1/2" %>
     </div>
     <% if @check_lists.present? %>
       <%= render @check_lists %>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -5,10 +5,10 @@
       <h2 class="md:text-lg font-bold md:ml-5"><%= @check_list.title %></h2>
       <div class="flex justify-end">
         <% if @travel_book.owned_by_user?(current_user) %>
-          <%= link_to edit_check_list_path(@check_list), class:"hover:opacity-50" do %>
+          <%= link_to edit_check_list_path(@check_list.uuid), class:"hover:opacity-50" do %>
             <i class="fa-solid fa-pen text-sm md:text-base"></i>
           <% end %>
-          <%= link_to check_list_path(@check_list), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+          <%= link_to check_list_path(@check_list.uuid), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
             <i class="fa-solid fa-trash text-sm md:text-base"></i>
           <% end %>
         <% end %>

--- a/app/views/list_items/_add_button.html.erb
+++ b/app/views/list_items/_add_button.html.erb
@@ -1,5 +1,5 @@
 <div id="add_list_item_button">
-  <%= link_to new_check_list_list_item_path(@check_list), class: "btn btn-primary", data: { turbo_stream: true } do %>
+  <%= link_to new_check_list_list_item_path(@check_list.uuid), class: "btn btn-primary", data: { turbo_stream: true } do %>
     <i class="fa-solid fa-plus"></i><%= t(".new_button") %>
   <% end %>
 </div>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag "list_item_#{list_item.id}" do %>
-  <%= form_with model: @list_item, url: @list_item.new_record? ? check_list_list_items_path(@check_list): list_item_path(@list_item) do |f| %>
+  <%= form_with model: @list_item, url: url do |f| %>
     <%= render "shared/error_messages", object: f.object %>
     <div class="flex gap-2 items-center">
       <%= f.text_field :title, autofocus: true, placeholder: t("list_items.form.placeholder.title"), class: "input input-bordered w-full" %>
       <div class="flex gap-2 items-center">
-        <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list) : cancel_list_item_path(@list_item), class: "btn btn-ghoast", data: { turbo_method: :post } do %>
+        <%= link_to @list_item.new_record? ? cancel_check_list_list_items_path(@check_list.uuid) : cancel_list_item_path(@list_item), class: "btn btn-ghoast", data: { turbo_method: :post } do %>
           <i class="fa-solid fa-xmark"></i>
         <% end %>
         <%= f.submit nil, class: "btn btn-primary" %>

--- a/app/views/list_items/edit.turbo_stream.erb
+++ b/app/views/list_items/edit.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
 
 <%= turbo_stream.replace "list_item_#{@list_item.id}" do %>
-  <%= render "list_items/form", list_item: @list_item %>
+  <%= render "list_items/form", list_item: @list_item, url: list_item_path(@list_item) %>
 <% end %>

--- a/app/views/list_items/new.turbo_stream.erb
+++ b/app/views/list_items/new.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.update "flash_messages", partial: "shared/flash_message" %>
 
 <%= turbo_stream.append "list_item_form" do %>
-  <%= render "list_items/form", list_item: @list_item %>
+  <%= render "list_items/form", list_item: @list_item, url: check_list_list_items_path(@check_list.uuid) %>
 <% end %>
 
 <%= turbo_stream.update "add_list_item_button", "" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
         get :map
       end
     end
-    resources :check_lists, shallow: true do
+    resources :check_lists, param: :uuid, shallow: true do
       resources :list_items, only: %i[ new create edit update destroy toggle ] do
         resources :reminders, only: %i[ create update clear_reminder ] do
           member do

--- a/db/migrate/20250406025142_add_id_to_check_lists.rb
+++ b/db/migrate/20250406025142_add_id_to_check_lists.rb
@@ -1,0 +1,38 @@
+class AddIdToCheckLists < ActiveRecord::Migration[7.2]
+  def up
+    # 関連する外部キー制約を削除
+    remove_foreign_key :list_items, column: :check_list_uuid
+
+    # 既存の主キーを削除
+    execute "ALTER TABLE check_lists DROP CONSTRAINT check_lists_pkey;"
+
+    # idカラムを追加
+    add_column :check_lists, :id, :primary_key
+
+    # 関連付けを作成する（カラム、インデックス、外部キーを作成）
+    add_reference :list_items, :check_list, null: false, foreign_key: true
+
+    # check_list_uuid カラムを削除
+    remove_column :list_items, :check_list_uuid
+  end
+
+  def down
+    # 関連付けを削除する
+    remove_reference :list_items, :check_list, foreign_key: true, index: false
+
+    # 既存の主キーを削除
+    execute "ALTER TABLE check_lists DROP CONSTRAINT check_lists_pkey;"
+
+    # 主キーをuuidに変更
+    execute "ALTER TABLE check_lists ADD PRIMARY KEY (uuid);"
+
+    # uuidカラムを追加
+    add_column :list_items, :check_list_uuid, :uuid
+
+    # 関連する外部キー制約を追加
+    add_foreign_key :list_items, :check_lists, column: :check_list_uuid, primary_key: :uuid
+
+    # idカラムを削除
+    remove_column :check_lists, :id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_05_091507) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_06_025142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +29,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_05_091507) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "check_lists", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "check_lists", force: :cascade do |t|
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -43,8 +44,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_05_091507) do
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "check_list_uuid", null: false
-    t.index ["check_list_uuid"], name: "index_list_items_on_check_list_uuid"
+    t.bigint "check_list_id", null: false
+    t.index ["check_list_id"], name: "index_list_items_on_check_list_id"
   end
 
   create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -167,7 +168,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_05_091507) do
   add_foreign_key "bookmarks", "travel_books"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "check_lists", "travel_books"
-  add_foreign_key "list_items", "check_lists", column: "check_list_uuid", primary_key: "uuid"
+  add_foreign_key "list_items", "check_lists"
   add_foreign_key "notes", "travel_books"
   add_foreign_key "reminders", "list_items"
   add_foreign_key "schedules", "travel_books"


### PR DESCRIPTION
# 概要
以前check_listテーブルのidカラムを破壊的にuuidカラムに変更しましたが、
idカラムを追加しidカラムを主キーに設定する修正を行いました。(uuidカラムは残す)
ルーティングにはuuidを使用するように設定を実装しました。

## 実施内容
- [x] check_listテーブルのマイグレーション
- idカラム追加
- idカラムを主キーに変更
- [x] check_listのアソシエーションを修正
- [x] check_list関連のルーティングでuuidを使用するように設定
- [x] check_list関連のリンクでパラメータにuuidを渡すように修正

## 未実施内容
- brakemanのバージョンアップ

## 補足
#136 でidカラムをuuidカラムに破壊的変更を加えていました。

## 関連issue
#136 , #293 