### PR TITLE
Feature/しおりの招待URLの発行

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,7 +22,7 @@ class Users::SessionsController < Devise::SessionsController
 
   # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource)
-    public_travel_books_path
+    session.delete(:after_sign_in_path) || public_travel_books_path
   end
 
   # ログアウト後のリダイレクト先

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -32,6 +32,12 @@ class TravelBook < ApplicationRecord
     [ "area_id", "traveler_type_id" ]
   end
 
+  # トークン生成のためのメソッド
+  def generate_token
+    self.invitation_token = Devise.friendly_token
+    update(invitation_token: self.invitation_token)
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,28 +1,19 @@
-<div class="max-w-screen-md mx-auto">
-  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
-    <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>
+<p>招待メールを送る場合は、招待したいメンバーのメールアドレスを入力して送信してください</p>
+<%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
 
-    <%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "shared/error_messages", object: resource %>
 
-      <%= render "shared/error_messages", object: resource %>
-
-      <div class="space-y-3">
+  <div class="space-y-3">
+    <div class="flex flex-col sm:flex-row items-center justify-center gap-1">
+      <div class="w-full">
         <% resource.class.invite_key_fields.each do |field| -%>
-          <div>
-            <div class="flex items-center gap-1">
-              <%= f.label :email, class: "label" %>
-              <i class="fa-solid fa-envelope"></i>
-            </div>
             <%= f.email_field field, autocomplete: "email", placeholder: t("users.form.placeholder.email"), class: "input input-bordered w-full" %>
-
-            <%= f.hidden_field :travel_book_uuid, value: params[:travel_book_uuid] || travel_book_uuid %>
-          </div>
+            <%= f.hidden_field :travel_book_uuid, value: @travel_book.uuid %>
         <% end -%>
-
-        <div class="actions">
-          <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-primary w-full" %>
-        </div>
-      <% end %>
+      </div>
+      <div class="w-full sm:w-auto">
+        <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-primary w-full sm:w-auto" %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/travel_books/invitation.html.erb
+++ b/app/views/travel_books/invitation.html.erb
@@ -1,0 +1,10 @@
+<%= turbo_frame_tag "invite-link" do %>
+  <div id="invite-link">
+    <div class="flex flex-col" data-controller="clipboard">
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-1">
+        <input type="text" value="<%= @invite_link %>" readonly class="input input-bordered w-full">
+        <%= button_tag "コピー", data: { controller: "clipboard", action: "clipboard#copy", clipboard_content_value: @invite_link }, class: "btn btn-primary w-full sm:w-auto" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -1,6 +1,25 @@
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 
+    <h2 class="text-lg font-bold text-center">メンバー招待</h2>
+    <div class="mt-5">
+      <%= turbo_frame_tag "invite-link" do %>
+        <% if @invite_link.present? %>
+          <%= render template: 'travel_books/invitation' %>
+        <% else %>
+          <div class="flex justify-center">
+            <%= button_to "招待リンクを生成", invitation_travel_book_path(uuid: params[:uuid]), class:"btn btn-primary w-full" %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    <!-- しおりに招待のフォームを表示 -->
+    <div class="mt-5">
+      <%= render template: 'devise/invitations/new', locals: { resource: @user, resource_name: @resource_name } %>
+    </div>
+  </div>
+  <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
+
     <h2 class="text-lg font-bold text-center">メンバーリスト</h2>
 
     <table class="table">
@@ -24,11 +43,6 @@
         <% end %>
       </tbody>
     </table>
-    <div class="text-right mt-5">
-      <%= link_to new_user_invitation_path(travel_book_uuid: @travel_book.uuid), class: "btn btn-primary" do %>
-        <i class="fa-solid fa-envelope"></i> しおりに招待
-      <% end %>
-    </div>
   </div>
   <div class="h-24"></div>
 </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -72,7 +72,7 @@ ja:
     invitations:
       new:
         title: しおりに招待する
-        submit_button: 招待メール送信
+        submit_button: 送信
       edit:
         title: しおりに参加する
         submit_button: しおりに参加

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     end
     member do
       get :share
+      post "invitation"
+      get "invitation/accept/:invitation_token", to: "travel_books#accept", as: "accept"
       delete "delete_owner"
     end
     delete "delete_image", on: :member

--- a/db/migrate/20250406095246_add_invitation_token_to_travel_books.rb
+++ b/db/migrate/20250406095246_add_invitation_token_to_travel_books.rb
@@ -1,0 +1,6 @@
+class AddInvitationTokenToTravelBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :travel_books, :invitation_token, :string
+    add_index :travel_books, :invitation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_06_034234) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_06_095246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -116,8 +116,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_06_034234) do
     t.bigint "traveler_type_id"
     t.string "travel_book_image"
     t.bigint "creator_id", null: false
+    t.string "invitation_token"
     t.index ["area_id"], name: "index_travel_books_on_area_id"
     t.index ["creator_id"], name: "index_travel_books_on_creator_id"
+    t.index ["invitation_token"], name: "index_travel_books_on_invitation_token", unique: true
     t.index ["traveler_type_id"], name: "index_travel_books_on_traveler_type_id"
     t.index ["uuid"], name: "index_travel_books_on_uuid", unique: true
   end


### PR DESCRIPTION
# 概要
しおりの招待URLを発行する機能を実装しました。

## 実施内容
- [x] travel_booksテーブルにinvitation_tokenカラム追加
- [x] 招待用のルーティングを追加
  - 招待リンク発行用
  - 招待リンクアクセス用
- [x] 招待トークン生成メソッドを追加
- [x] TravelBooks#inivitaion,acceptアクションを定義
- [x] TravelBooks#invitationsのビューを作成(招待トークンの表示画面)
- [x] メンバー表示画面に招待トークンの表示画面と招待メール送信フォームを組み込むように修正
- [x] セッションにパスがある場合、ログイン後のリダイレクト先に設定

### 実装イメージ
【修正前】
[![Image from Gyazo](https://i.gyazo.com/b10a0e3bccd8714b3808d04e0c183790.gif)](https://gyazo.com/b10a0e3bccd8714b3808d04e0c183790)

【修正後】
[![Image from Gyazo](https://i.gyazo.com/b51eed11b0ca8f2c67f1957d3717e8ba.gif)](https://gyazo.com/b51eed11b0ca8f2c67f1957d3717e8ba)

## 未実施内容
- 本番環境での確認

## 補足
しおりに招待したいメンバーに招待リンク(URL)を共有することで、しおりに招待できます。
以下の仕様にしております。
- ログインしている場合
しおりのメンバーに追加されしおり詳細画面へリダイレクト
（すでにしおりに参加している場合はしおり詳細画面へリダイレクト）

- ログインしていない場合
ログイン画面へリダイレクトし、ログイン後にしおりのメンバーに追加されしおり詳細画面へリダイレクト

## 関連issue
#303