### PR TITLE
Feature/認可機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem "devise"
 # 招待機能
 gem "devise_invitable"
 
+# 認可
+gem "pundit"
+
 # LINEログイン
 gem "omniauth-line"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,8 @@ GEM
     public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
+    pundit (2.5.0)
+      activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
@@ -508,6 +510,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)
+  pundit
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
   ransack

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  include Pundit::Authorization
   allow_browser versions: :modern
 
   before_action :authenticate_user!

--- a/app/controllers/check_lists_controller.rb
+++ b/app/controllers/check_lists_controller.rb
@@ -22,6 +22,7 @@ class CheckListsController < ApplicationController
   end
 
   def show
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     # 必ずlist_itemにreminderが紐づく
     @list_items = @check_list.list_items.order(created_at: :asc).map do |list_item|
       list_item.reminder || list_item.build_reminder
@@ -30,9 +31,12 @@ class CheckListsController < ApplicationController
   end
 
 
-  def edit; end
+  def edit
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
+  end
 
   def update
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     if @check_list.update(check_list_param)
       redirect_to check_list_path(@check_list.uuid), notice: t("defaults.flash_message.updated", item: CheckList.model_name.human)
     else
@@ -42,6 +46,7 @@ class CheckListsController < ApplicationController
   end
 
   def destroy
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     @check_list.destroy!
     redirect_to travel_book_check_lists_path(@travel_book.uuid), notice: t("defaults.flash_message.deleted", item: CheckList.model_name.human)
   end
@@ -49,11 +54,11 @@ class CheckListsController < ApplicationController
   private
 
   def set_travel_book
-    @travel_book = current_user.travel_books.find_by(uuid: params[:travel_book_uuid])
+    @travel_book = current_user.travel_books.find_by!(uuid: params[:travel_book_uuid])
   end
 
   def set_check_list
-    @check_list = CheckList.find_by(uuid: params[:uuid])
+    @check_list = CheckList.find_by!(uuid: params[:uuid])
     @travel_book = @check_list.travel_book
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -20,11 +20,16 @@ class NotesController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
+  end
 
-  def edit; end
+  def edit
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
+  end
 
   def update
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     if @note.update(note_params)
       redirect_to note_path(@note.uuid), notice: t("defaults.flash_message.updated", item: Note.model_name.human)
     else
@@ -34,6 +39,7 @@ class NotesController < ApplicationController
   end
 
   def destroy
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     @note.destroy
     redirect_to travel_book_notes_path(@travel_book.uuid), notice: t("defaults.flash_message.deleted", item: Note.model_name.human)
   end
@@ -41,11 +47,11 @@ class NotesController < ApplicationController
   private
 
   def set_travel_book
-    @travel_book = current_user.travel_books.find_by(uuid: params[:travel_book_uuid])
+    @travel_book = current_user.travel_books.find_by!(uuid: params[:travel_book_uuid])
   end
 
   def set_note
-    @note = Note.find_by(uuid: params[:uuid])
+    @note = Note.find_by!(uuid: params[:uuid])
     @travel_book = @note.travel_book
   end
 

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -31,7 +31,7 @@ class SchedulesController < ApplicationController
   end
 
   def show
-    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
+    authorize(@travel_book, policy_class: SchedulePolicy)
   end
 
   def edit

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -4,6 +4,7 @@ class SchedulesController < ApplicationController
   before_action :set_schedule, only: %i[ show edit update destroy ]
 
   def index
+    authorize(@travel_book, policy_class: SchedulePolicy)
     # scheduleには0以上のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
     # スケジュール一覧では初日を初期表示するためindexでは初日のデータのみ取得する
     @schedules = @travel_book.sorted_schedules
@@ -14,6 +15,7 @@ class SchedulesController < ApplicationController
   end
 
   def new
+    authorize(@travel_book, policy_class: SchedulePolicy)
     @schedule_form = ScheduleForm.new(travel_book: @travel_book)
   end
 
@@ -28,14 +30,18 @@ class SchedulesController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
+  end
 
   def edit
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     @spot = @schedule.spot
     @schedule_form = ScheduleForm.new(schedule: @schedule, spot: @spot)
   end
 
   def update
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     @spot = @schedule.spot
     @schedule_form = ScheduleForm.new(schedule_params, schedule: @schedule, spot: @spot)
 
@@ -48,11 +54,13 @@ class SchedulesController < ApplicationController
   end
 
   def destroy
