### PR TITLE
Fix/スケジュール開始・終了日時のtimezone変換処理をformObjectへ移行

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -20,8 +20,6 @@ class SchedulesController < ApplicationController
   def create
     @schedule_form = ScheduleForm.new(schedule_params)
 
-    convert_to_jst(schedule_params[:start_date], schedule_params[:end_date])
-
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
     else
@@ -40,8 +38,6 @@ class SchedulesController < ApplicationController
   def update
     @spot = @schedule.spot
     @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
-
-    convert_to_jst(schedule_params[:start_date], schedule_params[:end_date])
 
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
@@ -92,11 +88,5 @@ class SchedulesController < ApplicationController
   def set_schedule
     @schedule = Schedule.find_by(uuid: params[:uuid])
     @travel_book = @schedule.travel_book
-  end
-
-  # config.time_zoneで設定されたタイムゾーンに変換
-  def convert_to_jst(start_date, end_date)
-    @schedule_form.start_date = Time.zone.parse(start_date) unless start_date.nil?
-    @schedule_form.end_date = Time.zone.parse(end_date) unless end_date.nil?
   end
 end

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -2,6 +2,9 @@ class ScheduleForm
   include ActiveModel::Model # 通常のモデルのようにvalidationなどを使えるようにする
   include ActiveModel::Attributes # ActiveRecordのカラムのような属性を加えられるようにする
   extend CarrierWave::Mount # モデル以外でCarrierWaveを使用するため
+  include ActiveModel::Validations::Callbacks # コールバック(before_validation)を使えるようにする
+
+  before_validation :convert_to_local_timezone
 
   # パラメータの読み書きを許可する
   attribute :travel_book_id, :integer
@@ -17,6 +20,8 @@ class ScheduleForm
   attribute :schedule_icon_id, :integer
   attribute :schedule_image, :string
   attribute :schedule_image_cache, :string
+
+  attr_reader :schedule, :spot
 
   validates :travel_book_id, presence: true
   validates :title, presence: true, length: { maximum: 255 }
@@ -86,8 +91,6 @@ class ScheduleForm
 
   private
 
-  attr_reader :schedule, :spot
-
   def default_attributes(travel_book)
     {
       title: schedule.title,
@@ -103,6 +106,12 @@ class ScheduleForm
       schedule_image: schedule.schedule_image,
       schedule_image_cache: schedule.schedule_image_cache
     }
+  end
+
+  # config.time_zoneで設定されたタイムゾーンに変換
+  def convert_to_local_timezone
+    self.start_date = Time.zone.parse(start_date.to_s) if start_date.present?
+    self.end_date = Time.zone.parse(end_date.to_s) if end_date.present?
   end
 
   def end_date_after_start_date


### PR DESCRIPTION
# 概要
スケジュールの開始・終了時刻を保存する前に行なっていたタイムゾーンの変換処理を
コントローラーからフォームオブジェクトへ移行しました。

## 実施内容
- [x] schedule_formでconvert_to_local_timezoneメソッドを定義
- [x] schedules_controllerのconvert_to_jstメソッドを削除

## 未実施内容
なし

## 補足
schedule_formでbefore_validateを使用するためにActiveModel::Validations::Callbacksモジュールをincludeしました。

## 関連issue
ー