### PR TITLE
Fix/日時変換処理をフォームオブジェクトへ移行

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -18,8 +18,7 @@ class SchedulesController < ApplicationController
   end
 
   def create
-    parsed_schedule_params = parse_datetime(schedule_params)
-    @schedule_form = ScheduleForm.new(parsed_schedule_params)
+    @schedule_form = ScheduleForm.new(schedule_params)
 
     if @schedule_form.save
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.created", item: Schedule.model_name.human)
@@ -37,9 +36,8 @@ class SchedulesController < ApplicationController
   end
 
   def update
-    parsed_schedule_params = parse_datetime(schedule_params)
     @spot = @schedule.spot
-    @schedule_form = ScheduleForm.new(parsed_schedule_params, schedule: @schedule, spot: @spot)
+    @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
 
     if @schedule_form.update(schedule_params)
       redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.updated", item: Schedule.model_name.human)
@@ -63,14 +61,6 @@ class SchedulesController < ApplicationController
   end
 
   private
-
-  # paramsで受け取った日時をconfig.time_zoneで設定されたタイムゾーンに変換
-  def parse_datetime(params)
-    params.merge(
-      start_date: params[:start_date].present? ? Time.zone.parse(params[:start_date]) : nil,
-      end_date: params[:end_date].present? ? Time.zone.parse(params[:end_date]) : nil,
-    )
-  end
 
   def schedule_params
     params.require(:schedule_form).permit(

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -86,6 +86,15 @@ class ScheduleForm
     false
   end
 
+  # attributeのオーバーライド
+  def start_date=(value)
+    super(value.present? ? Time.zone.parse(value.to_s) : nil)
+  end
+
+  def end_date=(value)
+    super(value.present? ? Time.zone.parse(value.to_s) : nil)
+  end
+
   private
 
   def default_attributes(travel_book)


### PR DESCRIPTION
# 概要
今までコントローラーで行っていた日時の変換処理をフォームオブジェクトへ移行しました。

## 実施内容
- [x] フォームオブジェクト内でカスタムセッターを定義
- [x] コントローラー内の日時変換を行う独自メソッド(`parse_datetime`)の削除

## 未実施内容
- 本番環境での確認

## 補足
なし

## 関連issue
#370 