### PR TITLE
Fix/画像ファイルが壊れていたため修正

### DIFF
--- a/app/views/static_pages/_travel_book.html.erb
+++ b/app/views/static_pages/_travel_book.html.erb
@@ -9,7 +9,7 @@
         <p>画面下部の「しおり検索」をクリックすると、公開設定されたしおりが一覧表示されます。</p>
         <p>「エリア」と「旅行スタイル」で絞り込み検索することができます。</p>
       </div>
-      <img class="w-40 md:w-64 rounded shadow mx-auto md:mx-0 md:flex-1" src="https://i.gyazo.com/ea9fafb6844f11e15fb53db77bc88301.png" alt="Image from Gyazo">
+      <img class="w-40 md:w-64 rounded shadow mx-auto md:mx-0 md:flex-1" src="https://i.gyazo.com/531c6abb99e79f3be8fe5bc28eafca1e.png" alt="Image from Gyazo">
     </div>
   </div>
 


### PR DESCRIPTION
# 概要
アプリの使い方ページのしおり検索説明の画像が壊れていたため修正しました。
<img src="https://i.gyazo.com/df76688edd41ebf6e5ba7f15606a93ef.png" width="50%">

## 実施内容
- [x] 画像の撮り直しと変更

## 未実施内容
なし

## 補足
なし

## 関連issue
#321