### PR TITLE
Feature/スケジュールに画像を添付する機能

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -77,7 +77,9 @@ class SchedulesController < ApplicationController
       :telephone,
       :post_code,
       :address,
-      :schedule_icon_id
+      :schedule_icon_id,
+      :schedule_image,
+      :schedule_image_cache
     ).merge(
       travel_book_id: @travel_book.id
     )

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,5 @@
 class Schedule < ApplicationRecord
+  mount_uploader :schedule_image, ScheduleUploader
   belongs_to :travel_book
   has_one :spot, dependent: :destroy
   belongs_to :schedule_icon, optional: true

--- a/app/uploaders/schedule_uploader.rb
+++ b/app/uploaders/schedule_uploader.rb
@@ -1,0 +1,60 @@
+class ScheduleUploader < CarrierWave::Uploader::Base
+  # Include RMagick, MiniMagick, or Vips support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+  # include CarrierWave::Vips
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  # storage :fog
+  # 本番環境と開発・テスト環境で保存先を分ける
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+  process resize_to_limit: [ 1000, nil ]
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+  def extension_allowlist
+    %w[ jpg jpeg gif png heic webp ]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+  # WebPに変換
+  process convert: "webp"
+end

--- a/app/views/check_lists/show.html.erb
+++ b/app/views/check_lists/show.html.erb
@@ -42,4 +42,5 @@
       </div>
     </div>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -55,6 +55,15 @@
     </div>
 
     <div>
+      <%= f.label :schedule_image, Schedule.human_attribute_name(:schedule_image), class: "label-text" %>
+      <%= f.file_field :schedule_image, accept: "image/*", class: "file-input file-input-bordered w-full" %>
+      <%= f.hidden_field :schedule_image_cache %>
+      <% if @schedule.persisted? && @schedule.schedule_image.present? %>
+        <%= @schedule.schedule_image_identifier %>
+      <% end %>
+    </div>
+
+    <div>
       <%= f.label :schedule_icon_id, ScheduleIcon.human_attribute_name(:name), class: "label-text" %>
       <div class="flex flex-wrap gap-x-3 gap-y-2">
         <% ScheduleIcon.all.each do |icon| %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -31,5 +31,10 @@
         </li>
       </ul>
     </div>
+
+    <% if @schedule.schedule_image_url.present? %>
+      <%= image_tag @schedule.schedule_image_url, class: "max-h-96 mx-auto md:mx-0" %>
+    <% end %>
   </div>
+  <div class="h-24"></div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -34,6 +34,7 @@ ja:
         memo: メモ
         start_date: 開始時刻
         end_date: 終了時刻
+        schedule_image: 画像
       schedule_icon:
         name: アイコン
       spot:

--- a/db/migrate/20250411220032_add_schedule_image_to_schedules.rb
+++ b/db/migrate/20250411220032_add_schedule_image_to_schedules.rb
@@ -1,0 +1,5 @@
+class AddScheduleImageToSchedules < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schedules, :schedule_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_06_095246) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_11_220032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_06_095246) do
     t.datetime "updated_at", null: false
     t.integer "schedule_icon_id"
     t.bigint "travel_book_id", null: false
+    t.string "schedule_image"
     t.index ["travel_book_id"], name: "index_schedules_on_travel_book_id"
     t.index ["uuid"], name: "index_schedules_on_uuid", unique: true
   end


### PR DESCRIPTION
# 概要
スケジュールに画像を1枚添付できるように機能追加しました。

## 実施内容
- [x] スケジュールに添付する画像用カラム追加
- [x] uploader追加
- [x] ストロングパラメータに画像用パラメータ追加
- [x] modelとformObjectにuploaderをマウント
- [x] アップロードフォーム追加
- [x] 画像の表示領域を追加
- [x] check_lists#showアクションのビュー修正

## 未実施内容
- 本番環境での確認

## 補足
- 実際に使っていただいたユーザーの声を元に、スケジュールに画像を添付できるように機能を追加しました。
- チェックリストにリストアイテムを複数登録したときに画面が隠れる問題があったため、`<div class="h-24"></div>`を含めた応急処置を行いました。

## 関連issue
#337 