### PR TITLE
Fix/LINEログイン後に招待されたしおりに参加できない問題の解消

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,11 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  # ログイン後のリダイレクト先
+  def after_sign_in_path_for(resource_or_scope)
+    session.delete(:after_sign_in_path) || public_travel_books_path
+  end
+
   def set_travel_book
     @travel_book = TravelBook.find(params[:id])
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -54,11 +54,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :icon_image, :icon_image_cache ])
   end
 
-  # アカウント登録後のリダイレクト先
-  def after_sign_up_path_for(resource)
-    session.delete(:after_sign_in_path) || public_travel_books_path
-  end
-
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,11 +20,6 @@ class Users::SessionsController < Devise::SessionsController
 
   # protected
 
-  # ログイン後のリダイレクト先
-  def after_sign_in_path_for(resource)
-    session.delete(:after_sign_in_path) || public_travel_books_path
-  end
-
   # ログアウト後のリダイレクト先
   def after_sign_out_path_for(resource)
     home_index_path


### PR DESCRIPTION
# 概要
LINEログイン後に招待されたしおりに参加できない問題の解消のため、
ログイン後のリダイレクト先をapplication.html.erbに共通化しました。

## 実施内容
- [x] 新規登録後のリダイレクト先を定義するメソッドをapplication.html.erbに移行
- [x] ログイン後のリダイレクト先を定義するメソッドをapplication.html.erbに移行

## 未実施内容
- 本番環境でのLINEログインの確認

## 補足
なし

## 関連issue
#311