### PR TITLE
Update:所有するしおりの詳細ページにしおり一覧のリンクを設置

### DIFF
--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -1,6 +1,16 @@
 <% content_for(:title, @travel_book.title) %>
 <div class="max-w-screen-md mx-auto">
-  <div class="card bg-base-100 shadow-md m-3 md:m-5">
+  <% if @travel_book.owned_by_user?(current_user) %>
+    <div class="flex justify-between mt-2 mx-3 md:mx-5">
+      <%= link_to public_travel_books_path, class: "text-sm underline hover:opacity-50" do %>
+        <i class="fa-solid fa-chevron-left"></i> しおり検索へ
+      <% end %>
+      <%= link_to travel_books_path, class: "text-sm underline hover:opacity-50" do %>
+        マイしおりへ <i class="fa-solid fa-chevron-right"></i>
+      <% end %>
+    </div>
+  <% end %>
+  <div class="card bg-base-100 shadow-md mt-2 mx-3 md:mx-5">
     <figure>
       <%= image_tag @travel_book.travel_book_image_url %>
     </figure>


### PR DESCRIPTION
# 概要
所有するしおりの詳細ページにしおり一覧(しおり検索、マイしおり)画面のリンクを設置しました。

## 実施内容
- [x] 所有するしおりの詳細ページ(travel_books#showアクションのビュー)にしおり一覧のリンクを設置

### 実装イメージ
【修正前】
[![Image from Gyazo](https://i.gyazo.com/297fc67b97e73c7efb0eb200c702d999.jpg)](https://gyazo.com/297fc67b97e73c7efb0eb200c702d999)

【修正後】
※ヘッダーの直下に「しおり検索」、「マイしおり」のリンク設置
[![Image from Gyazo](https://i.gyazo.com/c2b2a6002fcb8e4308e4b043430bdc4b.jpg)](https://gyazo.com/c2b2a6002fcb8e4308e4b043430bdc4b)

## 未実施内容
- [x] 所有していないしおりの詳細ページへのリンク設置

## 補足
所有していないしおりの場合は、ボトムナビゲーションに「しおり検索」と「マイしおり」があるため不要と判断し、所有しているしおりでのみリンクを設置しました。

## 関連issue
#380 