### PR TITLE
Feature/403error page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   include Pundit::Authorization
+  rescue_from Pundit::NotAuthorizedError, with: :render404
+  rescue_from ActiveRecord::RecordNotFound, with: :render404
   allow_browser versions: :modern
 
   before_action :authenticate_user!
@@ -8,5 +10,11 @@ class ApplicationController < ActionController::Base
   # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource_or_scope)
     session.delete(:after_sign_in_path) || public_travel_books_path
+  end
+
+  # 404エラーページのレンダリング
+  def render404(error = nil)
+    Rails.logger.error("❌#{error.message}") if error
+    render template: "errors/error404", status: :not_found
   end
 end

--- a/app/views/errors/error404.html.erb
+++ b/app/views/errors/error404.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:title, "404 Not Found") %>
+<div class="max-w-screen-md mx-auto">
+  <div class="text-center p-4 md:p-8 m-3 md:m-5">
+    <h1 class="text-lg font-bold">404 Not Found</h1>
+    <p class="mb-5">お探しのページは一時的にアクセスができない状況にあるか、移動もしくは削除された可能性があります。</p>
+    <%= link_to "トップページへ", root_path, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -7,4 +7,4 @@ bundle exec rails assets:clean
 bundle exec rails db:migrate
 # DBをリセットする際に実行
 # DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
-bundle exec rails db:seed
+# bundle exec rails db:seed

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,5 @@ module Myapp
 
     config.i18n.default_locale = :ja
     config.time_zone = "Tokyo"
-
-    # 例外を403にする(デフォルトでは500になる)
-    config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,4 +64,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "static_pages#top"
+  # エラーページ
+  get "*path", to: "application#render404"
 end


### PR DESCRIPTION
# 概要
404のカスタムエラーページを作成しました。
また、punditで権限のないページへアクセスされた際に404エラーページをレンダリングするように修正しました。

## 実施内容
- [x] 404カスタムエラーページのビューを作成
- [x] application_controllerでカスタムエラーページへのアクションを定義
- [x] 存在しないURLへのアクセスに対するルーティングを追加
- [x] 不要になった設定を削除(config/application.rb)
- [x] delete:seed適用をコメントアウト

## 未実施内容

## 補足
- セキュリティの観点から、ページが存在すること自体を知らせないように403ではなく404エラーにしています
- render-build.shにてseedファイルの適用をコメントアウトしました

## 関連issue
#378 