### PR TITLE
Fix/LINEログイン時に招待されたしおりに参加できない問題の修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -43,7 +43,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in(:user, @profile)
 
       flash[:notice] = "ログインしました"
-      redirect_to public_travel_books_path
+      redirect_to session.delete(:after_sign_in_path) || public_travel_books_path
     else
       flash[:alert] = "認証に失敗しました"
       redirect_to user_session_path


### PR DESCRIPTION
# 概要
LINEログイン時に招待されたしおりに参加できない問題の修正を行いました。

## 実施内容
- [x] OmniauthCallbacksControllerでログイン後にセッションに招待URLのパスがある場合リダイレクト先させるように修正

## 未実施内容
- 本番環境での確認

## 補足
ngrokを使用したローカル環境での動作確認は完了しています。

## 関連issue
#311, #312 