### PR TITLE
Fix/動的OGPのXシェア用URLのパスを修正

### DIFF
--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -66,8 +66,8 @@
         <% end %>
 
         <% if @travel_book.is_public %>
-          <% prepare_meta_tags @travel_book %>
-          <% twitter_share_url = "https://twitter.com/intent/tweet?url= #{CGI.escape(travel_book_url(@travel_book))}" %>
+          <% prepare_meta_tags(@travel_book) %>
+          <% twitter_share_url = "https://twitter.com/intent/tweet?url= #{CGI.escape(travel_book_url(@travel_book.uuid))}" %>
           <%= link_to twitter_share_url, target: "_blank", data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア", class: "btn w-full" do %>
             <i class="fa-brands fa-square-x-twitter text-lg"></i> Xに投稿
           <% end %>


### PR DESCRIPTION
# 概要
Xシェアボタンで生成される動的OGPのパスにtravel_bookのuuidを渡すように修正しました。

## 実施内容
- [x] twitterシェア用URLを修正

## 未実施内容
- 本番環境での確認

## 補足
travel_booksテーブルにidを追加しuuidのルーティングを設定した(#291の変更)影響でパスが変更されました。

## 関連issue
#307 , #291