### PR TITLE
Fix/Brakemanのversion up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :development, :test do
   gem "pry-byebug"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.0.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     byebug (11.1.3)
@@ -455,7 +455,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (~> 7.0.2)
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails


### PR DESCRIPTION
# 概要
Github CIにて、Brakemanのversion upを促すエラーが出力されていたため、対処しました。
エラー内容
```
Brakeman 7.0.0 is not the latest version 7.0.2
Error: Process completed with exit code [5]
```
## 実施内容
- [x] Brakemanのv 7.0.2へ更新

## 未実施内容
なし

## 補足
なし

## 関連issue
#298 