### PR TITLE
Fix/カラム名の修正(budged→budget)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,6 @@
 https://www.figma.com/design/hFI7FPp7fZ95IcAQkhaPwx/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0-1&t=G3nde0mVRNaHbNWf-1
 
 ## ■ ER図
-[![Image from Gyazo](https://i.gyazo.com/e1e757a33dd611bc6778fb28367c0b28.png)](https://gyazo.com/e1e757a33dd611bc6778fb28367c0b28)
+https://drive.google.com/file/d/1dbgMbt2VltszC0EJGRvsLHx0v5A8Iyhb/view?usp=sharing
+
+[![Image from Gyazo](https://i.gyazo.com/998168297275b3ab629c086029c8acda.png)](https://gyazo.com/998168297275b3ab629c086029c8acda)

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -75,7 +75,7 @@ class SchedulesController < ApplicationController
       :title,
       :start_date,
       :end_date,
-      :budged,
+      :budget,
       :memo,
       :name,
       :telephone,

--- a/app/forms/schedule_form.rb
+++ b/app/forms/schedule_form.rb
@@ -8,7 +8,7 @@ class ScheduleForm
   attribute :title, :string
   attribute :start_date, :datetime
   attribute :end_date, :datetime
-  attribute :budged, :integer, default: 0
+  attribute :budget, :integer, default: 0
   attribute :memo, :string
   attribute :name, :string
   attribute :telephone, :string
@@ -23,7 +23,7 @@ class ScheduleForm
   validates :travel_book_id, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validate  :end_date_after_start_date
-  validates :budged, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :budget, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :memo, length: { maximum: 65_535 }
   validates :name, length: { maximum: 255 }
   validates :telephone, length: { maximum: 15 }
@@ -52,7 +52,7 @@ class ScheduleForm
   def save
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule = Schedule.create!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id, schedule_icon_id: schedule_icon_id, schedule_image: schedule_image)
+      @schedule = Schedule.create!(title: title, budget: budget, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id, schedule_icon_id: schedule_icon_id, schedule_image: schedule_image)
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
         @spot = Spot.create!(name: name, telephone: telephone, post_code: post_code, address: address, schedule_id: schedule.id)
@@ -69,7 +69,7 @@ class ScheduleForm
   def update(attributes)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @schedule.update!(title: title, budged: budged, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id, schedule_icon_id: schedule_icon_id, schedule_image: schedule_image)
+      @schedule.update!(title: title, budget: budget, memo: memo, start_date: start_date, end_date: end_date, travel_book_id: travel_book_id, schedule_icon_id: schedule_icon_id, schedule_image: schedule_image)
 
       # Spot のデータが存在する場合のみ作成
       if name.present? || telephone.present? || post_code.present? || address.present?
@@ -100,7 +100,7 @@ class ScheduleForm
   def default_attributes(travel_book)
     {
       title: schedule.title,
-      budged: schedule.budged,
+      budget: schedule.budget,
       memo: schedule.memo,
       start_date: schedule.start_date || travel_book&.start_date&.in_time_zone&.change(hour: 12),
       end_date: schedule.end_date || travel_book&.start_date&.in_time_zone&.change(hour: 12),

--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -21,7 +21,7 @@ module SchedulesHelper
   end
 
   def total_budget(schedules)
-    schedules.sum { |schedule| schedule.budged.to_i }.to_fs(:currency, locale: :ja)
+    schedules.sum { |schedule| schedule.budget.to_i }.to_fs(:currency, locale: :ja)
   end
 
   def fmt_budget(budget)

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -42,9 +42,9 @@
     </div>
 
     <div>
-      <%= f.label :budged, Schedule.human_attribute_name(:budged), class: "label-text" %>
+      <%= f.label :budget, Schedule.human_attribute_name(:budget), class: "label-text" %>
       <div class="flex items-center">
-        <%= f.number_field :budged, class: "input input-bordered w-full", autocomplete: "off" %>
+        <%= f.number_field :budget, class: "input input-bordered w-full", autocomplete: "off" %>
         <span class="ml-2"><%= t("helpers.currency_unit") %></span>
       </div>
     </div>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -20,7 +20,7 @@
       <ul class="fa-ul space-y-5">
         <li><span class="fa-li"><i class="fa-regular fa-clock"></i></span><%= fmt_datetime_range(@schedule, :default) %></li>
         <li><span class="fa-li"><i class="fa-solid fa-location-dot"></i></span><%= schedule_spot_info(@schedule.spot) %></li>
-        <li><span class="fa-li"><i class="fa-solid fa-wallet"></i></span><%= fmt_budget(@schedule.budged) %></li>
+        <li><span class="fa-li"><i class="fa-solid fa-wallet"></i></span><%= fmt_budget(@schedule.budget) %></li>
         <li>
           <span class="fa-li"><i class="fa-solid fa-file-pen"></i></span>
           <% if @schedule.memo.blank? %>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -8,7 +8,7 @@ ja:
         name: 場所名
         telephone: 電話番号
         address: 住所
-        budged: 予算
+        budget: 予算
         memo: メモ
     errors:
       models:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -30,7 +30,7 @@ ja:
         name: 旅行スタイル
       schedule:
         title: タイトル
-        budged: 予算
+        budget: 予算
         memo: メモ
         start_date: 開始時刻
         end_date: 終了時刻

--- a/db/migrate/20250509142200_rename_budged_column_to_budget.rb
+++ b/db/migrate/20250509142200_rename_budged_column_to_budget.rb
@@ -1,0 +1,5 @@
+class RenameBudgedColumnToBudget < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :schedules, :budged, :budget
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_03_020254) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_09_142200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_03_020254) do
   create_table "schedules", force: :cascade do |t|
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "title", null: false
-    t.integer "budged", default: 0
+    t.integer "budget", default: 0
     t.text "memo"
     t.datetime "start_date"
     t.datetime "end_date"

--- a/spec/forms/schedule_form_spec.rb
+++ b/spec/forms/schedule_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ScheduleForm, type: :model do
   let(:attributes) do
     {
       title: "title",
-      budged: 0,
+      budget: 0,
       travel_book_id: travel_book.id,
       schedule_icon_id: schedule_icon.id,
       start_date: nil,
@@ -48,11 +48,11 @@ RSpec.describe ScheduleForm, type: :model do
       expect(schedule_form.errors[:end_date]).to include("は開始時刻より後の時刻を入力してください")
     end
 
-    it "budgedが0未満の場合にバリデーションが機能してinvalidになるか" do
-      negative_budged = attributes.merge(budged: -1)
-      schedule_form = ScheduleForm.new(negative_budged)
+    it "budgetが0未満の場合にバリデーションが機能してinvalidになるか" do
+      negative_budget = attributes.merge(budget: -1)
+      schedule_form = ScheduleForm.new(negative_budget)
       expect(schedule_form).to be_invalid
-      expect(schedule_form.errors[:budged]).to include("は0以上の値にしてください")
+      expect(schedule_form.errors[:budget]).to include("は0以上の値にしてください")
     end
 
     it "memoが65536文字以上の場合にバリデーションが機能してinvalidになるか" do


### PR DESCRIPTION
# 概要
schedulesテーブルの予算のカラムのタイポを修正しました(budged→budget)。

## 実施内容
- [x] カラム名の修正(budged→budget)
- [x] コード内のカラム名を修正
- [x] READMEのER図のURLとキャプチャを修正

## 未実施内容
なし

## 補足
READMEに記載のER図も最新版に更新しています。

## 関連issue
#383 