### PR TITLE
Fix/しおりのtokenを削除しない、未ログイン時にセッションに保存するURLが間違えていたため修正

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -100,7 +100,7 @@ class TravelBooksController < ApplicationController
   def accept
     @travel_book = TravelBook.find_by(invitation_token: params[:invitation_token])
     # しおりがない場合、公開しおり一覧にリダイレクト
-    return redirect_to public_travel_books_path, alert: "招待されたしおりが存在しません" unless @travel_book
+    return redirect_to public_travel_books_path, alert: "招待URLが無効です" unless @travel_book
     # ログインしていない場合に招待されたしおりを特定するためにセッションにしおりのuuidを保存
     session[:travel_book_uuid] = @travel_book.uuid
 
@@ -119,12 +119,11 @@ class TravelBooksController < ApplicationController
           redirect_to public_travel_books_path, alert: "しおりのメンバーに追加できませんでした"
         end
       end
-      # セッションと招待tokenを無効にする
+      # セッションを無効にする
       session[:travel_book_uuid] = nil
-      @travel_book.update(invitation_token: nil)
     else
       # ログインしていない場合
-      session[:after_sign_in_path] = accept_plan_url(invitation_token: params[:invitation_token])
+      session[:after_sign_in_path] = accept_travel_book_url(invitation_token: params[:invitation_token])
       redirect_to new_user_session_path, alert: "ログインしてください"
     end
   end


### PR DESCRIPTION
# 概要
しおりに一人が招待されるたび招待tokenを変更していたが、同じURLで複数人参加できるように修正しました。
未ログイン時にセッションに保存するURLに誤記があったため修正しました。

## 実施内容
- [x] 一人が招待されるたびにしおりのtokenを削除しないように修正
- [x] 未ログイン時にセッションに保存するURLが間違えていたため修正

## 未実施内容
- i18n対応
- 本番環境での確認

## 補足
なし

## 関連issue
#304, #305