### PR TITLE
Refactor/ルーティングの整理

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,0 @@
-class HomeController < ApplicationController
-  skip_before_action :authenticate_user!
-  def index
-  end
-end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,7 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
+  def top; end
+
   def form; end
 
   def policy; end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -61,6 +61,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # プロフィール編集後にマイページにリダイレクトする
   def after_update_path_for(resource)
-    users_profile_path
+    profile_path
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,11 +20,6 @@ class Users::SessionsController < Devise::SessionsController
 
   # protected
 
-  # ログアウト後のリダイレクト先
-  def after_sign_out_path_for(resource)
-    home_index_path
-  end
-
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,13 +34,13 @@ module ApplicationHelper
 
   # 背景色の出しわけ
   def backgtound_color_class
-    controller_name == "home" ? "bg-primary" : "bg-base-200"
+    request.path == root_path ? "bg-primary" : "bg-base-200"
   end
 
   # ボトムナビゲーションのだしわけ判定
   def display_bottom_nav_on_travel_book
     return false if current_user.nil?
-    return false if controller_name == "home"
+    return false if request.path == root_path
     (controller_name == "travel_books" && action_name == "show" && current_user.travel_books.exists?(uuid: params[:uuid]))||
     (controller_name == "schedules")||
     (controller_name == "notes") ||

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,0 @@
-module HomeHelper
-end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,0 @@
-<div class="flex flex-col items-center  justify-center min-h-[calc(100vh-64px-100px)] bg-primary">
-  <%= image_tag "logo.svg", class: "w-[400px] md:w-[500px] lg:w-[600px]", alt: "logo" %>
-  <p class="text-white mb-10">共有できる旅行のしおり投稿サービス</p>
-</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,10 +42,10 @@
     </main>
     <% if user_signed_in? && display_bottom_nav_on_travel_book %>
       <%= render "shared/bottom_navigation_on_travel_book", travel_book: @travel_book %>
-    <% elsif controller_name != "home" %>
+    <% elsif request.path != root_path %>
       <%= render "shared/bottom_navigation" %>
     <% end %>
-    <% if controller_name == "home" %>
+    <% if request.path == root_path %>
       <%= render "shared/footer" %>
     <% end %>
   </body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,13 +16,13 @@
           <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 flex flex-col">
             <% if user_signed_in? %>
               <li>
-                <%= link_to users_profile_path do %>
+                <%= link_to profile_path do %>
                   <%= image_tag current_user.icon_image_url, class: "rounded-full w-10 h-10 object-cover border" %><%= current_user.name %>
                 <% end %>
               </li>
               <div class="divider"></div>
               <li>
-                <%= link_to users_profile_path do %>
+                <%= link_to profile_path do %>
                   <i class="fa-regular fa-user"></i><%= t("header.mypage") %>
                 <% end %>
               </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-primary shadow-sm">
   <div class="flex-1 px-2 lg:flex-none">
-    <%= link_to home_index_path, class: "hover:opacity-50" do %>
+    <%= link_to user_signed_in? ? travel_books_path : root_path, class: "hover:opacity-50" do %>
       <%= image_tag "logo.svg", class: "w-40", alt: "logo" %>
     <% end %>
   </div>

--- a/app/views/static_pages/_check_list.html.erb
+++ b/app/views/static_pages/_check_list.html.erb
@@ -47,7 +47,7 @@
       <div class="md:flex-1 text-sm md:text-base space-y-2 md:space-y-4">
         <p>2. LINEアカウント連携</p>
         <p>※LINEログインを利用されている方は不要です。<br>LINEログインを利用していない場合に以下の手順を実行してください。</p>
-        <p>① <%= link_to "マイページ", users_profile_path, class:"link link-primary" %>を確認します。</p>
+        <p>① <%= link_to "マイページ", profile_path, class:"link link-primary" %>を確認します。</p>
         <p>② 「LINEアカウント連携」をクリックします。</p>
         <p>③ 「LINEアカウント連携用トークン」をコピーします。</p>
         <p>④ コピーした「LINEアカウント連携用トークン」をたびくりっぷ公式LINEに送信します。</p>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,4 @@
+<div class="flex flex-col items-center justify-center min-h-[calc(100vh-64px-100px)] bg-primary">
+  <%= image_tag "logo.svg", class: "w-[400px] md:w-[500px] lg:w-[600px]", alt: "logo" %>
+  <p class="text-white mb-10">共有できる旅行のしおり投稿サービスです</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,48 +13,42 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks",
     invitations: "users/invitations"
   }
-  post "/callback" => "linebot#callback"
+
+  post "/callback", to: "linebot#callback"
   get "profile", to: "users#show"
   get "form", to: "static_pages#form"
   get "policy", to: "static_pages#policy"
   get "terms", to: "static_pages#terms"
   get "how_to_use", to: "static_pages#how_to_use"
   get "images/ogp.png", to: "images#ogp", as: "images_ogp"
+
   resources :travel_books, param: :uuid do
     collection do
       get "public", action: :public_travel_books
-      get "search"
+      get :search
       get :bookmarks
     end
     member do
       get :share
-      post "invitation"
+      post :invitation
       get "invitation/accept/:invitation_token", to: "travel_books#accept", as: "accept"
-      delete "delete_owner"
+      delete :delete_owner
+      delete :delete_image
     end
-    delete "delete_image", on: :member
     resources :schedules, param: :uuid, shallow: true do
-      collection do
-        get :map
-      end
+      get :map, on: :collection
     end
+    resources :notes, param: :uuid, shallow: true
     resources :check_lists, param: :uuid, shallow: true do
       resources :list_items, only: %i[ new create edit update destroy toggle ] do
         resources :reminders, only: %i[ create update clear_reminder ] do
-          member do
-            patch :clear_reminder
-          end
+          patch :clear_reminder, on: :member
         end
-        collection do
-          post :cancel # new 用
-        end
-        member do
-          post :cancel # edit 用
-          patch :toggle
-        end
+        post :cancel, on: :collection
+        post :cancel, on: :member
+        patch :toggle, on: :member
       end
     end
-    resources :notes, param: :uuid, shallow: true
   end
   resources :bookmarks, only: %i[ create destroy ]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     invitations: "users/invitations"
   }
   post "/callback" => "linebot#callback"
-  get "users/profile" => "users#show"
+  get "profile" to: "users#show"
   get "home/index"
   get "form", to: "static_pages#form"
   get "policy", to: "static_pages#policy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,7 @@ Rails.application.routes.draw do
     invitations: "users/invitations"
   }
   post "/callback" => "linebot#callback"
-  get "profile" to: "users#show"
-  get "home/index"
+  get "profile", to: "users#show"
   get "form", to: "static_pages#form"
   get "policy", to: "static_pages#policy"
   get "terms", to: "static_pages#terms"
@@ -70,5 +69,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "home#index"
+  root "static_pages#top"
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class HomeControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get home_index_url
-    assert_response :success
-  end
-end


### PR DESCRIPTION
# 概要
ルーティングの記法を統一し可読性を高めました。

## 実施内容
- [x] プロフィール画面のルーティング修正(`users#profile`)
- [x] topページをstatic_pages_controllerに移行(`static_pages#top`)し、root_pathに設定
- [x] ルーティングの記法を統一

## 未実施内容
なし

## 補足
`collection do end`, `member do end`が見づらい箇所は`on: :collection`, `on: :member`の書き方に変更しました。

## 関連issue
#334 