### PR TITLE
Fix/line_bot_controllerにskip_before_actionを追加する修正

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,4 +1,5 @@
 class LinebotController < ApplicationController
+  skip_before_action :authenticate_user!
   # gem 'line-bot-api'
   require "line/bot"
 


### PR DESCRIPTION
# 概要
line_bot_controllerを未ログインで実行可能にする修正を加えました。

## 実施内容
- [x] line_bot_controllerを未ログインで実行可能にする

## 未実施内容
なし

## 補足
#315 にてapplication_controllerに`before_action :authenticate_user!`を設定した際に編集が漏れていました。

## 関連issue
#315