### PR TITLE
Fix/notesテーブルにuuidカラムを追加

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -27,7 +27,7 @@ class NotesController < ApplicationController
 
   def update
     if @note.update(note_params)
-      redirect_to note_path(@note), notice: t("defaults.flash_message.updated", item: Note.model_name.human)
+      redirect_to note_path(@note.uuid), notice: t("defaults.flash_message.updated", item: Note.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated", item: Note.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -46,7 +46,7 @@ class NotesController < ApplicationController
   end
 
   def set_note
-    @note = Note.find(params[:id])
+    @note = Note.find_by(uuid: params[:uuid])
     @travel_book = @note.travel_book
   end
 

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: note, url: url do |f| %>
+<%= form_with model: @note, url: url do |f| %>
   <%= render "shared/error_messages", object: f.object %>
 
   <div class="space-y-3">

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,4 +1,4 @@
-<%= link_to note_path(note), data: { turbo: false }, class: "block" do %>
+<%= link_to note_path(note.uuid), data: { turbo: false }, class: "block" do %>
   <div class="bg-base-100 flex items-center  my-2 md:my-5 p-2 md:p-5 rounded-full shadow-sm hover:scale-[1.03]">
     <i class="fa-solid fa-book-open ml-3"></i>
     <div class="ml-3"><%= note.title %></div>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
-    <%= render "form", note: @note, travel_book: @travel_book, url: note_path(@note) %>
+    <%= render "form", note: @note, travel_book: @travel_book, url: note_path(@note.uuid) %>
   </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,10 +5,10 @@
     <h2 class="md:text-lg font-bold md:ml-5"><%= @note.title %></h2>
       <div class="justify-end">
         <% if @travel_book.owned_by_user?(current_user) %>
-          <%= link_to edit_note_path(@note), class:"hover:opacity-50" do %>
+          <%= link_to edit_note_path(@note.uuid), class:"hover:opacity-50" do %>
             <i class="fa-solid fa-pen text-sm md:text-base"></i>
           <% end %>
-          <%= link_to note_path(@note), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
+          <%= link_to note_path(@note.uuid), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "ml-5 hover:opacity-50" do %>
             <i class="fa-solid fa-trash text-sm md:text-base"></i>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
         end
       end
     end
-    resources :notes, shallow: true
+    resources :notes, param: :uuid, shallow: true
   end
   resources :bookmarks, only: %i[ create destroy ]
 

--- a/db/migrate/20250406034234_add_uuid_to_notes.rb
+++ b/db/migrate/20250406034234_add_uuid_to_notes.rb
@@ -1,0 +1,33 @@
+class AddUuidToNotes < ActiveRecord::Migration[7.2]
+  def up
+    # 既存の主キーを削除
+    execute "ALTER TABLE notes DROP CONSTRAINT notes_pkey;"
+
+    # idカラムをuuidカラムに変更
+    rename_column :notes, :id, :uuid
+
+    # 新しいbigintのidカラムを主キーとして追加
+    add_column :notes, :id, :bigint, null: false, primary_key: true
+
+    # uuidカラムにユニーク制約を追加
+    add_index :notes, :uuid, unique: true
+  end
+
+  def down
+    # 既存の主キーを削除
+    execute "ALTER TABLE notes DROP CONSTRAINT notes_pkey;"
+
+    # uuidカラムをidカラムに変更
+    rename_column :notes, :uuid, :id
+
+    # uuidカラムにユニーク制約を追加
+    add_index :notes, :id, unique: true
+
+    # 新しいuuidのidカラムを主キーとして追加
+    execute "ALTER TABLE notes ADD PRIMARY KEY (uuid);"
+
+    # uuidカラムを削除
+    remove_index :notes, :uuid
+    remove_column :notes, :uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_06_025142) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_06_034234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,13 +48,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_06_025142) do
     t.index ["check_list_id"], name: "index_list_items_on_check_list_id"
   end
 
-  create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "notes", force: :cascade do |t|
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "title", null: false
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "travel_book_id", null: false
     t.index ["travel_book_id"], name: "index_notes_on_travel_book_id"
+    t.index ["uuid"], name: "index_notes_on_uuid", unique: true
   end
 
   create_table "reminders", force: :cascade do |t|


### PR DESCRIPTION
# 概要
以前notesテーブルを作成した際に、notesテーブルのidカラムをuuid型にしていました。
他のテーブルと統一するために既存のidカラムをuuidカラムへ変更し、
idカラムを主キーとして新たに追加しました。
ルーティングにはuuidを使用するように設定を実装しました。

## 実施内容
- [x] notesテーブルのマイグレーション
- idカラム追加
- idカラムを主キーに変更
- [x] notesのアソシエーションを修正
- [x] notes関連のルーティングでuuidを使用するように設定
- [x] notes関連のリンクでパラメータにuuidを渡すように修正

## 未実施内容
- brakemanのバージョンアップ

## 補足
#208 でnotesテーブルを作成していました。

## 関連issue
#207 , #294 