### PR TITLE
Update/スケジュール一覧の表示方法を修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -24,10 +24,20 @@
   display: contents;
 }
 
+/* アプリの使い方のタブ */
 .is-active {
   @apply rounded-full bg-primary text-sm py-2 px-5 cursor-pointer
 }
 
 .not-active {
   @apply text-sm py-2 px-5 cursor-pointer
+}
+
+/* スケジュールのタブ */
+#schedule_index .is-active {
+  @apply rounded-full bg-primary text-white text-sm py-2 px-5 cursor-pointer
+}
+
+#schedule_index .not-active {
+  @apply rounded-full bg-base-200 text-sm py-2 px-5 cursor-pointer
 }

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -3,10 +3,33 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="tabs"
 export default class extends Controller {
   static values = { spots: Array }
+  static targets = ["tab", "content"]
 
-  changeTab(event){
+  tabClick(event){
+    // GoogleMapにspot情報を渡す
     this.spotsValue = JSON.parse(event.target.getAttribute("data-tabs-spots-value"));
     window.spots = this.spotsValue;
     initMap();
+
+    const tabs = this.tabTargets // タブ全体の要素
+    const current = event.currentTarget // クリックしたタブの要素（現在地）
+    const currentIndex = tabs.indexOf(current) // クリックしたタブのインデックス番号
+    const contents = this.contentTargets // コンテンツ全体の要素
+
+    // 全てのタブを"not-active"にする
+    tabs.forEach(tab => {
+      tab.classList.remove("is-active");
+      tab.classList.add("not-active");
+    });
+
+    // クリックしたタブに"is-active"を付与
+    current.classList.add("is-active");
+    current.classList.remove("not-active");
+
+    // 全ての日程のスケジュール一覧を非表示にする
+    contents.forEach(content => content.style.display = "none");
+
+    // クリックされたタブと同じ日付のスケジュール一覧を表示する
+    contents[currentIndex].style.display = "block";
   }
 }

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,26 +1,24 @@
-<div class="max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg">
-  <table class="table">
-    <tbody>
-      <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule.uuid) %>">
-        <td class="w-2/6">
-          <%= fmt_datetime_range(schedule, :short) %>
-        </td>
-        <td class="w-3/6">
-          <% if schedule.schedule_icon.name == "none" %>
-            <i class="fa-solid fa-circle" style="visibility: hidden;"></i>
-          <% else %>
-            <i class="fa-solid <%= schedule.schedule_icon.name %>"></i>
-          <% end %>
-          <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule.uuid) %></span>
-        </td>
-        <td class="w-1/6">
-          <% if schedule.spot&.latitude %>
-            <div class="relative inline-block">
-              <i class="fa-solid fa-location-pin text-2xl text-red-500"></i>
-            </div>
-          <% end %>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+<table class="table">
+  <tbody>
+    <tr class="hover cursor-pointer" data-controller="link" data-action="click->link#go" data-url="<%= schedule_path(schedule.uuid) %>">
+      <td class="w-2/6">
+        <%= fmt_datetime_range(schedule, :short) %>
+      </td>
+      <td class="w-3/6">
+        <% if schedule.schedule_icon.name == "none" %>
+          <i class="fa-solid fa-circle" style="visibility: hidden;"></i>
+        <% else %>
+          <i class="fa-solid <%= schedule.schedule_icon.name %>"></i>
+        <% end %>
+        <span class="ml-2"><%= link_to schedule.title, schedule_path(schedule.uuid) %></span>
+      </td>
+      <td class="w-1/6">
+        <% if schedule.spot&.latitude %>
+          <div class="relative inline-block">
+            <i class="fa-solid fa-location-pin text-2xl text-red-500"></i>
+          </div>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -2,28 +2,33 @@
 <div class="max-w-screen-md mx-auto flex-none md:flex md:max-w-none">
   <div class="bg-base-100 p-4 md:p-8 m-3 rounded-lg md:m-0 md:rounded-none md:shadow-md md:flex-1">
 
-    <div class="flex flex-grow flex-col items-center">
+    <div class="flex flex-grow flex-col items-center mb-5">
       <h2 class="text-lg font-bold"><%= @travel_book.title %></h2>
       <p><%= travel_book_duration(@travel_book) %></p>
     </div>
     <% if @schedules.present? %>
-    <div data-controller="tabs">
-      <div role="tablist" class="tabs tabs-bordered overflow-x-scroll">
-        <% Schedule.group_by_date(@schedules).each_with_index do |(date, schedules),i| %>
-          <input type="radio" data-action="change->tabs#changeTab"
+
+    <div data-controller="tabs" id="schedule_index">
+      <div class="overflow-x-auto">
+        <div class="flex items-center flex-nowrap gap-1 min-w-max md:min-w-0">
+          <% Schedule.group_by_date(@schedules).each_with_index do |(date, schedules),i| %>
+            <a class="<%= i == 0 ? 'is-active' : 'not-active' %>" aria-current="page" data-tabs-target="tab"
             data-tabs-spots-value="<%= schedules.map(&:spot).compact.select { |spot| spot.latitude.present? }.to_json %>"
-            name="my_tabs_1" role="tab" class="tab" aria-label="<%= fmt_date_label(date) %>" <%= 'checked' if i == 0 %> />
-          <div role="tabpanel" class="tab-content md:p-3">
-            <% schedules.each_with_index do |schedule, i| %>
-              <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>
-            <% end %>
-            <div class="max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg">
-              <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(schedules)) %><%= t("helpers.currency_unit") %></p>
-            </div>
-          </div>
-        <% end %>
+            data-action="tabs#tabClick"><%= fmt_date_label(date) %></a>
+          <% end %>
+        </div>
       </div>
+
+      <% Schedule.group_by_date(@schedules).each_with_index do |(date, schedules),i| %>
+        <div class="m-3 md:m-5" data-tabs-target="content" style="<%= i == 0 ? 'display: block;' : 'display: none;' %>">
+          <% schedules.each_with_index do |schedule, i| %>
+            <%= render partial: "schedule", locals: { schedule: schedule, index: i } %>
+          <% end %>
+          <p class="text-right my-5"><%= t("helpers.total_amount", amount: total_budget(schedules)) %><%= t("helpers.currency_unit") %></p>
+        </div>
+      <% end %>
     </div>
+
     <% else %>
       <% if @travel_book.owned_by_user?(current_user) %>
         <p class="text-center mt-10"><%= t(".no_creator_no_data") %><br><%= t(".no_data") %></p>


### PR DESCRIPTION
# 概要
スケジュール一覧の表示方法を修正しました。
修正意図は後述の修正イメージの通りです。

## 実施内容
- [x] スケジュールの表示方法をstimulusでの実装に修正

### 修正イメージ
スケジュールの日付のタブが複数並んだ時にタブのみをスクロールしたかったため修正しました。

【修正前】
[![Image from Gyazo](https://i.gyazo.com/09053e93b5de3189f401f8fb9ed54d90.gif)](https://gyazo.com/09053e93b5de3189f401f8fb9ed54d90)

【修正後】
[![Image from Gyazo](https://i.gyazo.com/8b9d088e9353e7a90aee6bf08972ac7b.gif)](https://gyazo.com/8b9d088e9353e7a90aee6bf08972ac7b)

## 未実施内容

## 補足

## 関連issue
#330 