### PR TITLE
Fix/未ログイン時に招待されたしおりに参加できない問題の修正

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,5 +1,5 @@
 class TravelBooksController < ApplicationController
-  before_action :authenticate_user!, except: %i[ show public_travel_books ]
+  before_action :authenticate_user!, except: %i[ show public_travel_books accept ]
   before_action :set_travel_book, only: %i[ edit update destroy delete_image share delete_owner ]
   # 設定したprepare_meta_tagsをprivateにあってもpostコントローラー以外にも使えるようにする
   helper_method :prepare_meta_tags

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -56,7 +56,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # アカウント登録後のリダイレクト先
   def after_sign_up_path_for(resource)
-    public_travel_books_path
+    session.delete(:after_sign_in_path) || public_travel_books_path
   end
 
   # The path used after sign up for inactive accounts.


### PR DESCRIPTION
# 概要
未ログインの時とアカウントがない場合はしおりの招待URLからしおりに参加することができない問題があったため、修正を行いました。

## 実施内容
- [ ] TravelBooksController#acceptアクションを未ログインで実行できるように修正
- [ ] RegistrationsControllerでafter_sign_up_path_forメソッドでセッションに保存した招待URLがある場合リダイレクトされるように修正

## 未実施内容
なし

## 補足
招待URLでしおりに招待されたユーザーがアカウント有無、ログイン有無に関わらず招待できるようになりました。

## 関連issue
#308, #303 
