### PR TITLE
Fix/他人のしおりのスケジュールで他のマップ情報が残存するバグ対処

### DIFF
--- a/app/controllers/travel_books_controller.rb
+++ b/app/controllers/travel_books_controller.rb
@@ -63,7 +63,7 @@ class TravelBooksController < ApplicationController
 
   def public_travel_books
     @q = TravelBook.ransack(params[:q])
-    @travel_books = @q.result.where(is_public: true).includes(:users).order(created_at: :desc).page(params[:page])
+    @travel_books = @q.result.public_travel_books.page(params[:page])
   end
 
   def share
@@ -71,6 +71,7 @@ class TravelBooksController < ApplicationController
     @users = @travel_book.users
     @user = User.new
     @resource_name = @user.class.name.underscore
+    # すでに招待トークンがある場合、招待リンク生成
     @invite_link = accept_travel_book_url(invitation_token: @travel_book.invitation_token) if @travel_book.invitation_token.present?
   end
 
@@ -97,6 +98,7 @@ class TravelBooksController < ApplicationController
     @bookmark_travel_books = current_user.bookmark_travel_books.order(created_at: :desc)
   end
 
+  # 招待ボタンをクリックした際に招待URLを生成
   def invitation
     authorize(@travel_book)
     if @travel_book.generate_token

--- a/app/models/travel_book.rb
+++ b/app/models/travel_book.rb
@@ -16,7 +16,7 @@ class TravelBook < ApplicationRecord
   validates :description, length: { maximum: 65_535 }
   validate :end_date_after_start_date
 
-  scope :public_travel_books, -> { where(is_public: true) }
+  scope :public_travel_books, -> { where(is_public: true).includes(:users).order(created_at: :desc) }
 
   def owned_by_user?(user)
     return false if user.nil?

--- a/app/views/travel_books/show.html.erb
+++ b/app/views/travel_books/show.html.erb
@@ -67,7 +67,7 @@
         </div>
 
         <% unless @travel_book.owned_by_user?(current_user) %>
-          <%= link_to travel_book_schedules_path(@travel_book.uuid), class: "btn btn-primary w-full" do %>
+          <%= link_to travel_book_schedules_path(@travel_book.uuid), data: { turbo: false }, class: "btn btn-primary w-full" do %>
             <i class="fa-regular fa-clock"></i> スケジュールを見る
           <% end %>
         <% else %>


### PR DESCRIPTION
# 概要
他人のしおりの「スケジュールを見る」ボタンからスケジュールを確認すると、
前回アクセスしたしおりのマップ情報が残存していたため修正しました。
合わせて、しおりのコントローラーでscopeを使用していない箇所を発見したため修正しました。

## 実施内容
- [x] 「スケジュールを見る」ボタンでturboを無効化
- [x] TravelBooksControllerでデータ取得時にscopeを使用するように修正

## 未実施内容
なし

## 補足
なし

## 関連issue
#391 