### PR TITLE
Feature/タイトルの動的変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def page_title(title = "")
+    base_title = "たびくりっぷ"
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
+
   def default_meta_tags
     {
       site: "たびくりっぷ",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,11 @@
 module ApplicationHelper
+  # タイトルの動的な変更
   def page_title(title = "")
     base_title = "たびくりっぷ"
     title.present? ? "#{title} | #{base_title}" : base_title
   end
 
+  # デフォルトのメタタグを設定
   def default_meta_tags
     {
       site: "たびくりっぷ",
@@ -11,7 +13,7 @@ module ApplicationHelper
       reverse: true,
       charset: "utf-8",
       description: "共有できる旅のしおり作成サービスです",
-      canonical: "request.original_url",
+      canonical: request.original_url,
       separator: "|",
       og: {
         site_name: :site,
@@ -30,9 +32,11 @@ module ApplicationHelper
     }
   end
 
+  # 背景色の出しわけ
   def backgtound_color_class
     controller_name == "home" ? "bg-primary" : "bg-base-200"
   end
+
   # ボトムナビゲーションのだしわけ判定
   def display_bottom_nav_on_travel_book
     return false if current_user.nil?
@@ -55,13 +59,13 @@ module ApplicationHelper
     controller_name == controller && action_name == action ? "text-white hover:scale-[1.1]" : "text-gray-500 hover:scale-[1.1]"
   end
 
-
   # 曜日をフォーマットする
   def fmt_wday(date)
     wdays = %w[日 月 火 水 木 金 土]
     "#{wdays[date.wday]}"
   end
 
+  # フラッシュメッセージの色変更
   def flash_message_color(type)
     case type.to_sym
     when :notice then "bg-green-300 text-green-600 border-green-500"

--- a/app/views/check_lists/edit.html.erb
+++ b/app/views/check_lists/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/check_lists/index.html.erb
+++ b/app/views/check_lists/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="m-5">
   <div class="max-w-screen-md mx-auto">
     <div class="flex gap-3">

--- a/app/views/check_lists/new.html.erb
+++ b/app/views/check_lists/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @check_list.title) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "たびくりっぷ" %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="m-5">
   <div class="max-w-screen-md mx-auto">
     <div class="flex gap-3">

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @note.title) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto flex-none md:flex md:max-w-none">
   <div class="bg-base-100 p-4 md:p-8 m-3 rounded-lg md:m-0 md:rounded-none md:shadow-md md:flex-1">
 

--- a/app/views/schedules/map.html.erb
+++ b/app/views/schedules/map.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div id="map-container" class="relative w-full h-[calc(100vh-64px-64px)]">
   <div id="map" class="w-full h-full"></div>
   <div id="popup" class="absolute bottom-[calc(64px+10px)] left-1/2 -translate-x-1/2"></div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 

--- a/app/views/static_pages/policy.html.erb
+++ b/app/views/static_pages/policy.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h1 class="text-lg font-bold text-center mb-4"><%= t(".title")%></h1>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h1 class="text-lg font-bold text-center mb-4"><%= t(".title")%></h1>

--- a/app/views/travel_books/bookmarks.html.erb
+++ b/app/views/travel_books/bookmarks.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-xl mx-auto">
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m-5">
     <%= render partial: "travel_books/travel_book", collection: @bookmark_travel_books, as: :travel_book %>

--- a/app/views/travel_books/edit.html.erb
+++ b/app/views/travel_books/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/travel_books/index.html.erb
+++ b/app/views/travel_books/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-xl mx-auto">
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m-5">
     <% if @travel_books.present? %>

--- a/app/views/travel_books/new.html.erb
+++ b/app/views/travel_books/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title")%></h2>

--- a/app/views/travel_books/public_travel_books.html.erb
+++ b/app/views/travel_books/public_travel_books.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-xl mx-auto">
   <div class="m-5 flex items-center">
     <%= search_form_for @q, url: public_travel_books_path, method: :get do |f| %>

--- a/app/views/travel_books/share.html.erb
+++ b/app/views/travel_books/share.html.erb
@@ -1,7 +1,8 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 
-    <h2 class="text-lg font-bold text-center">メンバー招待</h2>
+    <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>
     <div class="mt-5">
       <%= turbo_frame_tag "invite-link" do %>
         <% if @invite_link.present? %>

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @travel_book.title) %>
 <div class="max-w-screen-md mx-auto">
   <div class="card bg-base-100 shadow-md m-3 md:m-5">
     <figure>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
     <h2 class="text-lg font-bold text-center"><%= t(".title") %></h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="max-w-screen-md mx-auto">
   <div class="bg-base-100 rounded-lg shadow-md p-4 md:p-8 m-3 md:m-5">
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -92,12 +92,17 @@ ja:
         change_password: パスワードを再設定
         login_page: ログインページはこちら
     show:
+      title: マイページ
       profile_button: プロフィールを編集
   travel_books:
     index:
+      title: マイしおり一覧
       no_data: しおりがありません
       new_button: しおり作成
+    public_travel_books:
+      title: しおり検索
     show:
+      title: しおり情報
       duration: 期間
       total_amount: 合計金額
     new:
@@ -107,6 +112,10 @@ ja:
     my_travel_book:
       departure: 出発
       arrival: 到着
+    share:
+      title: メンバー招待
+    bookmarks:
+      title: ブックマーク一覧
     form:
       placeholder:
         title: 旅行のタイトルを記入
@@ -116,15 +125,19 @@ ja:
         false: 非公開
   schedules:
     index:
+      title: スケジュール
       new_button: スケジュール作成
       no_data: スケジュールを登録しましょう
       no_creator_no_data: スケジュールが登録されていません
     show:
+      title: スケジュール情報
       no_data: 場所が登録されていません
     new:
       title: スケジュール作成
     edit:
       title: スケジュール編集
+    map:
+      title: マップ
     form:
       placeholder:
         title: スケジュールのタイトルを記入
@@ -138,6 +151,7 @@ ja:
       no_memo: メモは登録されていません
   notes:
     index:
+      title: ノート一覧
       note_link: ノート
       check_list_link: チェックリスト
       new_button: ノート作成
@@ -152,6 +166,7 @@ ja:
         body: サイトのURLも貼ることができます
   check_lists:
     index:
+      title: チェックリスト一覧
       note_link: ノート
       check_list_link: チェックリスト
       new_button: チェックリスト作成


### PR DESCRIPTION
# 概要
タイトルを動的に変更する機能を実装しました。

## 実施内容
- [x] application_helperにpage_titleメソッドを追加
- [x] application.html.erbのtitleタグでpage_titleメソッドを使用するように修正
- [x] 各ページのページタイトル導入

## 未実施内容
- 画面遷移時の動的なタイトル変更(ページの再読み込みが必要)

## 補足
画面遷移した際に動的にページタイトルが変更されず画面を再起動しないとタイトルが表示されない状態です。
また以下の画面ではページの再読み込み後もタイトルが変更されない状態です。
- パスワード再設定画面
- しおりの招待への参加画面

スケジュールとの兼ね合いで、優先度を下げて別issueにて今後対処予定です。

## 関連issue
#325 