### PR TITLE
Fix/schedules_controllerでTime.zone.parse処理を復活#366の修正

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -18,9 +18,8 @@ class SchedulesController < ApplicationController
   end
 
   def create
-    @schedule_form = ScheduleForm.new(schedule_params)
-    # parsed_schedule_params = parse_datetime(schedule_params)
-    # @schedule_form = ScheduleForm.new(parsed_schedule_params)
+    parsed_schedule_params = parse_datetime(schedule_params)
+    @schedule_form = ScheduleForm.new(parsed_schedule_params)
 
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
@@ -38,9 +37,9 @@ class SchedulesController < ApplicationController
   end
 
   def update
-    # parsed_schedule_params = parse_datetime(schedule_params)
+    parsed_schedule_params = parse_datetime(schedule_params)
     @spot = @schedule.spot
-    @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
+    @schedule_form = ScheduleForm.new(parsed_schedule_params, schedule: @schedule, spot: @spot)
 
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
@@ -66,12 +65,12 @@ class SchedulesController < ApplicationController
   private
 
   # paramsで受け取った日時をconfig.time_zoneで設定されたタイムゾーンに変換
-  # def parse_datetime(params)
-  #   params.merge(
-  #     start_date: params[:start_date].present? ? Time.zone.parse(params[:start_date]) : nil,
-  #     end_date: params[:end_date].present? ? Time.zone.parse(params[:end_date]) : nil,
-  #   )
-  # end
+  def parse_datetime(params)
+    params.merge(
+      start_date: params[:start_date].present? ? Time.zone.parse(params[:start_date]) : nil,
+      end_date: params[:end_date].present? ? Time.zone.parse(params[:end_date]) : nil,
+    )
+  end
 
   def schedule_params
     params.require(:schedule_form).permit(


### PR DESCRIPTION
# 概要
datetime_fieldからdatetime_local_filedへの修正に伴い、controllerでTime.zone.parse処理をコメントアウトしていたが
config.time_zoneで指定したタイムゾーンへの変換がされなかったため
コントローラー内のparse_datetimeメソッドを復活させました。

## 実施内容
- [x] コントローラー内のparse_datetimeメソッドを復活

## 未実施内容
- 本番環境での確認

## 補足
datetime_fieldからdatetime_local_filedへの修正に伴い、controllerでTime.zone.parse処理をせずに
データがどう処理されるか確認したが、`config.time_zone`で設定しているJSTに変換されないことを確認したため
コントローラー内のparse_datetimeメソッドを復活させました。

## 関連issue
#366 