### PR TITLE
Fix/スケジュール開始・終了日時のタイムゾーン変換処理をコントローラーへ移行#364の修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -18,7 +18,8 @@ class SchedulesController < ApplicationController
   end
 
   def create
-    @schedule_form = ScheduleForm.new(schedule_params)
+    parsed_schedule_params = parse_datetime(schedule_params)
+    @schedule_form = ScheduleForm.new(parsed_schedule_params)
 
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
@@ -36,8 +37,9 @@ class SchedulesController < ApplicationController
   end
 
   def update
+    parsed_schedule_params = parse_datetime(schedule_params)
     @spot = @schedule.spot
-    @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
+    @schedule_form = ScheduleForm.new(parsed_schedule_params, schedule: @schedule, spot: @spot)
 
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
@@ -61,6 +63,14 @@ class SchedulesController < ApplicationController
   end
 
   private
+
+  # paramsで受け取った日時をconfig.time_zoneで設定されたタイムゾーンに変換
+  def parse_datetime(params)
+    params.merge(
+      start_date: params[:start_date].present? ? Time.zone.parse(params[:start_date]) : nil,
+      end_date: params[:end_date].present? ? Time.zone.parse(params[:end_date]) : nil,
+    )
+  end
 
   def schedule_params
     params.require(:schedule_form).permit(

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -2,9 +2,6 @@ class ScheduleForm
   include ActiveModel::Model # 通常のモデルのようにvalidationなどを使えるようにする
   include ActiveModel::Attributes # ActiveRecordのカラムのような属性を加えられるようにする
   extend CarrierWave::Mount # モデル以外でCarrierWaveを使用するため
-  include ActiveModel::Validations::Callbacks # コールバック(before_validation)を使えるようにする
-
-  before_validation :convert_to_local_timezone
 
   # パラメータの読み書きを許可する
   attribute :travel_book_id, :integer
@@ -106,12 +103,6 @@ class ScheduleForm
       schedule_image: schedule.schedule_image,
       schedule_image_cache: schedule.schedule_image_cache
     }
-  end
-
-  # config.time_zoneで設定されたタイムゾーンに変換
-  def convert_to_local_timezone
-    self.start_date = Time.zone.parse(start_date.to_s) if start_date.present?
-    self.end_date = Time.zone.parse(end_date.to_s) if end_date.present?
   end
 
   def end_date_after_start_date


### PR DESCRIPTION
# 概要
#364 にてformObjectでparseする方法に変更しましたが、本番環境で時間のずれの問題が発生したため
コントローラー側でformObjectにparamsを渡す前にparseする方法に修正しました。

## 実施内容
- [x] schedules_controllerでformObjectにparamsを渡す際にparseしてから渡すように修正
- parse_datetimeメソッドを定義

## 未実施内容
本番環境での確認

## 補足
formObjectのattributeでdatetimeを指定しており、datetimeでタイムゾーン情報がない場合、システムタイムゾーン(utc)に変換されていた。
```
attribute :start_date, :datetime
attribute :end_date, :datetime
```
そのため、formObjectでparseするには以下の対応をする方法しか辿り着けなかった。
- attributeのdatetimeをstring型にする
- formObject内でbefore_validationの際にparse
- ビューで表示する際にparseした日時を表示
- default_attributesで既存のscheduleがない場合、travel_bookのstart_dateをparseして12時にする

## 関連issue
#364 