+    authorize(@travel_book, policy_class: TravelBookOwnerPolicy)
     @schedule.destroy!
     redirect_to travel_book_schedules_path(@travel_book.uuid), notice: t("defaults.flash_message.deleted", item: Schedule.model_name.human)
   end
 
   def map
+    authorize(@travel_book, policy_class: SchedulePolicy)
     @schedules = @travel_book.sorted_schedules
     # scheduleには0もしくは1のspotがひも付くため、spotが紐づいていて緯度情報が存在するもののみ格納する
     @spots = @schedules
@@ -82,11 +90,11 @@ class SchedulesController < ApplicationController
   end
 
   def set_travel_book
-    @travel_book = TravelBook.find_by(uuid: params[:travel_book_uuid])
+    @travel_book = TravelBook.find_by!(uuid: params[:travel_book_uuid])
   end
 
   def set_schedule
-    @schedule = Schedule.find_by(uuid: params[:uuid])
+    @schedule = Schedule.find_by!(uuid: params[:uuid])
     @travel_book = @schedule.travel_book
   end
 end

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -8,8 +8,6 @@ export default class extends Controller {
   tabClick(event){
     // GoogleMapにspot情報を渡す
     this.spotsValue = JSON.parse(event.target.getAttribute("data-tabs-spots-value"));
-    console.log("click")
-    console.log(this.spotsValue)
     window.spots = this.spotsValue;
     initMap();
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/schedule_policy.rb
+++ b/app/policies/schedule_policy.rb
@@ -4,6 +4,10 @@ class SchedulePolicy < ApplicationPolicy
     record.is_public || record.owned_by_user?(user)
   end
 
+  def show?
+    index?
+  end
+
   def new?
     # しおりの所有者のみ操作可能
     record.owned_by_user?(user)

--- a/app/policies/schedule_policy.rb
+++ b/app/policies/schedule_policy.rb
@@ -1,0 +1,15 @@
+class SchedulePolicy < ApplicationPolicy
+  def index?
+    # 非公開のしおりのスケジュールは所有者のみ閲覧可能
+    record.is_public || record.owned_by_user?(user)
+  end
+
+  def new?
+    # しおりの所有者のみ操作可能
+    record.owned_by_user?(user)
+  end
+
+  def map?
+    index?
+  end
+end

--- a/app/policies/travel_book_owner_policy.rb
+++ b/app/policies/travel_book_owner_policy.rb
@@ -1,0 +1,18 @@
+class TravelBookOwnerPolicy < ApplicationPolicy
+  def show?
+    # 所有者のみ閲覧可能
+    record.owned_by_user?(user)
+  end
+
+  def edit?
+    show?
+  end
+
+  def update?
+    show?
+  end
+
+  def destroy?
+    show?
+  end
+end

--- a/app/policies/travel_book_policy.rb
+++ b/app/policies/travel_book_policy.rb
@@ -1,0 +1,34 @@
+class TravelBookPolicy < ApplicationPolicy
+  def show?
+    # 非公開のしおりは所有者のみ閲覧可能
+    record.is_public or record.owned_by_user?(user)
+  end
+
+  def edit?
+    record.owned_by_user?(user)
+  end
+
+  def update?
+    edit?
+  end
+
+  def destroy?
+    edit?
+  end
+
+  def delete_image?
+    edit?
+  end
+
+  def share?
+    edit?
+  end
+
+  def delete_owner?
+    edit?
+  end
+
+  def invitation?
+    edit?
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,8 @@ module Myapp
 
     config.i18n.default_locale = :ja
     config.time_zone = "Tokyo"
+
+    # 例外を403にする(デフォルトでは500になる)
+    config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
   end
 end


### PR DESCRIPTION
# 概要
gem Punditを導入し、認可の機能を実装しました。

## 実施内容
- [x] gem punditインストール
- [x] ApplicationControllerでPunditをinclude
- [x] generator(`rails g pundit:install`)でapplication_policy.rb作成
- [x] `Pundit::NotAuthorizedError`を403エラーに設定
- [x] TravelBookPolicyを設定
  - 非公開のしおりは所有者のみ閲覧可能
  - しおりの編集削除等は所有者のみ可能
- [x] SchedulePolicyを設定
  - 非公開のしおりに紐づくスケジュールは所有者のみ閲覧可能
  - スケジュールの編集削除等は所有者のみ可能
 - [x] TravelBookOwnerPolicyを設定
   - ノートの操作は所有者のみ可能
   - チェックリストの操作は所有者のみ可能

## 未実施内容
- 403エラー画面の実装

## 補足
app/javascript/controllers/tabs_controller.jsに不要なコンソールが残っていたため削除しました。

## 関連issue
#374 