### PR TITLE
Fix/しおりの招待URL発行機能の修正

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -112,9 +112,9 @@ class TravelBooksController < ApplicationController
       else
         # しおりのメンバーに参加していない場合
         # 中間テーブルに招待ユーザーと対象のしおりのidを保存
-        user_travel_book = UserTravelBook.new(user_id: current_user.id, travel_book_id: travel_book.id)
+        user_travel_book = UserTravelBook.new(user_id: current_user.id, travel_book_id: @travel_book.id)
         if user_travel_book.save
-          redirect_to travel_book_path(travel_book.uuid), notice: "しおりのメンバーに追加されました"
+          redirect_to travel_book_path(@travel_book.uuid), notice: "しおりのメンバーに追加されました"
         else
           redirect_to public_travel_books_path, alert: "しおりのメンバーに追加できませんでした"
         end


### PR DESCRIPTION
# 概要
しおりの招待URL発行機能で発行されたURLからログインできない問題の修正を行いました。

## 実施内容
- [x] TravelBooksControllers#acceptアクションでtravel_bookの`@`が抜けていた箇所を修正

## 未実施内容
- 本番環境で発行されたURLからしおりへの参加ができるか確認

## 補足
なし

## 関連issue
#304 の修正