### PR TITLE
Refactor/コントローラーのbefore_action :authenticate_user!メソッド共通化としおり画像の削除機能修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,4 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource_or_scope)
     session.delete(:after_sign_in_path) || public_travel_books_path
   end
-
-  def set_travel_book
-    @travel_book = TravelBook.find(params[:id])
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  before_action :authenticate_user!
+
   # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource_or_scope)
     session.delete(:after_sign_in_path) || public_travel_books_path

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,4 @@
 class BookmarksController < ApplicationController
-  before_action :authenticate_user!
-
   def create
     travel_book = TravelBook.find(params[:travel_book_id])
     current_user.bookmark(travel_book)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
+  skip_before_action :authenticate_user!
   def index
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,4 +1,6 @@
 class ImagesController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def ogp
     title = ogp_params[:title]
     creator = ogp_params[:creator]

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,5 +1,4 @@
 class ListItemsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_check_list, only: %i[ new create ]
   before_action :set_list_item, only: %i[ edit update destroy toggle]
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,5 +1,4 @@
 class NotesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_travel_book, only: %i[ index new create ]
   before_action :set_note, only: %i[ show edit update destroy ]
 

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,5 +1,4 @@
 class RemindersController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_reminder, only: %i[ update clear_reminder ]
 
   def create

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,5 +1,5 @@
 class SchedulesController < ApplicationController
-  before_action :authenticate_user!, only: [ :new, :edit, :update, :destroy ]
+  skip_before_action :authenticate_user!, only: %i[ index show map ]
   before_action :set_travel_book, only: %i[ index new create map ]
   before_action :set_schedule, only: %i[ show edit update destroy ]
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,4 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :authenticate_user!
   def form; end
 end

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,5 +1,5 @@
 class TravelBooksController < ApplicationController
-  before_action :authenticate_user!, except: %i[ show public_travel_books accept ]
+  skip_before_action :authenticate_user!, only: %i[ show public_travel_books accept ]
   before_action :set_travel_book, only: %i[ edit update destroy delete_image share delete_owner ]
   # 設定したprepare_meta_tagsをprivateにあってもpostコントローラー以外にも使えるようにする
   helper_method :prepare_meta_tags

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -51,7 +51,7 @@ class TravelBooksController < ApplicationController
   def delete_image
     @travel_book.remove_travel_book_image! # CarrierWaveのメソッドを使って画像を削除
     @travel_book.save
-    redirect_to edit_travel_book_path(@travel_book), notice: "しおりの画像を削除しました"
+    redirect_to edit_travel_book_path(@travel_book.uuid), notice: "しおりの画像を削除しました"
   end
 
   def public_travel_books

--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -1,6 +1,6 @@
 class TravelBooksController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[ show public_travel_books accept ]
-  before_action :set_travel_book, only: %i[ edit update destroy delete_image share delete_owner ]
+  before_action :set_travel_book, only: %i[ edit update destroy delete_image share delete_owner invitation ]
   # 設定したprepare_meta_tagsをprivateにあってもpostコントローラー以外にも使えるようにする
   helper_method :prepare_meta_tags
 
@@ -89,7 +89,6 @@ class TravelBooksController < ApplicationController
   end
 
   def invitation
-    @travel_book = TravelBook.find_by(uuid: params[:uuid])
     if @travel_book.generate_token
       @invite_link = accept_travel_book_url(invitation_token: @travel_book.invitation_token)
     else

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,5 +1,6 @@
 class Users::InvitationsController < Devise::InvitationsController
   before_action :configure_permitted_parameters
+  skip_before_action :authenticate_user!, only: %i[ edit update ]
 
   def new
     super

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
-
   def show
     @user = current_user
   end

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -43,9 +43,12 @@
       <%= f.hidden_field :travel_book_image_cache %>
     </div>
 
-    <div class="flex flex-row-reverse">
-      <% if @travel_book.persisted? && @travel_book.travel_book_image %>
-        <%= link_to delete_image_travel_book_path(@travel_book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "hover:opacity-50" do %>
+    <div class="flex justify-between">
+      <% if @travel_book.persisted? && @travel_book.travel_book_image.present? %>
+        <%= @travel_book.travel_book_image_identifier %>
+        <%= link_to delete_image_travel_book_path(@travel_book.uuid),
+        data: { turbo_method: :delete, turbo_confirm: "しおりの画像を削除しますか？" },
+        class: "hover:opacity-50" do %>
           <i class="fa-solid fa-trash"></i>
         <% end %>
       <% end %>


### PR DESCRIPTION
# 概要
before_action :authenticate_user!を各コントローラーで実施せず、application_controllerで共通化させます。
しおり画像の削除機能に不備が見つかったため合わせて修正しました。

## 実施内容
- [x] application_controllerに`before_action :authenticate_user!`設置
- [x] 各コントローラーで`skip_before_action :authenticate_user!`設置
- [x] しおり編集時のしおり画像削除機能の修正とCSS調整

## 未実施内容
なし

## 補足
- しおり画像の削除機能に不備が見つかったため合わせて修正し、画像ファイル名を表示するように修正しました
[![Image from Gyazo](https://i.gyazo.com/dfe2f5f4f9dd6b1fa10fd193c0e3ec1c.png)](https://gyazo.com/dfe2f5f4f9dd6b1fa10fd193c0e3ec1c)


## 関連issue
#314 