### PR TITLE
WIP/datetime_fieldをdatetime_local_filedに修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -18,8 +18,9 @@ class SchedulesController < ApplicationController
   end
 
   def create
-    parsed_schedule_params = parse_datetime(schedule_params)
-    @schedule_form = ScheduleForm.new(parsed_schedule_params)
+    @schedule_form = ScheduleForm.new(schedule_params)
+    # parsed_schedule_params = parse_datetime(schedule_params)
+    # @schedule_form = ScheduleForm.new(parsed_schedule_params)
 
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
@@ -37,9 +38,9 @@ class SchedulesController < ApplicationController
   end
 
   def update
-    parsed_schedule_params = parse_datetime(schedule_params)
+    # parsed_schedule_params = parse_datetime(schedule_params)
     @spot = @schedule.spot
-    @schedule_form = ScheduleForm.new(parsed_schedule_params, schedule: @schedule, spot: @spot)
+    @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
 
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
@@ -65,12 +66,12 @@ class SchedulesController < ApplicationController
   private
 
   # paramsで受け取った日時をconfig.time_zoneで設定されたタイムゾーンに変換
-  def parse_datetime(params)
-    params.merge(
-      start_date: params[:start_date].present? ? Time.zone.parse(params[:start_date]) : nil,
-      end_date: params[:end_date].present? ? Time.zone.parse(params[:end_date]) : nil,
-    )
-  end
+  # def parse_datetime(params)
+  #   params.merge(
+  #     start_date: params[:start_date].present? ? Time.zone.parse(params[:start_date]) : nil,
+  #     end_date: params[:end_date].present? ? Time.zone.parse(params[:end_date]) : nil,
+  #   )
+  # end
 
   def schedule_params
     params.require(:schedule_form).permit(

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -15,12 +15,12 @@
       <div class="flex flex-col sm:flex-row sm:gap-2">
         <div class="w-full">
           <%= f.label :start_date, Schedule.human_attribute_name(:start_date), class: "label-text" %>
-          <%= f.datetime_field :start_date, class: "input input-bordered w-full", autocomplete: "off",
+          <%= f.datetime_local_field :start_date, class: "input input-bordered w-full", autocomplete: "off",
           data: { input_datetime_target: "startDate", action: "input-datetime#copyStartToEnd" } %>
         </div>
         <div class="w-full">
           <%= f.label :end_date, Schedule.human_attribute_name(:end_date), class: "label-text" %>
-          <%= f.datetime_field :end_date, class: "input input-bordered w-full", autocomplete: "off",
+          <%= f.datetime_local_field :end_date, class: "input input-bordered w-full", autocomplete: "off",
           data: { input_datetime_target: "endDate" } %>
         </div>
       </div>


### PR DESCRIPTION
# 概要
datetime_fieldをdatetime_local_filedに修正しました。

## 実施内容
- [x] datetime_fieldをdatetime_local_filedに修正
- [x] parse_datetimeメソッド(コントローラー内のTime.zone.parseの処理)をコメントアウト

## 未実施内容
- 本番環境での確認

## 補足
日時入力時のフォームヘルパーとしてdatetime_local_filedが推奨されるため修正しました。

Railsガイド：
https://railsguides.jp/v7.2/form_helpers.html#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E3%83%98%E3%83%AB%E3%83%91%E3%83%BC

## 関連issue
#365 