### PR TITLE
Update/フラッシュメッセージとエラーメッセージのCSS修正等

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -15,8 +15,8 @@ class NotesController < ApplicationController
     if @note.save
       redirect_to travel_book_notes_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Note.model_name.human)
     else
-      flash.now[:alert] = t("defaults.flash_message.not_created")
-      render :new
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Note.model_name.human)
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,6 +58,9 @@ module ApplicationHelper
   end
 
   def flash_message_color(type)
-    type.to_sym == :notice ? "alert-success" : "alert-error"
+    case type.to_sym
+    when :notice then "bg-green-300 text-green-600 border-green-500"
+    when :alert then "bg-red-200 text-red-600 boder border-red-500"
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_travel_books, through: :bookmarks, source: :travel_book
 
+  validates :name, presence: true
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,8 +36,7 @@
 
   <body class="flex flex-col min-h-screen <%= backgtound_color_class %>">
     <%= render "shared/header" %>
-    <div id="flash_messages"></div>
-    <%= render "shared/flash_message" %>
+    <div id="flash_messages"><%= render "shared/flash_message" %></div>
     <main class="flex-grow">
       <%= yield %>
     </main>

--- a/app/views/list_items/_list_item.html.erb
+++ b/app/views/list_items/_list_item.html.erb
@@ -23,7 +23,7 @@
               <li>
                 <button class="hover:opacity-50" type="button" onclick="modal_<%= list_item.id %>.showModal()">
                   <% if list_item.reminder.reminder_date %>
-                    <i class="fa-solid fa-bell fa-fw text-sm md:text-base"></i> リマインダー解除
+                    <i class="fa-solid fa-bell fa-fw text-sm md:text-base"></i> リマインダー設定
                   <% else %>
                     <i class="fa-solid fa-bell-slash fa-fw text-sm md:text-base"></i> リマインダー設定
                   <% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,6 +1,5 @@
 <%= form_with model: @note, url: url do |f| %>
-  <%= render "shared/error_messages", object: f.object %>
-
+  <%= render "/shared/error_messages", object: f.object %>
   <div class="space-y-3">
     <div>
       <%= f.label :title, class: "label" do %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -3,4 +3,5 @@
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", note: @note, travel_book: @travel_book, url: note_path(@note.uuid) %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -3,4 +3,5 @@
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>
     <%= render "form", note: @note, travel_book: @travel_book, url: travel_book_notes_path(@travel_book.uuid) %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @schedule_form, url: url, data: { turbo: false } do |f| %>
-  <%= render "shared/error_messages", object: f.object %>
+  <%= render "/shared/error_messages", object: f.object %>
 
   <div class="space-y-3">
     <div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,7 @@
 <% if object.errors.any? %>
-  <div role="alert" class="alert alert-error">
-    <ul>
-      <% object.errors.each do | error | %>
-        <li><%= error.full_message %></li>
-      <% end %>
-    </ul>
-  </div>
+  <ul class="p-2">
+    <% object.errors.each do | error | %>
+      <li class="text-red-500 text-sm"><%= error.full_message %></li>
+    <% end %>
+  </ul>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div role="alert" class="alert <%= flash_message_color(message_type) %>">
+  <div role="alert" class="alert <%= flash_message_color(message_type) %> p-4">
     <span><%= message %></span>
   </div>
 <% end %>

--- a/app/views/travel_books/_form.html.erb
+++ b/app/views/travel_books/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @travel_book, url: url do |f| %>
-  <%= render "shared/error_messages", object: f.object %>
+  <%= render "/shared/error_messages", object: f.object %>
 
   <div class="space-y-3">
     <div>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,8 +1,8 @@
 <% if resource.errors.any? %>
-  <div role="alert" class="alert alert-error" data-turbo-cache="false">
-    <ul>
+  <div data-turbo-cache="false">
+    <ul class="p-2">
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="text-red-500 text-sm"><%= message %></li>
       <% end %>
     </ul>
   </div>


### PR DESCRIPTION
# 概要
フラッシュメッセージとバリデーションエラーメッセージのCSS修正を行いました

## 実施内容
- [x] flashメッセージのCSS修正
- [x] バリデーションエラーメッセージのCSS修正
- [x] 新規登録時のnameを必須にするvalidatesをUserモデルに追加
- [x] リマインダー設定メニューの文言修正(`リマインダー解除`→`リマインダー設定`)
- [x] NotesController#createアクション失敗時の修正(`status: :unprocessable_entity`が抜けていたため追加)
- [x] flashメッセージのパーシャル記述位置の修正(`id="flash_messages"`付与)
- [x] ノート作成・編集時のビューでボトムナビゲーションに被らないように一時的に修正(`<div class="h-24"></div>`追加)

## 未実施内容
- i18n対応

## 補足
- フラッシュメッセージとバリデーションエラーメッセージのCSS修正中に見つけた軽微なエラー等も合わせて修正しています。

## 関連issue
#316 