### PR TITLE
Fix/スケジュールが新規投稿できない問題の修正

### DIFF
--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -58,9 +58,6 @@
       <%= f.label :schedule_image, Schedule.human_attribute_name(:schedule_image), class: "label-text" %>
       <%= f.file_field :schedule_image, accept: "image/*", class: "file-input file-input-bordered w-full" %>
       <%= f.hidden_field :schedule_image_cache %>
-      <% if @schedule.persisted? && @schedule.schedule_image.present? %>
-        <%= @schedule.schedule_image_identifier %>
-      <% end %>
     </div>
 
     <div>


### PR DESCRIPTION
# 概要
#338 の修正により、スケジュールの新規登録ができない状態になったため修正

## 実施内容
- [ ] persisted?メソッドを削除

## 未実施内容
なし

## 補足
なし

## 関連issue
#338 , #337 