### PR TITLE
Update/ヘッダーのドロップダウンメニューボタンの色を変更

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
       <div class="drawer drawer-end z-50">
         <input id="my-drawer" type="checkbox" class="drawer-toggle" />
         <div class="drawer-content">
-          <label for="my-drawer" class="drawer-button btn btn-primary text-white"><i class="fa-solid fa-bars"></i></label>
+          <label for="my-drawer" class="drawer-button btn text-gray-500"><i class="fa-solid fa-bars"></i></label>
         </div>
         <div class="drawer-side">
           <label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>


### PR DESCRIPTION
# 概要
ヘッダーのドロップダウンメニューが背景色に埋もれてわかりづらいとのフィードバックをいただいたため
ボタンの背景色を変更しました。

## 実施内容
- [x] ボタンの色を変更

### 修正イメージ
【修正前】
<a href="https://gyazo.com/f2c0e3f268fe801ccab8de11ec5100d8"><img src="https://i.gyazo.com/f2c0e3f268fe801ccab8de11ec5100d8.png" alt="Image from Gyazo" width="387"/></a>

【修正後】
<a href="https://gyazo.com/f5103397362c0e061885e4bbbc58239e"><img src="https://i.gyazo.com/f5103397362c0e061885e4bbbc58239e.png" alt="Image from Gyazo" width="391"/></a>

## 未実施内容
なし

## 補足

## 関連issue
なし